### PR TITLE
Setting jest threshold value to a minimum where still passes validation

### DIFF
--- a/Meadowlark-js/jest.ci-config.js
+++ b/Meadowlark-js/jest.ci-config.js
@@ -10,10 +10,10 @@ module.exports = {
   collectCoverageFrom: ['packages/**/src/**/*.ts'],
   coverageThreshold: {
     global: {
-      branches: 10,
-      functions: 10,
-      lines: 10,
-      statements: 10,
+      branches: 67,
+      functions: 73,
+      lines: 82,
+      statements: 81,
     },
   },
   modulePathIgnorePatterns: ['dist*', 'docs*'],

--- a/Meadowlark-js/jest.config.js
+++ b/Meadowlark-js/jest.config.js
@@ -9,10 +9,10 @@ module.exports = {
   collectCoverageFrom: ['packages/**/src/**/*.ts'],
   coverageThreshold: {
     global: {
-      branches: 10,
-      functions: 10,
-      lines: 10,
-      statements: 10,
+      branches: 67,
+      functions: 73,
+      lines: 82,
+      statements: 81,
     },
   },
   modulePathIgnorePatterns: ['dist*', 'docs*'],


### PR DESCRIPTION
Setting values for jest coverage to a value that still passes but is close to the current coverage.

If the new changes start to decrease the coverage, the build will fail until adding new tests