### PR TITLE
Pointing the instructions to the folder instead of the readme file

### DIFF
--- a/docs/LOCALHOST.md
+++ b/docs/LOCALHOST.md
@@ -8,10 +8,10 @@ Instructions for running a local "developer" environment on localhost:
 4. Review the [General Docker Guidance](../Meadowlark-js/docker/using-docker.md) for Meadowlark
 5. Initialize a backend technology:
    * **MongoDB**: Start a MongoDB cluster in Docker
-     ([instructions](../Meadowlark-js/backends/meadowlark-mongodb-backend/docker/readme.md)).
-   * **PostgreSQL**: Start PostgreSQL in Docker ([instructions](../Meadowlark-js/backends/meadowlark-postgresql-backend/docker/readme.md)).
+     ([instructions](../Meadowlark-js/backends/meadowlark-mongodb-backend/docker)).
+   * **PostgreSQL**: Start PostgreSQL in Docker ([instructions](../Meadowlark-js/backends/meadowlark-postgresql-backend/docker)).
 6. Initialize OpenSearch by starting it up in Docker
-   ([instructions](../Meadowlark-js/backends/meadowlark-opensearch-backend/docker/readme.md)).
+   ([instructions](../Meadowlark-js/backends/meadowlark-opensearch-backend/docker)).
 7. Setup environment variables for running [meadowlark-fastify](../Meadowlark-js/services/meadowlark-fastify/)
    service. The folder has an example.env file with all settings needed to run the service, the easiest way to set your environment variables is to duplicate this file in the folder and rename the file to .env
    1. Review the settings in the .env file to see what values, if any, to change. In particular:


### PR DESCRIPTION
When pointing to link for instructions on Postgres, Mongo and OpenSearch, the LOCALHOST.md file is pointing to the readme file instead of the folder, when done this way, you only get the file and not the compose files that the doc is referring to. Given that the files are readme files, this could be pointed to the root of the folder to get the entire information