### PR TITLE
Proof of concept PostgreSQL as query handler

### DIFF
--- a/Meadowlark-js/.vscode/launch.json
+++ b/Meadowlark-js/.vscode/launch.json
@@ -33,6 +33,7 @@
       "port": 9229,
       "console": "integratedTerminal",
       "cwd": "${workspaceFolder}/services/meadowlark-fastify",
+      "envFile": "${workspaceFolder}/services/meadowlark-fastify/.env",
       "justMyCode": false
     },
     {

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/script/README.md
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/script/README.md
@@ -1,0 +1,7 @@
+These are SQL scripts for PostgreSQL backend initialization.
+
+document-index.sql - Adds a GIN "pathops" index to the edfi_doc JSONB column, improving the
+                     performance of ad-hoc document queries at the cost of slower writes.
+                     This is only necessary in a PostgreSQL "standalone" configuration,
+                     where the PostgreSQL backend is providing API search query support,
+                     as opposed to using a separate search engine.

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/script/document-index.sql
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/script/document-index.sql
@@ -1,0 +1,11 @@
+-- Adds a GIN "pathops" index to the edfi_doc JSONB column, improving the
+-- performance of ad-hoc document queries at the cost of slower writes.
+-- This is only necessary in a PostgreSQL "standalone" configuration,
+-- where the PostgreSQL backend is providing API search query support
+-- (as opposed to using a separate search engine like OpenSearch).
+CREATE INDEX IF NOT EXISTS ix_meadowlark_documents_edfi_doc ON meadowlark.documents USING GIN (edfi_doc jsonb_path_ops);
+
+-- TODO: Add an index for ResourceInfo e.g. the (project name, resource name, resource version) tuple
+
+-- Search queries will need to be constructed to perform as well as possible, given that GIN indexes are not sortable,
+

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/BackendFacade.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/BackendFacade.ts
@@ -9,6 +9,8 @@ import {
   GetRequest,
   GetResult,
   MiddlewareModel,
+  QueryRequest,
+  QueryResult,
   UpdateRequest,
   UpdateResult,
   UpsertRequest,
@@ -20,6 +22,7 @@ import * as Upsert from './repository/Upsert';
 import * as Delete from './repository/Delete';
 import * as Get from './repository/Get';
 import * as Update from './repository/Update';
+import * as Query from './repository/Query';
 import { getSharedClient } from './repository/Db';
 import * as SecurityMiddleware from './security/SecurityMiddleware';
 
@@ -63,6 +66,15 @@ export async function securityMiddleware(middlewareModel: MiddlewareModel): Prom
   const poolClient: PoolClient = await getSharedClient();
   try {
     return SecurityMiddleware.securityMiddleware(middlewareModel, poolClient);
+  } finally {
+    poolClient.release();
+  }
+}
+
+export async function queryDocuments(request: QueryRequest): Promise<QueryResult> {
+  const poolClient: PoolClient = await getSharedClient();
+  try {
+    return Query.queryDocuments(request, poolClient);
   } finally {
     poolClient.release();
   }

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/index.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/index.ts
@@ -3,13 +3,14 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-import { DocumentStorePlugin } from '@edfi/meadowlark-core';
+import { DocumentStorePlugin, QueryHandlerPlugin } from '@edfi/meadowlark-core';
 import {
   upsertDocument,
   deleteDocumentById,
   getDocumentById,
   updateDocumentById,
   securityMiddleware,
+  queryDocuments,
 } from './BackendFacade';
 
 export function initializeDocumentStore(): DocumentStorePlugin {
@@ -19,6 +20,12 @@ export function initializeDocumentStore(): DocumentStorePlugin {
     updateDocumentById,
     deleteDocumentById,
     securityMiddleware,
+  };
+}
+
+export function initializeQueryHandler(): QueryHandlerPlugin {
+  return {
+    queryDocuments,
   };
 }
 

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Query.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Query.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+import type { PoolClient, QueryResult as PostgresResult } from 'pg';
+import { QueryRequest, QueryResult, Logger, ResourceInfo } from '@edfi/meadowlark-core';
+
+// TODO: Unsafe for SQL injection
+function edfiDocWhereConditionsFrom(queryStringParameters: object): string {
+  // TODO: Convert dot notation in query to subobjects before stringifying
+  //       Consider "set-value" or "dot-prop" libraries for this
+  return JSON.stringify(queryStringParameters);
+}
+
+/**
+ * TODO: Unsafe for SQL injection
+ * TODO: These 3 columns need to be indexed...or a new concatenated column indexed
+ *
+ */
+function resourceInfoWhereConditionsFrom(resourceInfo: ResourceInfo): string {
+  return `d.project_name='${resourceInfo.projectName}' AND d.resource_name='${resourceInfo.resourceName}' AND d.resource_version='${resourceInfo.resourceVersion}'`;
+}
+
+/**
+ * Indexing optimization will be interesting. GIN indexes are necessary on JSONB columns for search. GIN indexes
+ * do not provide sorting, yet we need pagination support. We also need to filter by resource-name/project-name/version,
+ * not just the JSON.
+ *
+ * Problem #1: We need to query both on resource-name/project-name/version and the query parameters. Query parameters
+ * can be handled by the GIN index on edfi_doc column, resource-name/project-name/version would be handled by the
+ * standard btree indexes on resource-name/project-name/version columns. However, we want this to be a single index,
+ * but you can't GIN on a string column like resource_name or BTREE on a JSONB column like edfi_doc.
+ *
+ * Solution #1: Use the trusted btree_gin PostgreSQL extension, which extends GIN to simple column types, and create
+ * a multi-column index on resource_name, project_name, resource_version and edfi_doc. Consider collapsing down the
+ * resource-name/project-name/version tuple to a single concatenated column -- though this is an optimization only
+ * relevant to "standalone PostgreSQL".
+ *
+ * See: https://pganalyze.com/blog/gin-index
+ *
+ * Problem #2: We need to provide pagination support. GIN indexes (including btree_gin's implementation) do not
+ * support sorting.
+ *
+ * Solution #2: If Meadowlark provides "next cursor"-style support instead of limit/offset, we can implement pagination on a
+ * sortable column like documentid. This might take the form of a subquery that uses the GIN index first (ensuring the
+ * GIN index gets used, as the query optimizer often gets the best option wrong here), then the main query sorts and limits
+ * on documentIds, optionally starting with the next cursor token.
+ *
+ * See: https://ivopereira.net/efficient-pagination-dont-use-offset-limit,
+ *      https://slack.engineering/evolving-api-pagination-at-slack-1c1f644f8e12,
+ *      https://dba.stackexchange.com/questions/113132/gin-index-not-used-when-adding-order-clause
+ *      https://dba.stackexchange.com/questions/208065/why-is-limit-killing-performance-of-this-postgres-query
+ */
+export async function queryDocuments(request: QueryRequest, client: PoolClient): Promise<QueryResult> {
+  // TODO: ignores pagination parameters
+  const { resourceInfo, queryStringParameters, traceId } = request;
+
+  Logger.debug(`Building query`, traceId);
+
+  let documents: any = [];
+  try {
+    const query = `SELECT * FROM meadowlark.meadowlark.documents d WHERE d.edfi_doc @> '${edfiDocWhereConditionsFrom(
+      queryStringParameters,
+    )}' AND ${resourceInfoWhereConditionsFrom(resourceInfo)}`;
+
+    Logger.debug(`meadowlark-opensearch-backend: queryDocuments executing query: ${query}`, traceId);
+
+    const queryResult: PostgresResult = await client.query(query);
+
+    documents = queryResult.rows.map((row) => row.edfi_doc);
+  } catch (e) {
+    // TODO: Handle invalid query parameters without 500-ing
+    Logger.error('meadowlark-postgresql: queryDocuments', traceId, e);
+    return { response: 'UNKNOWN_FAILURE', documents: [] };
+  }
+
+  return { response: 'QUERY_SUCCESS', documents };
+}

--- a/Meadowlark-js/tests/http/manual.system.test.http
+++ b/Meadowlark-js/tests/http/manual.system.test.http
@@ -3,7 +3,7 @@
 @auth_header=Authorization: bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJlZC1maS1tZWFkb3dsYXJrIiwiYXVkIjoibWVhZG93bGFyayIsInN1YiI6InN1cGVyLWdyZWF0LVNJUyIsImp0aSI6IjNkNTliNzVmLWE3NjItNGJhYS05MTE2LTE5YzgyZmRmOGRlMyIsImlhdCI6MTYzNjU2MjA2MCwiZXhwIjozODQ1NTQ4ODgxfQ.WF5ABFZAvNsLDZktwa8VxDR846fGptRXJObtQitbL8I
 
 ### API Version
-GET http://localhost:3000/metaed
+GET http://localhost:3000/local/metaed
 {{auth_header}}
 
 
@@ -24,7 +24,7 @@ content-type: application/json
 
 
 ### Get the created record
-GET http://localhost:3000/local/v3.3b/ed-fi/schools/x1GptgyYapmpBGiZegIbM2XC_NLMVVjisNLEtg
+GET http://localhost:3000/local/v3.3b/ed-fi/schools/L9gXuk9vioIoG64QKp8NFO2f3AOe78fV-HrtfQ
 {{auth_header}}
 
 ### Query the created record
@@ -33,7 +33,7 @@ GET http://localhost:3000/local/v3.3b/ed-fi/schools/?nameOfInstitution=abc
 
 
 ### Update the created record
-PUT http://localhost:3000/local/v3.3b/ed-fi/schools/x1GptgyYapmpBGiZegIbM2XC_NLMVVjisNLEtg
+PUT http://localhost:3000/local/v3.3b/ed-fi/schools/L9gXuk9vioIoG64QKp8NFO2f3AOe78fV-HrtfQ
 {{auth_header}}
 reference-validation: true
 content-type: application/json
@@ -46,7 +46,7 @@ content-type: application/json
 }
 
 ### Delete the created record
-DELETE http://localhost:3000/local/v3.3b/ed-fi/schools/x1GptgyYapmpBGiZegIbM2XC_NLMVVjisNLEtg
+DELETE http://localhost:3000/local/v3.3b/ed-fi/schools/L9gXuk9vioIoG64QKp8NFO2f3AOe78fV-HrtfQ
 {{auth_header}}
 
 
@@ -112,7 +112,7 @@ GET http://localhost:3000/local/v3.3b/ed-fi/academicWeeks
 
 
 ### Query schools
-GET http://localhost:3000/local/v3.3b/ed-fi/schools?schoolId=12
+GET http://localhost:3000/local/v3.3b/ed-fi/schools?schoolId=123
 {{auth_header}}
 
 


### PR DESCRIPTION
Indexing optimization will be interesting. GIN indexes are necessary on JSONB columns for search. GIN indexes
do not provide sorting, yet we need pagination support. We also need to filter by resource-name/project-name/version,
not just the JSON.
 
Problem #1: We need to query both on resource-name/project-name/version and the query parameters. Query parameters
can be handled by the GIN index on edfi_doc column, resource-name/project-name/version would be handled by the
standard btree indexes on resource-name/project-name/version columns. However, we want this to be a single index,
but you can't GIN on a string column like resource_name or BTREE on a JSONB column like edfi_doc.

Solution #1: Use the trusted btree_gin PostgreSQL extension, which extends GIN to simple column types, and create
a multi-column index on resource_name, project_name, resource_version and edfi_doc. Consider collapsing down the
resource-name/project-name/version tuple to a single concatenated column -- though this is an optimization only
relevant to "standalone PostgreSQL".

See: https://pganalyze.com/blog/gin-index

Problem #2: We need to provide pagination support. GIN indexes (including btree_gin's implementation) do not
support sorting.

Solution #2: If Meadowlark provides "next cursor"-style support instead of limit/offset, we can implement pagination on a
sortable column like documentid. This might take the form of a subquery that uses the GIN index first (ensuring the
GIN index gets used, as the query optimizer often gets the best option wrong here), then the main query sorts and limits
on documentIds, optionally starting with the next cursor token.

See: https://ivopereira.net/efficient-pagination-dont-use-offset-limit
      https://slack.engineering/evolving-api-pagination-at-slack-1c1f644f8e12
      https://dba.stackexchange.com/questions/113132/gin-index-not-used-when-adding-order-clause
      https://dba.stackexchange.com/questions/208065/why-is-limit-killing-performance-of-this-postgres-query