### PR TITLE
[RND-365] Run End To End Tests

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -24,6 +24,14 @@ jobs:
               file: "integration-tests/junit.xml",
             },
             { name: "System Test Report", file: "system-tests/junit.xml" },
+            {
+              name: "Mongo End To End Tests",
+              file: "Mongo-e2e-tests/junit.xml",
+            },
+            {
+              name: "PostgreSQL End To End Tests",
+              file: "PGSQL-e2e-tests/junit.xml",
+            },
           ]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,8 +73,16 @@ jobs:
           retention-days: 1
 
   end-to-end:
-    name: End to End tests
+    name: End to End tests for ${{ matrix.config.db }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          [
+            { db: "PGSQL", plugin: "@edfi/meadowlark-postgresql-backend" },
+            { db: "Mongo", plugin: "@edfi/meadowlark-mongodb-backend" },
+          ]
 
     defaults:
       run:
@@ -94,36 +102,66 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-      - name: Start Containers
-        run: |
-          docker compose -f ./backends/meadowlark-postgresql-backend/docker/docker-compose.yml up -d
-          docker compose -f ./backends/meadowlark-opensearch-backend/docker/docker-compose.yml up -d
+      - name: Start OpenSearch Container
+        run: docker compose -f ./backends/meadowlark-opensearch-backend/docker/docker-compose.yml up -d
 
-      - name: Build
+      - if: ${{ matrix.config.db == 'PGSQL' }}
+        name: Start Postgres Container
+        run: docker compose -f ./backends/meadowlark-postgresql-backend/docker/docker-compose.yml up -d
+
+      - if: ${{ matrix.config.db == 'Mongo' }}
+        name: Setup Mongo
+        run: |
+          chmod +x ../eng/setup-mongo.sh
+          ../eng/setup-mongo.sh
+
+      - name: Cache Build
+        uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09 #v3.0.2
+        env:
+          cache-name: cache-build
+        with:
+          path: "**/dist/**"
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/dist/**') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+
+      - if: ${{ steps.cache-build.outputs.cache-hit != 'true' }}
+        name: Build
         run: yarn build
 
-      - name: Start Fastify against Postgres
+      - name: Run Fastify in background
         run: |
           cp ./tests/e2e/setup/e2e.env ./services/meadowlark-fastify/.env
-          yarn start:local &
+          yarn start:local > fastify.log &
         env:
+          DOCUMENT_STORE_PLUGIN: ${{ matrix.config.plugin }}
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: abcdefgh1!
           OPENSEARCH_USERNAME: admin
           OPENSEARCH_PASSWORD: admin
-          DOCUMENT_STORE_PLUGIN: "@edfi/meadowlark-postgresql-backend"
+          MONGO_URL: "mongodb://mongo:abcdefgh1!@mongo1:27017,mongo2:27018,mongo3:27019/?replicaSet=rs0"
 
-      - name: End to End tests for Postgres
+      - name: End to End tests for ${{matrix.config.db}}
         run: |
           cp ./tests/e2e/.env.example ./tests/e2e/.env
           yarn test:e2e --ci --config ./jest.ci-config.js
         env:
-          JEST_JUNIT_OUTPUT_DIR: pg-e2e-tests
+          JEST_JUNIT_OUTPUT_DIR: ${{matrix.config.db}}-e2e-tests
 
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        with:
+          name: fastify-logs
+          path: "**/fastify.log"
+          retention-days: 10
+
+      # Workaround for issue https://github.com/actions/upload-artifact/issues/174
       - name: Upload test results
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: test-results
           path: |
-            Meadowlark-js/pg-e2e-tests/junit.xml
+            Meadowlark-js/${{matrix.config.db}}-e2e-tests/junit.xml
+            Meadowlark-js/.prettierrc
           retention-days: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,3 +71,59 @@ jobs:
             Meadowlark-js/integration-tests/junit.xml
             Meadowlark-js/system-tests/junit.xml
           retention-days: 1
+
+  end-to-end:
+    name: End to End tests
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: Meadowlark-js
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+
+      - name: NPM caching
+        uses: actions/setup-node@17f8bd926464a1afa4c6a11669539e9c1ba77048 # v3.2.0
+        with:
+          node-version: "16"
+          cache: "yarn"
+          cache-dependency-path: "**/yarn.lock"
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Start Containers
+        run: |
+          docker compose -f ./backends/meadowlark-postgresql-backend/docker/docker-compose.yml up -d
+          docker compose -f ./backends/meadowlark-opensearch-backend/docker/docker-compose.yml up -d
+
+      - name: Build
+        run: yarn build
+
+      - name: Start Fastify against Postgres
+        run: |
+          cp ./tests/e2e/setup/e2e.env ./services/meadowlark-fastify/.env
+          yarn start:local &
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: abcdefgh1!
+          OPENSEARCH_USERNAME: admin
+          OPENSEARCH_PASSWORD: admin
+          DOCUMENT_STORE_PLUGIN: "@edfi/meadowlark-postgresql-backend"
+
+      - name: End to End tests for Postgres
+        run: |
+          cp ./tests/e2e/.env.example ./tests/e2e/.env
+          yarn test:e2e --ci --config ./jest.ci-config.js
+        env:
+          JEST_JUNIT_OUTPUT_DIR: pg-e2e-tests
+
+      - name: Upload test results
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        with:
+          name: test-results
+          path: |
+            Meadowlark-js/pg-e2e-tests/junit.xml
+          retention-days: 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,8 +80,8 @@ jobs:
       matrix:
         config:
           [
-            { db: "PGSQL", plugin: "@edfi/meadowlark-postgresql-backend" },
             { db: "Mongo", plugin: "@edfi/meadowlark-mongodb-backend" },
+            { db: "PGSQL", plugin: "@edfi/meadowlark-postgresql-backend" },
           ]
 
     defaults:
@@ -110,10 +110,12 @@ jobs:
         run: docker compose -f ./backends/meadowlark-postgresql-backend/docker/docker-compose.yml up -d
 
       - if: ${{ matrix.config.db == 'Mongo' }}
-        name: Setup Mongo
-        run: |
-          chmod +x ../eng/setup-mongo.sh
-          ../eng/setup-mongo.sh
+        name: Start MongoDB
+        uses: supercharge/mongodb-github-action@538a4d2a1041920c47630172445cb688592d6e51 #v1.8.0
+        with:
+          mongodb-version: "4.0.28"
+          mongodb-replica-set: rs0
+          mongodb-port: 42069
 
       - name: Cache Build
         uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09 #v3.0.2
@@ -139,7 +141,7 @@ jobs:
           POSTGRES_PASSWORD: abcdefgh1!
           OPENSEARCH_USERNAME: admin
           OPENSEARCH_PASSWORD: admin
-          MONGO_URL: "mongodb://mongo:abcdefgh1!@mongo1:27017,mongo2:27018,mongo3:27019/?replicaSet=rs0"
+          MONGO_URL: "mongodb://127.0.0.1:42069/?replicaSet=rs0"
 
       - name: End to End tests for ${{matrix.config.db}}
         run: |

--- a/Meadowlark-js/tests/e2e/setup/e2e.env
+++ b/Meadowlark-js/tests/e2e/setup/e2e.env
@@ -1,0 +1,12 @@
+SIGNING_KEY=v/AbsYGRvIfCf1bxufA6+Ras5NR+kIroLUg5RKYMjmqvNa1fVanmPBXKFH+MD1TPHpSgna0g+6oRnmRGUme6vJ7x91OA7Lp1hWzr6NnpdLYA9BmDHWjkRFvlx9bVmP+GTave2E4RAYa5b/qlvXOVnwaqEWzHxefqzkd1F1mQ6dVNFWYdiOmgw8ofQ87Xi1W0DkToRNS/Roc4rxby/BZwHUj7Y4tYdMpkWDMrZK6Vwat1KuPyiqsaBQYa9Xd0pxKqUOrAp8a+BFwiPfxf4nyVdOSAd77A/wuKIJaERNY5xJXUHwNgEOMf+Lg4032u4PnsnH7aJb2F4z8AhHldM6w5jw==
+ACCESS_TOKEN_REQUIRED=true
+OPENSEARCH_ENDPOINT=http://localhost:9200
+QUERY_HANDLER_PLUGIN=@edfi/meadowlark-opensearch-backend
+LISTENER1_PLUGIN=@edfi/meadowlark-opensearch-backend
+AUTHORIZATION_STORE_PLUGIN=@edfi/meadowlark-mongodb-backend
+FASTIFY_RATE_LIMIT=true
+FASTIFY_PORT=3000
+MEADOWLARK_STAGE=local
+TOKEN_URL: http://localhost:3000/local/api/oauth/token
+LOG_LEVEL=INFO
+IS_LOCAL=true

--- a/eng/setup-mongo.sh
+++ b/eng/setup-mongo.sh
@@ -1,0 +1,22 @@
+cd ../Meadowlark-js/backends/meadowlark-mongodb-backend/docker/
+
+chmod -R +x ./scripts
+docker run -d --name mongo-temp -v mongo-auth:/auth mongo:4.0.28
+docker exec mongo-temp mkdir /scripts
+docker cp ./scripts/mongo-key-file-setup.sh mongo-temp:/scripts/mongo-key-file-setup.sh
+docker exec mongo-temp ./scripts/mongo-key-file-setup.sh
+docker compose up -d
+
+echo "Adding URL to hosts"
+echo '127.0.0.1 mongo1 mongo2 mongo3' | sudo tee -a /etc/hosts
+
+# Wait for environment
+sleep 30;
+
+echo "Setting replica set"
+docker exec mongo1 ./scripts/mongo-rs-setup.sh
+
+# Wait for environment
+sleep 30;
+
+docker exec -e ADMIN_USERNAME=mongo -e ADMIN_PASSWORD=abcdefgh1! mongo1 ./scripts/mongo-user-setup.sh


### PR DESCRIPTION
- Adding end to end tests running Fastify and Postgres Backend
- Separating testing process into two jobs
- Adding MongoDB Action to run Mongo Tests
- Including new files to reporter.

Must be approved after https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-Actions/pull/32 is merged.