### PR TITLE
RND-296 - Descriptors could be deleted when another document was referencing descriptor

### DIFF
--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Upsert.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Upsert.ts
@@ -4,7 +4,13 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 import { Collection, ClientSession, MongoClient } from 'mongodb';
-import { UpsertResult, Logger, UpsertRequest } from '@edfi/meadowlark-core';
+import {
+  UpsertResult,
+  Logger,
+  UpsertRequest,
+  DocumentReference,
+  documentIdForDocumentReference,
+} from '@edfi/meadowlark-core';
 import { MeadowlarkDocument, meadowlarkDocumentFrom } from '../model/MeadowlarkDocument';
 import { getCollection } from './Db';
 import { asUpsert, onlyReturnId, validateReferences } from './ReferenceValidation';
@@ -58,6 +64,12 @@ export async function upsertDocument(
           return;
         }
       }
+
+      // Adding descriptors to outRefs for reference checking
+      const descriptorOutRefs = documentInfo.descriptorReferences.map((dr: DocumentReference) =>
+        documentIdForDocumentReference(dr),
+      );
+      document.outRefs.push(...descriptorOutRefs);
 
       // Perform the document upsert
       Logger.debug(`mongodb.repository.Upsert.upsertDocument: Upserting document id ${id}`, traceId);

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
@@ -84,6 +84,12 @@ export async function upsertDocument(
     Logger.debug(`postgresql.repository.Upsert.upsertDocument: Deleting references for document id ${id}`, traceId);
     await client.query(deleteReferencesSql(id));
 
+    // Adding descriptors to outRefs for reference checking
+    const descriptorOutRefs = documentInfo.descriptorReferences.map((dr: DocumentReference) =>
+      documentIdForDocumentReference(dr),
+    );
+    outRefs.push(...descriptorOutRefs);
+
     // Perform insert of references to the references table
     outRefs.forEach(async (ref: string) => {
       Logger.debug(`postgresql.repository.Upsert.upsertDocument: Inserting reference id ${ref} for document id ${id}`, ref);

--- a/Meadowlark-js/tests/system/crud/Delete.test.ts
+++ b/Meadowlark-js/tests/system/crud/Delete.test.ts
@@ -11,6 +11,9 @@ import {
   schoolDeleteClient2,
   schoolBodyClient1,
   schoolGetClient1,
+  schoolCategoryDescriptorBody,
+  schoolBodyWithDescriptorReference,
+  schoolCategoryDelete,
 } from './SystemTestSetup';
 
 jest.setTimeout(40000);
@@ -116,6 +119,38 @@ describe('given the DELETE of a school referenced by an academic week', () => {
   it('should return delete failure due to a reference to the school', async () => {
     expect(deleteResult.body).toMatchInlineSnapshot(
       `"{\\"message\\":\\"Delete failed due to existing references to document: Resource AcademicWeek with identity '[{\\\\\\"name\\\\\\":\\\\\\"schoolReference.schoolId\\\\\\",\\\\\\"value\\\\\\":123},{\\\\\\"name\\\\\\":\\\\\\"weekIdentifier\\\\\\",\\\\\\"value\\\\\\":\\\\\\"1st\\\\\\"}]'\\"}"`,
+    );
+    expect(deleteResult.statusCode).toBe(409);
+  });
+
+  it('should return still found from get', async () => {
+    expect(getResult.statusCode).toBe(200);
+  });
+});
+
+describe('given the DELETE of a descriptor referenced by a school', () => {
+  let client: SystemTestClient;
+  let deleteResult: FrontendResponse;
+  let getResult: FrontendResponse;
+
+  beforeAll(async () => {
+    client = await backendToTest.systemTestSetup();
+
+    await upsert(schoolCategoryDescriptorBody());
+    await upsert(schoolBodyWithDescriptorReference());
+
+    // Act
+    deleteResult = await deleteIt(schoolCategoryDelete());
+    getResult = await get(schoolGetClient1());
+  });
+
+  afterAll(async () => {
+    await backendToTest.systemTestTeardown(client);
+  });
+
+  it('should return delete failure due to a reference to the school', async () => {
+    expect(deleteResult.body).toMatchInlineSnapshot(
+      `"{\\"message\\":\\"Delete failed due to existing references to document: Resource School with identity '[{\\\\\\"name\\\\\\":\\\\\\"schoolId\\\\\\",\\\\\\"value\\\\\\":123}]'\\"}"`,
     );
     expect(deleteResult.statusCode).toBe(409);
   });

--- a/Meadowlark-js/tests/system/crud/SystemTestSetup.ts
+++ b/Meadowlark-js/tests/system/crud/SystemTestSetup.ts
@@ -149,3 +149,44 @@ export function descriptorGetClient2(): FrontendRequest {
     path: '/v3.3b/ed-fi/absenceEventCategoryDescriptors/iAJs9ozLKVAzev_3uNkiENZZfPU_PoI3qwet9Q',
   };
 }
+
+export function schoolCategoryDescriptorBody(): FrontendRequest {
+  return {
+    ...newFrontendRequestTemplate(),
+    path: '/v3.3b/ed-fi/schoolCategoryDescriptors',
+    headers: { ...JSON_HEADER, ...CLIENT1_HEADERS },
+    body: `{
+      "codeValue": "All Levels",
+      "shortDescription": "All Levels",
+      "description": "All Levels",
+      "namespace":"uri://ed-fi.org/SchoolCategoryDescriptor"
+    }`,
+  };
+}
+
+export function schoolBodyWithDescriptorReference(): FrontendRequest {
+  return {
+    ...newFrontendRequestTemplate(),
+    path: '/v3.3b/ed-fi/schools',
+    headers: { ...JSON_HEADER, ...CLIENT1_HEADERS },
+    body: `{
+    "schoolId": 123,
+    "schoolCategories": [
+      {
+           "schoolCategoryDescriptor": "uri://ed-fi.org/SchoolCategoryDescriptor#All Levels"
+      }
+    ],
+    "gradeLevels": [],
+    "nameOfInstitution": "abc",
+    "educationOrganizationCategories": []
+  }`,
+  };
+}
+
+export function schoolCategoryDelete(): FrontendRequest {
+  return {
+    ...newFrontendRequestTemplate(),
+    headers: { ...JSON_HEADER, ...CLIENT1_HEADERS },
+    path: '/v3.3b/ed-fi/schoolCategoryDescriptors/gPVEJ4PgrhnDa-eMNdqix4aoE8oeVAt8E9opyQ',
+  };
+}


### PR DESCRIPTION
We were not adding the descriptor references to the outRefs of the document in both PostgreSQL and MongoDB
Also added system test covering this issue