### PR TITLE
[RND-346] change existence table related naming to alias

### DIFF
--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/model/MeadowlarkDocument.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/model/MeadowlarkDocument.ts
@@ -52,7 +52,7 @@ export interface MeadowlarkDocument extends MeadowlarkDocumentId {
    * An array of ids extracted from the ODS/API document for all externally
    * referenced documents.
    */
-  outRefs: string[];
+  outboundRefs: string[];
 
   /**
    * An array of ids this document will satisfy when reference validation performs existence checks.
@@ -124,7 +124,7 @@ export function meadowlarkDocumentFrom(
     _id: id,
     edfiDoc,
     aliasIds,
-    outRefs: referencedDocumentIdsFrom(documentInfo),
+    outboundRefs: referencedDocumentIdsFrom(documentInfo),
     validated: validate,
     createdBy,
   };

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/model/MeadowlarkDocument.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/model/MeadowlarkDocument.ts
@@ -56,9 +56,9 @@ export interface MeadowlarkDocument extends MeadowlarkDocumentId {
 
   /**
    * An array of ids this document will satisfy when reference validation performs existence checks.
-   * This array always includes the document id. If this document is a subclass, the array will also
+   * This array always includes the document id itself. If this document is a subclass, the array will also
    * contain the id of this document in superclass form (superclass name and project, identity property
-   * naming differences - like schoolId versus educationOrganizationId - accounted for).
+   * naming differences - like schoolId versus educationOrganizationId - accounted for). Such an id is an alias.
    *
    * The idea is that a subclass document provides the existence validation of both the document as its given type
    * AND as a reference to the superclass when the identity is equivalent.
@@ -71,7 +71,7 @@ export interface MeadowlarkDocument extends MeadowlarkDocumentId {
    *          a reference from ClassPeriod to a School with schoolId=123, as well as a reference from
    *          Assessment to EducationOrganization with educationOrganizationId=123.
    */
-  existenceIds: string[];
+  aliasIds: string[];
 
   /**
    * True if this document has been reference and descriptor validated.
@@ -110,9 +110,9 @@ export function meadowlarkDocumentFrom(
   validate: boolean,
   createdBy: string,
 ): MeadowlarkDocument {
-  const existenceIds: string[] = [id];
+  const aliasIds: string[] = [id];
   if (documentInfo.superclassInfo != null) {
-    existenceIds.push(documentIdForSuperclassInfo(documentInfo.superclassInfo));
+    aliasIds.push(documentIdForSuperclassInfo(documentInfo.superclassInfo));
   }
 
   return {
@@ -123,7 +123,7 @@ export function meadowlarkDocumentFrom(
     isDescriptor: resourceInfo.isDescriptor,
     _id: id,
     edfiDoc,
-    existenceIds,
+    aliasIds,
     outRefs: referencedDocumentIdsFrom(documentInfo),
     validated: validate,
     createdBy,

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Db.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Db.ts
@@ -41,7 +41,7 @@ export async function getNewClient(): Promise<MongoClient> {
     const collection = newClient.db(DATABASE_NAME).collection(COLLECTION_NAME);
 
     // Note this does nothing if the index already exists (triggers an index build otherwise)
-    await collection.createIndex({ outRefs: 1 });
+    await collection.createIndex({ outboundRefs: 1 });
     await collection.createIndex({ aliasIds: 1 });
 
     return newClient;

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Db.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Db.ts
@@ -42,7 +42,7 @@ export async function getNewClient(): Promise<MongoClient> {
 
     // Note this does nothing if the index already exists (triggers an index build otherwise)
     await collection.createIndex({ outRefs: 1 });
-    await collection.createIndex({ existenceIds: 1 });
+    await collection.createIndex({ aliasIds: 1 });
 
     return newClient;
   } catch (e) {
@@ -88,7 +88,7 @@ export async function writeLockReferencedDocuments(
   session: ClientSession,
 ): Promise<void> {
   await mongoCollection.updateMany(
-    { existenceIds: { $in: referencedDocumentIds } },
+    { aliasIds: { $in: referencedDocumentIds } },
     { $set: { lock: new ObjectId() } },
     { session },
   );

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/ReferenceValidation.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/ReferenceValidation.ts
@@ -8,7 +8,15 @@ import { ClientSession, Collection, Filter, FindOptions, ReplaceOptions } from '
 import { documentIdForDocumentReference, DocumentReference, Logger } from '@edfi/meadowlark-core';
 import { MeadowlarkDocument, MeadowlarkDocumentId } from '../model/MeadowlarkDocument';
 
-export async function findReferencedDocumentIdsById(
+/**
+ * Finds whether the given reference ids are actually documents in the db.
+ *
+ * @param referenceIds The reference ids to check for existence in the db
+ * @param mongoDocuments The MongoDb collection the documents are in
+ * @param findOptions MongoDb findOptions for the query
+ * @returns The subset of the given reference ids that are actually documents in the db
+ */
+async function findReferencedDocumentIdsById(
   referenceIds: string[],
   mongoDocuments: Collection<MeadowlarkDocument>,
   findOptions: FindOptions,

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/ReferenceValidation.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/ReferenceValidation.ts
@@ -30,21 +30,21 @@ async function findReferencedDocumentIdsById(
  * Finds references in the document that are missing in the database
  *
  * @param refsInDb The document references that were actually found in the db (id property only)
- * @param documentOutRefs The document references extracted from the document, as id strings
+ * @param documentOutboundRefs The document outbound references extracted from the document, as id strings
  * @param documentReferences The DocumentInfo of the document
  * @returns Failure message listing out the resource name and identity of missing document references.
  */
 export function findMissingReferences(
   refsInDb: MeadowlarkDocumentId[],
-  documentOutRefs: string[],
+  documentOutboundRefs: string[],
   documentReferences: DocumentReference[],
 ): string[] {
   // eslint-disable-next-line no-underscore-dangle
   const idsOfRefsInDb: string[] = refsInDb.map((outRef) => outRef._id);
-  const outRefIdsNotInDb: string[] = R.difference(documentOutRefs, idsOfRefsInDb);
+  const outRefIdsNotInDb: string[] = R.difference(documentOutboundRefs, idsOfRefsInDb);
 
-  // Gets the array indexes of the missing references, for the documentOutRefs array
-  const arrayIndexesOfMissing: number[] = outRefIdsNotInDb.map((outRefId) => documentOutRefs.indexOf(outRefId));
+  // Gets the array indexes of the missing references, for the documentOutboundRefs array
+  const arrayIndexesOfMissing: number[] = outRefIdsNotInDb.map((outRefId) => documentOutboundRefs.indexOf(outRefId));
 
   // Pick out the DocumentReferences of the missing from the entire array of DocumentReferences,
   const pickedDocumentReferencesOfMissing: DocumentReference[] = R.props(
@@ -66,9 +66,9 @@ export const onlyReturnAliasIds = (session: ClientSession): FindOptions => ({
   session,
 });
 
-// MongoDB Filter on documents with the given aliasIds in their outRefs list
+// MongoDB Filter on documents with the given aliasIds in their outboundRefs list
 export const onlyDocumentsReferencing = (aliasIds: string[]): Filter<MeadowlarkDocument> => ({
-  outRefs: { $in: aliasIds },
+  outboundRefs: { $in: aliasIds },
 });
 
 // MongoDB ReplaceOption that enables upsert (insert if not exists)

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/ReferenceValidation.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/ReferenceValidation.ts
@@ -9,7 +9,8 @@ import { documentIdForDocumentReference, DocumentReference, Logger } from '@edfi
 import { MeadowlarkDocument, MeadowlarkDocumentId } from '../model/MeadowlarkDocument';
 
 /**
- * Finds whether the given reference ids are actually documents in the db.
+ * Finds whether the given reference ids are actually documents in the db. Uses the aliasIds
+ * array for this existence check.
  *
  * @param referenceIds The reference ids to check for existence in the db
  * @param mongoDocuments The MongoDb collection the documents are in
@@ -21,7 +22,7 @@ async function findReferencedDocumentIdsById(
   mongoDocuments: Collection<MeadowlarkDocument>,
   findOptions: FindOptions,
 ): Promise<MeadowlarkDocumentId[]> {
-  const findReferencedDocuments = mongoDocuments.find({ existenceIds: { $in: referenceIds } }, findOptions);
+  const findReferencedDocuments = mongoDocuments.find({ aliasIds: { $in: referenceIds } }, findOptions);
   return (await findReferencedDocuments.toArray()) as unknown as MeadowlarkDocumentId[];
 }
 
@@ -59,15 +60,15 @@ export function findMissingReferences(
 // MongoDB FindOption to return only the indexed _id field, making this a covered query (MongoDB will optimize)
 export const onlyReturnId = (session: ClientSession): FindOptions => ({ projection: { _id: 1 }, session });
 
-// MongoDB FindOption to return only the existenceIds field
-export const onlyReturnExistenceIds = (session: ClientSession): FindOptions => ({
-  projection: { existenceIds: 1 },
+// MongoDB FindOption to return only the aliasIds field
+export const onlyReturnAliasIds = (session: ClientSession): FindOptions => ({
+  projection: { aliasIds: 1 },
   session,
 });
 
-// MongoDB Filter on documents with the given existenceIds in their outRefs list
-export const onlyDocumentsReferencing = (existenceIds: string[]): Filter<MeadowlarkDocument> => ({
-  outRefs: { $in: existenceIds },
+// MongoDB Filter on documents with the given aliasIds in their outRefs list
+export const onlyDocumentsReferencing = (aliasIds: string[]): Filter<MeadowlarkDocument> => ({
+  outRefs: { $in: aliasIds },
 });
 
 // MongoDB ReplaceOption that enables upsert (insert if not exists)

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Update.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Update.ts
@@ -55,7 +55,7 @@ export async function updateDocumentById(
         security.clientId,
       );
 
-      await writeLockReferencedDocuments(mongoCollection, document.outRefs, session);
+      await writeLockReferencedDocuments(mongoCollection, document.outboundRefs, session);
 
       // Perform the document update
       Logger.debug(`mongodb.repository.Upsert.updateDocumentById: Updating document id ${id}`, traceId);

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Upsert.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Upsert.ts
@@ -58,7 +58,7 @@ export async function upsertDocument(
         security.clientId,
       );
 
-      await writeLockReferencedDocuments(mongoCollection, document.outRefs, session);
+      await writeLockReferencedDocuments(mongoCollection, document.outboundRefs, session);
 
       // Perform the document upsert
       Logger.debug(`mongodb.repository.Upsert.upsertDocument: Upserting document id ${id}`, traceId);

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Update.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Update.test.ts
@@ -185,7 +185,7 @@ describe('given an update of a document that references a non-existent document 
     const collection: Collection<MeadowlarkDocument> = getCollection(client);
     const result: any = await collection.findOne({ _id: documentWithReferencesId });
     expect(result.documentIdentity.natural).toBe('update4');
-    expect(result.outRefs).toMatchInlineSnapshot(`
+    expect(result.outboundRefs).toMatchInlineSnapshot(`
       Array [
         "QtykK4uDYZK7VOChNxRsMDtOcAu6a0oe9ozl2Q",
       ]
@@ -277,7 +277,7 @@ describe('given an update of a document that references an existing document wit
     const collection: Collection<MeadowlarkDocument> = getCollection(client);
     const result: any = await collection.findOne({ _id: documentWithReferencesId });
     expect(result.documentIdentity.natural).toBe('update6');
-    expect(result.outRefs).toMatchInlineSnapshot(`
+    expect(result.outboundRefs).toMatchInlineSnapshot(`
       Array [
         "Qw5FvPdKxAXWnGghsMh3I61yLFfls4Q949Fk2w",
       ]
@@ -378,7 +378,7 @@ describe('given an update of a document with one existing and one non-existent r
   it('should not have updated the document with an invalid reference in the db', async () => {
     const collection: Collection<MeadowlarkDocument> = getCollection(client);
     const result: any = await collection.findOne({ _id: documentWithReferencesId });
-    expect(result.outRefs).toHaveLength(0);
+    expect(result.outboundRefs).toHaveLength(0);
   });
 });
 
@@ -478,7 +478,7 @@ describe('given an update of a subclass document referenced by an existing docum
   it('should have updated the document with a valid reference to superclass in the db', async () => {
     const collection: Collection<MeadowlarkDocument> = getCollection(client);
     const result: any = await collection.findOne({ _id: documentWithReferencesId });
-    expect(result.outRefs).toMatchInlineSnapshot(`
+    expect(result.outboundRefs).toMatchInlineSnapshot(`
       Array [
         "BS3Ub80H5FHOD2j0qzdjhJXZsGSfcZtPWaiepA",
       ]

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Upsert.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Upsert.test.ts
@@ -455,7 +455,7 @@ describe('given an upsert of a subclass document referenced by an existing docum
   it('should have a valid reference to superclass in the db', async () => {
     const collection: Collection<MeadowlarkDocument> = getCollection(client);
     const result: any = await collection.findOne({ _id: documentWithReferencesId });
-    expect(result.outRefs).toMatchInlineSnapshot(`
+    expect(result.outboundRefs).toMatchInlineSnapshot(`
       Array [
         "BS3Ub80H5FHOD2j0qzdjhJXZsGSfcZtPWaiepA",
       ]
@@ -529,7 +529,7 @@ describe('given an update of a document that references a non-existent document 
     const collection: Collection<MeadowlarkDocument> = getCollection(client);
     const result: any = await collection.findOne({ _id: documentWithReferencesId });
     expect(result.documentIdentity.natural).toBe('upsert4');
-    expect(result.outRefs).toMatchInlineSnapshot(`
+    expect(result.outboundRefs).toMatchInlineSnapshot(`
       Array [
         "QtykK4uDYZK7VOChNxRsMDtOcAu6a0oe9ozl2Q",
       ]
@@ -621,7 +621,7 @@ describe('given an update of a document that references an existing document wit
     const collection: Collection<MeadowlarkDocument> = getCollection(client);
     const result: any = await collection.findOne({ _id: documentWithReferencesId });
     expect(result.documentIdentity.natural).toBe('upsert6');
-    expect(result.outRefs).toMatchInlineSnapshot(`
+    expect(result.outboundRefs).toMatchInlineSnapshot(`
       Array [
         "Qw5FvPdKxAXWnGghUWv5LKuA2cXaJPWJGJRDBQ",
       ]
@@ -722,7 +722,7 @@ describe('given an update of a document with one existing and one non-existent r
   it('should not have updated the document with an invalid reference in the db', async () => {
     const collection: Collection<MeadowlarkDocument> = getCollection(client);
     const result: any = await collection.findOne({ _id: documentWithReferencesId });
-    expect(result.outRefs).toHaveLength(0);
+    expect(result.outboundRefs).toHaveLength(0);
   });
 });
 
@@ -822,7 +822,7 @@ describe('given an update of a subclass document referenced by an existing docum
   it('should have updated the document with a valid reference to superclass in the db', async () => {
     const collection: Collection<MeadowlarkDocument> = getCollection(client);
     const result: any = await collection.findOne({ _id: documentWithReferencesId });
-    expect(result.outRefs).toMatchInlineSnapshot(`
+    expect(result.outboundRefs).toMatchInlineSnapshot(`
       Array [
         "BS3Ub80H5FHOD2j0qzdjhJXZsGSfcZtPWaiepA",
       ]

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/locking/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/locking/Delete.test.ts
@@ -112,7 +112,7 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
 
     // ***** Read-for-write lock the validated referenced documents in the insert
     // see https://www.mongodb.com/blog/post/how-to-select--for-update-inside-mongodb-transactions
-    await writeLockReferencedDocuments(mongoCollection, academicWeekDocument.outRefs, upsertSession);
+    await writeLockReferencedDocuments(mongoCollection, academicWeekDocument.outboundRefs, upsertSession);
 
     // ----
     // Start transaction to delete the School document - interferes with the AcademicWeek insert referencing the School

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/locking/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/locking/Delete.test.ts
@@ -21,7 +21,7 @@ import { getCollection, getNewClient, writeLockReferencedDocuments } from '../..
 import {
   validateReferences,
   asUpsert,
-  onlyReturnExistenceIds,
+  onlyReturnAliasIds,
   onlyDocumentsReferencing,
   onlyReturnId,
 } from '../../../src/repository/ReferenceValidation';
@@ -120,15 +120,12 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
     const deleteSession: ClientSession = client.startSession();
     deleteSession.startTransaction();
 
-    // Get the existenceIds for the School document, used to check for references to it as School or as EducationOrganization
-    const deleteCandidate: any = await mongoCollection.findOne(
-      { _id: schoolDocumentId },
-      onlyReturnExistenceIds(deleteSession),
-    );
+    // Get the aliasIds for the School document, used to check for references to it as School or as EducationOrganization
+    const deleteCandidate: any = await mongoCollection.findOne({ _id: schoolDocumentId }, onlyReturnAliasIds(deleteSession));
 
     // Check for any references to the School document
     const anyReferences = await mongoCollection.findOne(
-      onlyDocumentsReferencing(deleteCandidate.existenceIds),
+      onlyDocumentsReferencing(deleteCandidate.aliasIds),
       onlyReturnId(deleteSession),
     );
 

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Db.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Db.ts
@@ -14,9 +14,9 @@ import {
   createReferencesTableSql,
   createSchemaSql,
   createDatabaseSql,
-  createExistenceTableSql,
-  createExistenceTableDocumentIndexSql,
-  createExistenceTableExistenceIndexSql,
+  createAliasesTableSql,
+  createAliasesTableDocumentIndexSql,
+  createAliasesTableAliasIndexSql,
 } from './SqlHelper';
 
 let singletonDbPool: Pool | null = null;
@@ -41,9 +41,9 @@ export async function checkExistsAndCreateTables(client: PoolClient) {
     await client.query(createReferencesTableSql);
     await client.query(createReferencesTableCheckingIndexSql);
     await client.query(createReferencesTableDeletingIndexSql);
-    await client.query(createExistenceTableSql);
-    await client.query(createExistenceTableDocumentIndexSql);
-    await client.query(createExistenceTableExistenceIndexSql);
+    await client.query(createAliasesTableSql);
+    await client.query(createAliasesTableDocumentIndexSql);
+    await client.query(createAliasesTableAliasIndexSql);
   } catch (e) {
     const message = e.constructor.name.includes('Error') ? e.message : 'unknown';
     Logger.error(`Error connecting to PostgreSQL. Error was ${message}`, null);

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Get.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Get.ts
@@ -5,11 +5,11 @@
 
 import type { PoolClient, QueryResult } from 'pg';
 import { GetResult, GetRequest } from '@edfi/meadowlark-core';
-import { documentByIdSql } from './SqlHelper';
+import { findDocumentByIdSql } from './SqlHelper';
 
 export async function getDocumentById({ id }: GetRequest, client: PoolClient): Promise<GetResult> {
   try {
-    const queryResult: QueryResult = await client.query(documentByIdSql(id));
+    const queryResult: QueryResult = await client.query(findDocumentByIdSql(id));
 
     if (queryResult.rowCount === 0) return { response: 'GET_FAILURE_NOT_EXISTS', document: {} };
 

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/OwnershipSecurity.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/OwnershipSecurity.ts
@@ -6,7 +6,7 @@
 import { documentIdForDocumentInfo, FrontendRequest, Logger } from '@edfi/meadowlark-core';
 import type { PoolClient, QueryResult } from 'pg';
 import { SecurityResult } from '../security/SecurityResponse';
-import { documentOwnershipByIdSql } from './SqlHelper';
+import { findOwnershipForDocumentSql } from './SqlHelper';
 
 function extractIdIfUpsert(frontendRequest: FrontendRequest): string | null {
   if (frontendRequest.action !== 'upsert') return null;
@@ -40,7 +40,7 @@ export async function rejectByOwnershipSecurity(
   }
 
   try {
-    const result: QueryResult = await client.query(documentOwnershipByIdSql(id));
+    const result: QueryResult = await client.query(findOwnershipForDocumentSql(id));
 
     if (result.rowCount === 0) {
       Logger.debug(`${functionName} - document not found for id ${id}`, frontendRequest.traceId);

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/ReferenceValidation.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/ReferenceValidation.ts
@@ -6,16 +6,22 @@
 import R from 'ramda';
 import { documentIdForDocumentReference, DocumentReference, Logger } from '@edfi/meadowlark-core';
 import { PoolClient } from 'pg';
-import { validateReferenceExistence } from './SqlHelper';
+import { validateReferenceExistenceSql } from './SqlHelper';
 
-export async function findReferencedDocumentIdsById(referenceIds: string[], client: PoolClient): Promise<string[]> {
+/**
+ * Finds whether the given reference ids are actually documents in the db.
+ *
+ * @param referenceIds The reference ids to check for existence in the db
+ * @param client The PostgreSQL client used for querying the database
+ * @returns The subset of the given reference ids that are actually documents in the db
+ */
+async function findReferencedDocumentIdsById(referenceIds: string[], client: PoolClient): Promise<string[]> {
   if (referenceIds.length === 0) {
     return [];
   }
-  const sql = validateReferenceExistence(referenceIds);
-  const existRef = await client.query(sql);
-  const references = existRef.rows.map((val) => val.existence_id);
-  return references;
+
+  const referenceExistenceResult = await client.query(validateReferenceExistenceSql(referenceIds));
+  return referenceExistenceResult.rows.map((val) => val.alias_id);
 }
 
 /**

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/ReferenceValidation.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/ReferenceValidation.ts
@@ -28,19 +28,19 @@ async function findReferencedDocumentIdsById(referenceIds: string[], client: Poo
  * Finds references in the document that are missing in the database
  *
  * @param refsInDb The document references that were actually found in the db (id property only)
- * @param documentOutRefs The document references extracted from the document, as id strings
+ * @param documentOutboundRefs The document references extracted from the document, as id strings
  * @param documentReferences The DocumentReferences of the document
  * @returns Failure message listing out the resource name and identity of missing document references, if any.
  */
 export function findMissingReferences(
   refsInDb: string[],
-  documentOutRefs: string[],
+  documentOutboundRefs: string[],
   documentReferences: DocumentReference[],
 ): string[] {
-  const outRefIdsNotInDb: string[] = R.difference(documentOutRefs, refsInDb);
+  const outRefIdsNotInDb: string[] = R.difference(documentOutboundRefs, refsInDb);
 
-  // Gets the array indexes of the missing references, for the documentOutRefs array
-  const arrayIndexesOfMissing: number[] = outRefIdsNotInDb.map((outRefId) => documentOutRefs.indexOf(outRefId));
+  // Gets the array indexes of the missing references, for the documentOutboundRefs array
+  const arrayIndexesOfMissing: number[] = outRefIdsNotInDb.map((outRefId) => documentOutboundRefs.indexOf(outRefId));
 
   // Pick out the DocumentReferences of the missing from the entire array of DocumentReferences,
   const pickedDocumentReferencesOfMissing: DocumentReference[] = R.props(
@@ -58,7 +58,7 @@ export function findMissingReferences(
  *
  * @param documentReferences References for the document
  * @param descriptorReferences Descriptor references for the document
- * @param outRefs The list of ids for the document references
+ * @param outboundRefs The list of ids for the document references
  * @param client The PostgreSQL client used for querying the database
  * @param traceId The trace id from a service call
  * @returns A array of validation failure message, if any
@@ -66,16 +66,16 @@ export function findMissingReferences(
 export async function validateReferences(
   documentReferences: DocumentReference[],
   descriptorReferences: DocumentReference[],
-  outRefs: string[],
+  outboundRefs: string[],
   client: PoolClient,
   traceId: string,
 ): Promise<string[]> {
   const failureMessages: string[] = [];
 
-  const referencesInDb = await findReferencedDocumentIdsById(outRefs, client);
-  if (outRefs.length !== referencesInDb.length) {
+  const referencesInDb = await findReferencedDocumentIdsById(outboundRefs, client);
+  if (outboundRefs.length !== referencesInDb.length) {
     Logger.debug('postgresql.repository.WriteHelper.validateReferences: documentReferences not found', traceId);
-    failureMessages.push(...findMissingReferences(referencesInDb, outRefs, documentReferences));
+    failureMessages.push(...findMissingReferences(referencesInDb, outboundRefs, documentReferences));
   }
 
   // Validate descriptor references

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SystemTestHelper.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SystemTestHelper.ts
@@ -10,14 +10,14 @@ export async function systemTestSetup(): Promise<PoolClient> {
   const client = (await getSharedClient()) as PoolClient;
   await client.query('TRUNCATE TABLE meadowlark.documents');
   await client.query('TRUNCATE TABLE meadowlark.references');
-  await client.query('TRUNCATE TABLE meadowlark.existence');
+  await client.query('TRUNCATE TABLE meadowlark.aliases');
   return client;
 }
 
 export async function systemTestTeardown(client: PoolClient): Promise<void> {
   await client.query('TRUNCATE TABLE meadowlark.documents');
   await client.query('TRUNCATE TABLE meadowlark.references');
-  await client.query('TRUNCATE TABLE meadowlark.existence');
+  await client.query('TRUNCATE TABLE meadowlark.aliases');
   client.release();
   await resetSharedClient();
 }

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
@@ -27,7 +27,7 @@ export async function updateDocumentById(
 ): Promise<UpdateResult> {
   let updateResult: UpdateResult = { response: 'UNKNOWN_FAILURE' };
 
-  const outRefs: string[] = documentInfo.documentReferences.map((dr: DocumentReference) =>
+  const outboundRefs: string[] = documentInfo.documentReferences.map((dr: DocumentReference) =>
     documentIdForDocumentReference(dr),
   );
 
@@ -38,7 +38,7 @@ export async function updateDocumentById(
       const failures = await validateReferences(
         documentInfo.documentReferences,
         documentInfo.descriptorReferences,
-        outRefs,
+        outboundRefs,
         client,
         traceId,
       );
@@ -80,15 +80,15 @@ export async function updateDocumentById(
     Logger.debug(`postgresql.repository.Upsert.upsertDocument: Deleting references for document id ${id}`, traceId);
     await client.query(deleteOutboundReferencesOfDocumentSql(id));
 
-    // Adding descriptors to outRefs for reference checking
-    const descriptorOutRefs = documentInfo.descriptorReferences.map((dr: DocumentReference) =>
+    // Adding descriptors to outboundRefs for reference checking
+    const descriptorOutboundRefs = documentInfo.descriptorReferences.map((dr: DocumentReference) =>
       documentIdForDocumentReference(dr),
     );
-    outRefs.push(...descriptorOutRefs);
+    outboundRefs.push(...descriptorOutboundRefs);
 
     // Perform insert of references to the references table
     // eslint-disable-next-line no-restricted-syntax
-    for (const ref of outRefs) {
+    for (const ref of outboundRefs) {
       Logger.debug(`postgresql.repository.Upsert.upsertDocument: Inserting reference id ${ref} for document id ${id}`, ref);
       await client.query(insertOutboundReferencesSql(id, ref));
     }

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
@@ -29,7 +29,7 @@ export async function upsertDocument(
 ): Promise<UpsertResult> {
   let upsertResult: UpsertResult = { response: 'UNKNOWN_FAILURE' };
 
-  const outRefs = documentInfo.documentReferences.map((dr: DocumentReference) => documentIdForDocumentReference(dr));
+  const outboundRefs = documentInfo.documentReferences.map((dr: DocumentReference) => documentIdForDocumentReference(dr));
 
   try {
     await client.query('BEGIN');
@@ -46,7 +46,7 @@ export async function upsertDocument(
       const failures = await validateReferences(
         documentInfo.documentReferences,
         documentInfo.descriptorReferences,
-        outRefs,
+        outboundRefs,
         client,
         traceId,
       );
@@ -83,15 +83,15 @@ export async function upsertDocument(
     Logger.debug(`postgresql.repository.Upsert.upsertDocument: Deleting references for document id ${id}`, traceId);
     await client.query(deleteOutboundReferencesOfDocumentSql(id));
 
-    // Adding descriptors to outRefs for reference checking
-    const descriptorOutRefs = documentInfo.descriptorReferences.map((dr: DocumentReference) =>
+    // Adding descriptors to outboundRefs for reference checking
+    const descriptorOutboundRefs = documentInfo.descriptorReferences.map((dr: DocumentReference) =>
       documentIdForDocumentReference(dr),
     );
-    outRefs.push(...descriptorOutRefs);
+    outboundRefs.push(...descriptorOutboundRefs);
 
     // Perform insert of references to the references table
     // eslint-disable-next-line no-restricted-syntax
-    for (const ref of outRefs) {
+    for (const ref of outboundRefs) {
       Logger.debug(`postgresql.repository.Upsert.upsertDocument: Inserting reference id ${ref} for document id ${id}`, ref);
       await client.query(insertOutboundReferencesSql(id, ref));
     }

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
@@ -14,12 +14,12 @@ import {
 } from '@edfi/meadowlark-core';
 
 import {
-  deleteReferencesSql,
+  deleteOutboundReferencesOfDocumentSql,
   documentInsertOrUpdateSql,
-  referencesInsertSql,
-  deleteExistenceIdsByDocumentId,
-  existenceInsertSql,
-  existenceIdsForDocument,
+  insertOutboundReferencesSql,
+  deleteAliasesForDocumentSql,
+  insertAliasSql,
+  findAliasIdsForDocumentSql,
 } from './SqlHelper';
 import { validateReferences } from './ReferenceValidation';
 
@@ -29,19 +29,18 @@ export async function upsertDocument(
 ): Promise<UpsertResult> {
   let upsertResult: UpsertResult = { response: 'UNKNOWN_FAILURE' };
 
-  let recordExistsResult: QueryResult;
-  let documentUpsertSql: string;
-  let isInsert: boolean;
-
   const outRefs = documentInfo.documentReferences.map((dr: DocumentReference) => documentIdForDocumentReference(dr));
 
   try {
     await client.query('BEGIN');
 
-    recordExistsResult = await client.query(existenceIdsForDocument(id));
-    isInsert = recordExistsResult.rowCount === 0;
+    const documentExistsResult: QueryResult = await client.query(findAliasIdsForDocumentSql(id));
+    const isInsert: boolean = documentExistsResult.rowCount === 0;
 
-    documentUpsertSql = documentInsertOrUpdateSql({ id, resourceInfo, documentInfo, edfiDoc, validate, security }, isInsert);
+    const documentUpsertSql: string = documentInsertOrUpdateSql(
+      { id, resourceInfo, documentInfo, edfiDoc, validate, security },
+      isInsert,
+    );
 
     if (validate) {
       const failures = await validateReferences(
@@ -70,19 +69,19 @@ export async function upsertDocument(
     Logger.debug(`postgresql.repository.Upsert.upsertDocument: Upserting document id ${id}`, traceId);
     await client.query(documentUpsertSql);
 
-    // Delete existing values from the existence table
-    await client.query(deleteExistenceIdsByDocumentId(id));
+    // Delete existing values from the aliases table
+    await client.query(deleteAliasesForDocumentSql(id));
 
-    // Perform insert of existence ids
-    await client.query(existenceInsertSql(id, id));
+    // Perform insert of alias ids
+    await client.query(insertAliasSql(id, id));
     if (documentInfo.superclassInfo != null) {
-      const existenceId = documentIdForSuperclassInfo(documentInfo.superclassInfo);
-      await client.query(existenceInsertSql(id, existenceId));
+      const superclassAliasId = documentIdForSuperclassInfo(documentInfo.superclassInfo);
+      await client.query(insertAliasSql(id, superclassAliasId));
     }
 
     // Delete existing references in references table
     Logger.debug(`postgresql.repository.Upsert.upsertDocument: Deleting references for document id ${id}`, traceId);
-    await client.query(deleteReferencesSql(id));
+    await client.query(deleteOutboundReferencesOfDocumentSql(id));
 
     // Adding descriptors to outRefs for reference checking
     const descriptorOutRefs = documentInfo.descriptorReferences.map((dr: DocumentReference) =>
@@ -94,7 +93,7 @@ export async function upsertDocument(
     // eslint-disable-next-line no-restricted-syntax
     for (const ref of outRefs) {
       Logger.debug(`postgresql.repository.Upsert.upsertDocument: Inserting reference id ${ref} for document id ${id}`, ref);
-      await client.query(referencesInsertSql(id, ref));
+      await client.query(insertOutboundReferencesSql(id, ref));
     }
 
     await client.query('COMMIT');

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
@@ -24,7 +24,7 @@ import { deleteAll, retrieveReferencesByDocumentIdSql } from './TestHelper';
 import { getSharedClient, resetSharedClient } from '../../src/repository/Db';
 import { deleteDocumentById } from '../../src/repository/Delete';
 import { upsertDocument } from '../../src/repository/Upsert';
-import { documentByIdSql } from '../../src/repository/SqlHelper';
+import { findDocumentByIdSql } from '../../src/repository/SqlHelper';
 
 jest.setTimeout(40000);
 
@@ -112,7 +112,7 @@ describe('given the delete of an existing document', () => {
   });
 
   it('should have deleted the document in the db', async () => {
-    const result: any = await client.query(documentByIdSql(id));
+    const result: any = await client.query(findDocumentByIdSql(id));
     expect(result.rowCount).toEqual(0);
   });
 });
@@ -179,7 +179,7 @@ describe('given an delete of a document referenced by an existing document with 
   });
 
   it('should still have the referenced document in the db', async () => {
-    const docResult: any = await client.query(documentByIdSql(referencedDocumentId));
+    const docResult: any = await client.query(findDocumentByIdSql(referencedDocumentId));
     expect(docResult.rows[0].document_identity.natural).toBe('delete5');
   });
 });
@@ -251,7 +251,7 @@ describe('given an delete of a document with an outbound reference only, with va
   });
 
   it('should have deleted the document in the db', async () => {
-    const result: any = await client.query(documentByIdSql(documentWithReferencesId));
+    const result: any = await client.query(findDocumentByIdSql(documentWithReferencesId));
 
     expect(result.rowCount).toEqual(0);
   });
@@ -318,7 +318,7 @@ describe('given an delete of a document referenced by an existing document with 
   });
 
   it('should not have the referenced document in the db', async () => {
-    const docResult: any = await client.query(documentByIdSql(referencedDocumentId));
+    const docResult: any = await client.query(findDocumentByIdSql(referencedDocumentId));
     expect(docResult.rowCount).toEqual(0);
   });
 
@@ -404,7 +404,7 @@ describe('given the delete of a subclass document referenced by an existing docu
   });
 
   it('should still have the referenced document in the db', async () => {
-    const result: any = await client.query(documentByIdSql(referencedDocumentId));
+    const result: any = await client.query(findDocumentByIdSql(referencedDocumentId));
     expect(result.rows[0].document_identity.schoolId).toBe('123');
   });
 });

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Read.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Read.test.ts
@@ -20,7 +20,7 @@ import type { PoolClient } from 'pg';
 import { resetSharedClient, getSharedClient } from '../../src/repository/Db';
 import { deleteAll } from './TestHelper';
 import { getDocumentById } from '../../src/repository/Get';
-import { documentByIdSql } from '../../src/repository/SqlHelper';
+import { findDocumentByIdSql } from '../../src/repository/SqlHelper';
 import { upsertDocument } from '../../src/repository/Upsert';
 
 jest.setTimeout(40000);
@@ -69,7 +69,7 @@ describe('given the get of a non-existent document', () => {
   });
 
   it('should not exist in the db', async () => {
-    const result = await client.query(documentByIdSql(id));
+    const result = await client.query(findDocumentByIdSql(id));
 
     expect(result.rowCount).toBe(0);
   });

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/TestHelper.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/TestHelper.ts
@@ -8,14 +8,14 @@ import format from 'pg-format';
 export async function deleteAll(client: PoolClient): Promise<void> {
   await client.query('TRUNCATE TABLE meadowlark.documents');
   await client.query('TRUNCATE TABLE meadowlark.references');
-  await client.query('TRUNCATE TABLE meadowlark.existence');
+  await client.query('TRUNCATE TABLE meadowlark.aliases');
 }
 
-export const verifyExistenceId = (existenceId: string): string =>
+export const verifyAliasId = (aliasId: string): string =>
   format(
-    `SELECT existence_id from meadowlark.existence
-  WHERE document_id = %L AND existence_id != %1$L`,
-    [existenceId],
+    `SELECT alias_id from meadowlark.aliases
+  WHERE document_id = %L AND alias_id != %1$L`,
+    [aliasId],
   );
 
 /**

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
@@ -24,9 +24,9 @@ import type { PoolClient } from 'pg';
 import { resetSharedClient, getSharedClient } from '../../src/repository/Db';
 import { updateDocumentById } from '../../src/repository/Update';
 import { upsertDocument } from '../../src/repository/Upsert';
-import { deleteAll, retrieveReferencesByDocumentIdSql, verifyExistenceId } from './TestHelper';
+import { deleteAll, retrieveReferencesByDocumentIdSql, verifyAliasId } from './TestHelper';
 import { getDocumentById } from '../../src/repository/Get';
-import { documentByIdSql } from '../../src/repository/SqlHelper';
+import { findDocumentByIdSql } from '../../src/repository/SqlHelper';
 
 jest.setTimeout(40000);
 
@@ -128,7 +128,7 @@ describe('given the update of an existing document', () => {
   });
 
   it('should have updated the document in the db', async () => {
-    const result: any = await client.query(documentByIdSql(id));
+    const result: any = await client.query(findDocumentByIdSql(id));
     // await getDocumentById({ ...newGetRequest(), id }, client);
 
     expect(result.rows[0].document_identity.natural).toBe('update2');
@@ -199,7 +199,7 @@ describe('given an update of a document that references a non-existent document 
   });
 
   it('should have updated the document with an invalid reference in the db', async () => {
-    const docResult: any = await client.query(documentByIdSql(documentWithReferencesId));
+    const docResult: any = await client.query(findDocumentByIdSql(documentWithReferencesId));
     const refsResult: any = await client.query(retrieveReferencesByDocumentIdSql(documentWithReferencesId));
 
     const outRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
@@ -296,7 +296,7 @@ describe('given an update of a document that references an existing document wit
   });
 
   it('should have updated the document with a valid reference in the db', async () => {
-    const docResult: any = await client.query(documentByIdSql(documentWithReferencesId));
+    const docResult: any = await client.query(findDocumentByIdSql(documentWithReferencesId));
     const refsResult: any = await client.query(retrieveReferencesByDocumentIdSql(documentWithReferencesId));
 
     const outRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
@@ -500,8 +500,8 @@ describe('given an update of a subclass document referenced by an existing docum
   });
 
   it('should have updated the document with a valid reference to superclass in the db', async () => {
-    const result: any = await client.query(verifyExistenceId(referencedDocumentId));
-    const outRefs = result.rows.map((row) => row.existence_id);
+    const result: any = await client.query(verifyAliasId(referencedDocumentId));
+    const outRefs = result.rows.map((row) => row.alias_id);
     expect(outRefs).toMatchInlineSnapshot(`
       Array [
         "BS3Ub80H5FHOD2j0qzdjhJXZsGSfcZtPWaiepA",

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
@@ -202,11 +202,11 @@ describe('given an update of a document that references a non-existent document 
     const docResult: any = await client.query(findDocumentByIdSql(documentWithReferencesId));
     const refsResult: any = await client.query(retrieveReferencesByDocumentIdSql(documentWithReferencesId));
 
-    const outRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
+    const outboundRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
 
     expect(docResult.rows[0].document_identity.natural).toBe('update4');
 
-    expect(outRefs).toMatchInlineSnapshot(`
+    expect(outboundRefs).toMatchInlineSnapshot(`
       Array [
         "QtykK4uDYZK7VOChNxRsMDtOcAu6a0oe9ozl2Q",
       ]
@@ -299,9 +299,9 @@ describe('given an update of a document that references an existing document wit
     const docResult: any = await client.query(findDocumentByIdSql(documentWithReferencesId));
     const refsResult: any = await client.query(retrieveReferencesByDocumentIdSql(documentWithReferencesId));
 
-    const outRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
+    const outboundRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
     expect(docResult.rows[0].document_identity.natural).toBe('update6');
-    expect(outRefs).toMatchInlineSnapshot(`
+    expect(outboundRefs).toMatchInlineSnapshot(`
       Array [
         "Qw5FvPdKxAXWnGghsMh3I61yLFfls4Q949Fk2w",
       ]
@@ -403,8 +403,8 @@ describe('given an update of a document with one existing and one non-existent r
   it('should not have updated the document with an invalid reference in the db', async () => {
     const refsResult: any = await client.query(retrieveReferencesByDocumentIdSql(documentWithReferencesId));
 
-    const outRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
-    expect(outRefs).toHaveLength(0);
+    const outboundRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
+    expect(outboundRefs).toHaveLength(0);
   });
 });
 
@@ -501,8 +501,8 @@ describe('given an update of a subclass document referenced by an existing docum
 
   it('should have updated the document with a valid reference to superclass in the db', async () => {
     const result: any = await client.query(verifyAliasId(referencedDocumentId));
-    const outRefs = result.rows.map((row) => row.alias_id);
-    expect(outRefs).toMatchInlineSnapshot(`
+    const outboundRefs = result.rows.map((row) => row.alias_id);
+    expect(outboundRefs).toMatchInlineSnapshot(`
       Array [
         "BS3Ub80H5FHOD2j0qzdjhJXZsGSfcZtPWaiepA",
       ]

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Upsert.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Upsert.test.ts
@@ -443,9 +443,9 @@ describe('given an update of a document that references a non-existent document 
     const docResult: any = await client.query(findDocumentByIdSql(documentWithReferencesId));
     const refsResult: any = await client.query(retrieveReferencesByDocumentIdSql(documentWithReferencesId));
 
-    const outRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
+    const outboundRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
     expect(docResult.rows[0].document_identity.natural).toBe('upsert4');
-    expect(outRefs).toMatchInlineSnapshot(`
+    expect(outboundRefs).toMatchInlineSnapshot(`
         Array [
           "QtykK4uDYZK7VOChNxRsMDtOcAu6a0oe9ozl2Q",
         ]
@@ -538,10 +538,10 @@ describe('given an update of a document that references an existing document wit
     const docResult: any = await client.query(findDocumentByIdSql(documentWithReferencesId));
     const refsResult: any = await client.query(retrieveReferencesByDocumentIdSql(documentWithReferencesId));
 
-    const outRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
+    const outboundRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
 
     expect(docResult.rows[0].document_identity.natural).toBe('upsert6');
-    expect(outRefs).toMatchInlineSnapshot(`
+    expect(outboundRefs).toMatchInlineSnapshot(`
       Array [
         "Qw5FvPdKxAXWnGghUWv5LKuA2cXaJPWJGJRDBQ",
       ]
@@ -644,9 +644,9 @@ describe('given an update of a document with one existing and one non-existent r
     await client.query(findDocumentByIdSql(documentWithReferencesId));
     const refsResult: any = await client.query(retrieveReferencesByDocumentIdSql(documentWithReferencesId));
 
-    const outRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
+    const outboundRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
 
-    expect(outRefs).toHaveLength(0);
+    expect(outboundRefs).toHaveLength(0);
   });
 });
 
@@ -746,8 +746,8 @@ describe('given an update of a subclass document referenced by an existing docum
 
   it('should have updated the document with a valid reference to superclass in the db', async () => {
     const result: any = await client.query(verifyAliasId(referencedDocumentId));
-    const outRefs = result.rows.map((row) => row.alias_id);
-    expect(outRefs).toMatchInlineSnapshot(`
+    const outboundRefs = result.rows.map((row) => row.alias_id);
+    expect(outboundRefs).toMatchInlineSnapshot(`
       Array [
         "BS3Ub80H5FHOD2j0qzdjhJXZsGSfcZtPWaiepA",
       ]

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/locking/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/locking/Delete.test.ts
@@ -20,14 +20,14 @@ import { PoolClient } from 'pg';
 import { getSharedClient, resetSharedClient } from '../../../src/repository/Db';
 import { validateReferences } from '../../../src/repository/ReferenceValidation';
 import {
-  checkIfDocumentReferenced,
+  findReferencingDocumentIdsSql,
   deleteDocumentByIdSql,
-  deleteExistenceIdsByDocumentId,
-  documentByIdSql,
+  deleteAliasesForDocumentSql,
+  findDocumentByIdSql,
   documentInsertOrUpdateSql,
-  existenceIdsForDocument,
-  existenceInsertSql,
-  referencesInsertSql,
+  findAliasIdsForDocumentSql,
+  insertAliasSql,
+  insertOutboundReferencesSql,
 } from '../../../src/repository/SqlHelper';
 import { upsertDocument } from '../../../src/repository/Upsert';
 import { deleteAll } from '../TestHelper';
@@ -117,19 +117,19 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
     await deleteClient.query('BEGIN');
 
     try {
-      // Get the existence id's for the document we're trying to delete, because the update transaction is trying
+      // Get the alias ids for the document we're trying to delete, because the update transaction is trying
       // to use our school, this is where the code will throw a locking error. This is technically the last line
       // of code in this try block that should execute
-      const existenceIdResult = await deleteClient.query(existenceIdsForDocument(schoolDocumentId));
+      const aliasIdResult = await deleteClient.query(findAliasIdsForDocumentSql(schoolDocumentId));
 
-      const validDocIds = existenceIdResult.rows.map((ref) => ref.existence_id);
-      const referenceResult = await deleteClient.query(checkIfDocumentReferenced(validDocIds));
+      const validDocIds = aliasIdResult.rows.map((ref) => ref.alias_id);
+      const referenceResult = await deleteClient.query(findReferencingDocumentIdsSql(validDocIds));
       const anyReferences = referenceResult.rows.filter((ref) => ref.document_id !== schoolDocumentId);
 
       expect(anyReferences.length).toEqual(0);
 
       await deleteClient.query(deleteDocumentByIdSql(schoolDocumentId));
-      await deleteClient.query(deleteExistenceIdsByDocumentId(schoolDocumentId));
+      await deleteClient.query(deleteAliasesForDocumentSql(schoolDocumentId));
       await deleteClient.query('COMMIT');
     } catch (e1) {
       await deleteClient.query('ROLLBACK');
@@ -152,8 +152,8 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
     const insertResult = await insertClient.query(documentUpsertSql);
     // eslint-disable-next-line no-restricted-syntax
     for (const ref of outRefs) {
-      await insertClient.query(referencesInsertSql(academicWeekDocumentId, ref));
-      await insertClient.query(existenceInsertSql(academicWeekDocumentId, ref));
+      await insertClient.query(insertOutboundReferencesSql(academicWeekDocumentId, ref));
+      await insertClient.query(insertAliasSql(academicWeekDocumentId, ref));
     }
 
     // **** The insert of AcademicWeek document should have been successful
@@ -174,7 +174,7 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
   });
 
   it('should have still have the School document in the db - a success', async () => {
-    const docResult: any = await insertClient.query(documentByIdSql(schoolDocumentId));
+    const docResult: any = await insertClient.query(findDocumentByIdSql(schoolDocumentId));
     expect(docResult.rows[0].document_identity.schoolId).toBe('123');
   });
 });
@@ -195,24 +195,24 @@ describe('given an insert concurrent with a delete referencing the to-be-deleted
     // ----
     await deleteClient.query('BEGIN');
 
-    // Retrieve the existence id's for the school that we're trying to delete, this call will also
+    // Retrieve the alias ids for the school that we're trying to delete, this call will also
     // lock the school record so when we try to lock the records during the insert of the academic week
     // below it will fail
-    const existenceIdResult = await deleteClient.query(existenceIdsForDocument(schoolDocumentId));
+    const aliasIdResult = await deleteClient.query(findAliasIdsForDocumentSql(schoolDocumentId));
 
     // The school is in the database
-    expect(existenceIdResult.rowCount).toEqual(1);
+    expect(aliasIdResult.rowCount).toEqual(1);
 
     // See if there are existing references to this document
-    const validDocIds = existenceIdResult.rows.map((ref) => ref.existence_id);
-    const referenceResult = await deleteClient.query(checkIfDocumentReferenced(validDocIds));
+    const validDocIds = aliasIdResult.rows.map((ref) => ref.alias_id);
+    const referenceResult = await deleteClient.query(findReferencingDocumentIdsSql(validDocIds));
     const anyReferences = referenceResult.rows.filter((ref) => ref.document_id !== schoolDocumentId);
 
     expect(anyReferences.length).toEqual(0);
 
     // Delete the document
     await deleteClient.query(deleteDocumentByIdSql(schoolDocumentId));
-    await deleteClient.query(deleteExistenceIdsByDocumentId(schoolDocumentId));
+    await deleteClient.query(deleteAliasesForDocumentSql(schoolDocumentId));
 
     // Start the insert
     await insertClient.query('BEGIN');
@@ -252,8 +252,8 @@ describe('given an insert concurrent with a delete referencing the to-be-deleted
       expect(insertResult.rowCount).toEqual(0);
       // eslint-disable-next-line no-restricted-syntax
       for (const ref of outRefs) {
-        await insertClient.query(referencesInsertSql(academicWeekDocumentId, ref));
-        await insertClient.query(existenceInsertSql(academicWeekDocumentId, ref));
+        await insertClient.query(insertOutboundReferencesSql(academicWeekDocumentId, ref));
+        await insertClient.query(insertAliasSql(academicWeekDocumentId, ref));
       }
       await insertClient.query('COMMIT');
     } catch (e1) {
@@ -273,8 +273,8 @@ describe('given an insert concurrent with a delete referencing the to-be-deleted
   });
 
   it('should have still have the School document in the db - a success', async () => {
-    const schoolDocResult: any = await insertClient.query(documentByIdSql(schoolDocumentId));
-    const awDocResult: any = await insertClient.query(documentByIdSql(academicWeekDocumentId));
+    const schoolDocResult: any = await insertClient.query(findDocumentByIdSql(schoolDocumentId));
+    const awDocResult: any = await insertClient.query(findDocumentByIdSql(academicWeekDocumentId));
     expect(schoolDocResult.rowCount).toEqual(0);
     expect(awDocResult.rowCount).toEqual(0);
   });

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/locking/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/locking/Delete.test.ts
@@ -94,7 +94,7 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
     // ----
     // try {
     await insertClient.query('BEGIN');
-    const outRefs = academicWeekDocumentInfo.documentReferences.map((dr: DocumentReference) =>
+    const outboundRefs = academicWeekDocumentInfo.documentReferences.map((dr: DocumentReference) =>
       documentIdForDocumentReference(dr),
     );
 
@@ -103,7 +103,7 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
     const upsertFailures = await validateReferences(
       academicWeekDocumentInfo.documentReferences,
       [],
-      outRefs,
+      outboundRefs,
       insertClient,
       '',
     );
@@ -151,7 +151,7 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
 
     const insertResult = await insertClient.query(documentUpsertSql);
     // eslint-disable-next-line no-restricted-syntax
-    for (const ref of outRefs) {
+    for (const ref of outboundRefs) {
       await insertClient.query(insertOutboundReferencesSql(academicWeekDocumentId, ref));
       await insertClient.query(insertAliasSql(academicWeekDocumentId, ref));
     }
@@ -217,7 +217,7 @@ describe('given an insert concurrent with a delete referencing the to-be-deleted
     // Start the insert
     await insertClient.query('BEGIN');
 
-    const outRefs = academicWeekDocumentInfo.documentReferences.map((dr: DocumentReference) =>
+    const outboundRefs = academicWeekDocumentInfo.documentReferences.map((dr: DocumentReference) =>
       documentIdForDocumentReference(dr),
     );
 
@@ -228,7 +228,7 @@ describe('given an insert concurrent with a delete referencing the to-be-deleted
       const upsertFailures = await validateReferences(
         academicWeekDocumentInfo.documentReferences,
         [],
-        outRefs,
+        outboundRefs,
         insertClient,
         '',
       );
@@ -251,7 +251,7 @@ describe('given an insert concurrent with a delete referencing the to-be-deleted
       const insertResult = await insertClient.query(documentUpsertSql);
       expect(insertResult.rowCount).toEqual(0);
       // eslint-disable-next-line no-restricted-syntax
-      for (const ref of outRefs) {
+      for (const ref of outboundRefs) {
         await insertClient.query(insertOutboundReferencesSql(academicWeekDocumentId, ref));
         await insertClient.query(insertAliasSql(academicWeekDocumentId, ref));
       }


### PR DESCRIPTION
This 1st commit is for PostgreSQL. Aside from directly renaming "existence" to "alias", changes are around related function naming for clarity/action-orientation, and enhancement of comments. Also a `let` -> `const` in there, but no logic changes.