### PR TITLE
[RND-299] - Harden PostgreSQL error handling

### DIFF
--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
@@ -29,7 +29,7 @@ export async function deleteDocumentById(
       const documentAliasIdsResult: QueryResult = await client.query(findAliasIdsForDocumentSql(id));
 
       // All documents have alias ids. If no alias ids were found, the document doesn't exist
-      if (documentAliasIdsResult?.rowCount === 0) {
+      if (documentAliasIdsResult.rowCount == null || documentAliasIdsResult.rowCount === 0) {
         await client.query('ROLLBACK');
         deleteResult = { response: 'DELETE_FAILURE_NOT_EXISTS' };
         return deleteResult;
@@ -40,7 +40,13 @@ export async function deleteDocumentById(
 
       // Find any documents that reference this document, either it's own id or an alias
       const referenceResult = await client.query(findReferencingDocumentIdsSql(documentAliasIds));
-      const references = referenceResult.rows.filter((ref) => ref.document_id !== id);
+
+      if (referenceResult.rows == null) {
+        await client.query('ROLLBACK');
+        return deleteResult;
+      }
+
+      const references = referenceResult?.rows.filter((ref) => ref.document_id !== id);
 
       // If this document is referenced, it's a validation failure
       if (references.length > 0) {
@@ -52,6 +58,12 @@ export async function deleteDocumentById(
         // Get the information of up to five referring documents for failure message purposes
         const referenceIds = references.map((ref) => ref.parent_document_id);
         const referringDocuments = await client.query(findReferringDocumentInfoForErrorReportingSql(referenceIds));
+
+        if (referringDocuments.rows == null) {
+          await client.query('ROLLBACK');
+          return deleteResult;
+        }
+
         const blockingDocuments: BlockingDocument[] = referringDocuments.rows.map((document) => ({
           resourceName: document.resource_name,
           documentId: document.document_id,
@@ -71,6 +83,12 @@ export async function deleteDocumentById(
     // Perform the document delete
     Logger.debug(`postgresql.repository.Delete.deleteDocumentById: Deleting document id ${id}`, traceId);
     const deleteQueryResult: QueryResult = await client.query(deleteDocumentByIdSql(id));
+
+    if (deleteQueryResult.rowCount === 0 || deleteQueryResult.rows == null) {
+      await client.query('ROLLBACK');
+      return deleteResult;
+    }
+
     deleteResult =
       deleteQueryResult.rows[0].count === '0' ? { response: 'DELETE_FAILURE_NOT_EXISTS' } : { response: 'DELETE_SUCCESS' };
 

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
@@ -31,6 +31,7 @@ export async function deleteDocumentById(
       // All documents have alias ids. If no alias ids were found, the document doesn't exist
       if (documentAliasIdsResult.rowCount == null || documentAliasIdsResult.rowCount === 0) {
         await client.query('ROLLBACK');
+        Logger.debug(`postgres.repository.Delete.deleteDocumentById: Document id ${id} does not exist`, traceId);
         deleteResult = { response: 'DELETE_FAILURE_NOT_EXISTS' };
         return deleteResult;
       }
@@ -43,8 +44,10 @@ export async function deleteDocumentById(
 
       if (referenceResult.rows == null) {
         await client.query('ROLLBACK');
-        deleteResult.failureMessage = `deleteDocumentById: Error determining documents referenced by ${id},
+        const errorMessage = `deleteDocumentById: Error determining documents referenced by ${id},
         a null result set was returned`;
+        deleteResult.failureMessage = errorMessage;
+        Logger.error(errorMessage, traceId);
         return deleteResult;
       }
 
@@ -63,8 +66,10 @@ export async function deleteDocumentById(
 
         if (referringDocuments.rows == null) {
           await client.query('ROLLBACK');
-          deleteResult.failureMessage = `deleteDocumentById: Error retrieving documents referenced by ${id},
+          const errorMessage = `deleteDocumentById: Error retrieving documents referenced by ${id},
           a null result set was returned`;
+          deleteResult.failureMessage = errorMessage;
+          Logger.error(errorMessage, traceId);
           return deleteResult;
         }
 

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
@@ -44,8 +44,7 @@ export async function deleteDocumentById(
 
       if (referenceResult.rows == null) {
         await client.query('ROLLBACK');
-        const errorMessage = `deleteDocumentById: Error determining documents referenced by ${id},
-        a null result set was returned`;
+        const errorMessage = `deleteDocumentById: Error determining documents referenced by ${id}, a null result set was returned`;
         deleteResult.failureMessage = errorMessage;
         Logger.error(errorMessage, traceId);
         return deleteResult;
@@ -66,8 +65,7 @@ export async function deleteDocumentById(
 
         if (referringDocuments.rows == null) {
           await client.query('ROLLBACK');
-          const errorMessage = `deleteDocumentById: Error retrieving documents referenced by ${id},
-          a null result set was returned`;
+          const errorMessage = `deleteDocumentById: Error retrieving documents referenced by ${id}, a null result set was returned`;
           deleteResult.failureMessage = errorMessage;
           Logger.error(errorMessage, traceId);
           return deleteResult;

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
@@ -112,7 +112,7 @@ export async function deleteDocumentById(
   } catch (e) {
     Logger.error('postgresql.repository.Delete.deleteDocumentById', traceId, e);
     await client.query('ROLLBACK');
-    return { response: 'UNKNOWN_FAILURE', failureMessage: e.message };
+    return { response: 'UNKNOWN_FAILURE', failureMessage: '' };
   }
   return deleteResult;
 }

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
@@ -43,6 +43,8 @@ export async function deleteDocumentById(
 
       if (referenceResult.rows == null) {
         await client.query('ROLLBACK');
+        deleteResult.failureMessage = `deleteDocumentById: Error determining documents referenced by ${id},
+        a null result set was returned`;
         return deleteResult;
       }
 
@@ -61,6 +63,8 @@ export async function deleteDocumentById(
 
         if (referringDocuments.rows == null) {
           await client.query('ROLLBACK');
+          deleteResult.failureMessage = `deleteDocumentById: Error retrieving documents referenced by ${id},
+          a null result set was returned`;
           return deleteResult;
         }
 
@@ -86,6 +90,7 @@ export async function deleteDocumentById(
 
     if (deleteQueryResult.rowCount === 0 || deleteQueryResult.rows == null) {
       await client.query('ROLLBACK');
+      deleteResult.failureMessage = `deleteDocumentById: Failure deleting document ${id}, a null result was returned`;
       return deleteResult;
     }
 

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Get.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Get.ts
@@ -11,6 +11,11 @@ export async function getDocumentById({ id }: GetRequest, client: PoolClient): P
   try {
     const queryResult: QueryResult = await client.query(findDocumentByIdSql(id));
 
+    // Postgres will return an empty row set if no results are returned, if we have no rows, there is a problem
+    if (queryResult.rows == null) {
+      return { response: 'UNKNOWN_FAILURE', document: {} };
+    }
+
     if (queryResult.rowCount === 0) return { response: 'GET_FAILURE_NOT_EXISTS', document: {} };
 
     const response: GetResult = {

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Get.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Get.ts
@@ -13,11 +13,13 @@ export async function getDocumentById({ id, traceId }: GetRequest, client: PoolC
 
     // Postgres will return an empty row set if no results are returned, if we have no rows, there is a problem
     if (queryResult.rows == null) {
+      const errorMessage = `Could not retrieve document ${id}
+      a null result set was returned, indicating system failure`;
+      Logger.error(errorMessage, traceId);
       return {
         response: 'UNKNOWN_FAILURE',
         document: {},
-        failureMessage: `Could not retrieve document ${id}
-      a null result set was returned, indicating system failure`,
+        failureMessage: errorMessage,
       };
     }
 

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/OwnershipSecurity.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/OwnershipSecurity.ts
@@ -44,6 +44,10 @@ export async function rejectByOwnershipSecurity(
   try {
     const result: QueryResult = await client.query(findOwnershipForDocumentSql(id));
 
+    if (result.rows == null) {
+      return 'UNKNOWN_FAILURE';
+    }
+
     if (result.rowCount === 0) {
       Logger.debug(`${functionName} - document not found for id ${id}`, frontendRequest.traceId);
       return 'NOT_APPLICABLE';

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/OwnershipSecurity.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/OwnershipSecurity.ts
@@ -45,6 +45,7 @@ export async function rejectByOwnershipSecurity(
     const result: QueryResult = await client.query(findOwnershipForDocumentSql(id));
 
     if (result.rows == null) {
+      Logger.error(`${functionName} - Unknown Error determining access`, frontendRequest.traceId);
       return 'UNKNOWN_FAILURE';
     }
 

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/OwnershipSecurity.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/OwnershipSecurity.ts
@@ -61,6 +61,7 @@ export async function rejectByOwnershipSecurity(
     Logger.debug(`${functionName} - access denied: id ${id}, clientId ${clientId}`, frontendRequest.traceId);
     return 'ACCESS_DENIED';
   } catch (e) {
+    Logger.error(`${functionName} - Error determining access`, frontendRequest.traceId, e);
     return 'UNKNOWN_FAILURE';
   }
 }

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/ReferenceValidation.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/ReferenceValidation.ts
@@ -21,6 +21,17 @@ async function findReferencedDocumentIdsById(referenceIds: string[], client: Poo
   }
 
   const referenceExistenceResult = await client.query(validateReferenceExistenceSql(referenceIds));
+
+  if (referenceExistenceResult.rows == null) {
+    Logger.error(
+      'postgresql.repository.referencevalidation.findReferencedDocumentIdsById: Database error parsing references',
+      null,
+    );
+    throw new Error(
+      'postgresql.repository.referencevalidation.findReferencedDocumentIdsById: Database error parsing references',
+    );
+  }
+
   return referenceExistenceResult.rows.map((val) => val.alias_id);
 }
 


### PR DESCRIPTION
These are all checks to make sure that the objects returned from a query have a rows object before access. I don't see a problem with these in general, but... 

If a database or table gets deleted while Meadowlark running the query will error, and wind up in the catch block which will end with a 500 error to the client, it will never hit the rows objects.

If a table is deleted and Meadowlark is restarted, there is no error, any query that attempts to hit a non-existent table will return empty and thus most of the time act like a 404.

If the database gets deleted and Meadowlark is restarted, the database is generated.