### PR TITLE
[RND-461] CI Performance Improvements

### DIFF
--- a/.github/workflows/after-pullrequest.yml
+++ b/.github/workflows/after-pullrequest.yml
@@ -19,12 +19,12 @@ jobs:
       matrix:
         tests:
           [
-            { name: "Unit Test Report", file: "unit-tests/junit.xml" },
+            { name: "Unit Test Report", file: "Unit-tests/junit.xml" },
             {
               name: "Integration Test Report",
-              file: "integration-tests/junit.xml",
+              file: "Integration-tests/junit.xml",
             },
-            { name: "System Test Report", file: "system-tests/junit.xml" },
+            { name: "System Test Report", file: "System-tests/junit.xml" },
             {
               name: "Mongo End To End Tests",
               file: "Mongo-e2e-tests/junit.xml",

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -111,8 +111,8 @@ jobs:
       - name: Linter
         run: yarn test:lint
 
-  test:
-    name: Unit, Integration and System Tests
+  unit-test:
+    name: Unit Tests
     needs: lint
     runs-on: ubuntu-latest
 
@@ -150,6 +150,42 @@ jobs:
           path: Meadowlark-js/coverage/lcov-report
           retention-days: 10
 
+      - name: Upload test results
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+        with:
+          name: test-results
+          path: |
+            Meadowlark-js/unit-tests/junit.xml
+            Meadowlark-js/.prettierrc
+          retention-days: 1
+
+  integration-test:
+    name: Integration Tests
+    needs: lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+
+      - name: Setup Node
+        uses: actions/setup-node@17f8bd926464a1afa4c6a11669539e9c1ba77048 # v3.2.0
+        with:
+          node-version: "16"
+          cache: "yarn"
+          cache-dependency-path: "**/yarn.lock"
+
+      - name: Node modules cache
+        id: modules-cache
+        uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09 #v3.0.2
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install dependencies
+        if: ${{ steps.modules-cache.outputs.cache-hit != 'true' }}
+        run: yarn install
+
       - name: Configure postgres
         run: |
           sudo systemctl start postgresql.service
@@ -159,6 +195,47 @@ jobs:
         run: yarn test:integration --ci --config ./jest.ci-config.js
         env:
           JEST_JUNIT_OUTPUT_DIR: integration-tests
+
+      - name: Upload test results
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
+        with:
+          name: test-results
+          path: |
+            Meadowlark-js/integration-tests/junit.xml
+            Meadowlark-js/.prettierrc
+          retention-days: 1
+
+  system-test:
+    name: System Tests
+    needs: lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+
+      - name: Setup Node
+        uses: actions/setup-node@17f8bd926464a1afa4c6a11669539e9c1ba77048 # v3.2.0
+        with:
+          node-version: "16"
+          cache: "yarn"
+          cache-dependency-path: "**/yarn.lock"
+
+      - name: Node modules cache
+        id: modules-cache
+        uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09 #v3.0.2
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install dependencies
+        if: ${{ steps.modules-cache.outputs.cache-hit != 'true' }}
+        run: yarn install
+
+      - name: Configure postgres
+        run: |
+          sudo systemctl start postgresql.service
+          sudo -u postgres psql -U postgres -c "alter user postgres with password '${{env.POSTGRES_PASSWORD}}';"
 
       - name: System tests
         run: yarn test:system --ci --config ./jest.ci-config.js
@@ -170,9 +247,8 @@ jobs:
         with:
           name: test-results
           path: |
-            Meadowlark-js/integration-tests/junit.xml
             Meadowlark-js/system-tests/junit.xml
-            Meadowlark-js/unit-tests/junit.xml
+            Meadowlark-js/.prettierrc
           retention-days: 1
 
   end-to-end:

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -182,6 +182,13 @@ jobs:
           cache: "yarn"
           cache-dependency-path: "**/yarn.lock"
 
+      - name: Load MongoDB binary cache
+        id: cache-mongodb-binaries
+        uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09 #v3.0.2
+        with:
+          path: ~/.cache/mongodb-binaries
+          key: ${{ runner.os }}-mongo-${{ hashFiles('**/yarn.lock') }}
+
       - name: Node modules cache
         id: modules-cache
         uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09 #v3.0.2
@@ -244,6 +251,13 @@ jobs:
           node-version: "16"
           cache: "yarn"
           cache-dependency-path: "**/yarn.lock"
+
+      - name: Load MongoDB binary cache
+        id: cache-mongodb-binaries
+        uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09 #v3.0.2
+        with:
+          path: ~/.cache/mongodb-binaries
+          key: ${{ runner.os }}-mongo-${{ hashFiles('**/yarn.lock') }}
 
       - name: Node modules cache
         id: modules-cache

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -111,6 +111,43 @@ jobs:
       - name: Linter
         run: yarn test:lint
 
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+
+      - name: Setup Node
+        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
+        with:
+          node-version: "16"
+          cache: "yarn"
+          cache-dependency-path: "**/yarn.lock"
+
+      - name: Node modules cache
+        id: modules-cache
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 #v3.0.11
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install dependencies
+        if: ${{ steps.modules-cache.outputs.cache-hit != 'true' }}
+        run: yarn install
+
+      - name: Build Cache
+        id: build-cache
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 #v3.0.11
+        with:
+          path: "**/dist/**"
+          key: ${{ runner.os }}-build-${{ hashFiles('**/dist/**') }}
+
+      - name: Build
+        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
+        run: yarn build
+
   unit-test:
     name: Unit Tests
     needs: lint
@@ -166,10 +203,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
 
       - name: Setup Node
-        uses: actions/setup-node@17f8bd926464a1afa4c6a11669539e9c1ba77048 # v3.2.0
+        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
         with:
           node-version: "16"
           cache: "yarn"
@@ -177,7 +214,7 @@ jobs:
 
       - name: Node modules cache
         id: modules-cache
-        uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09 #v3.0.2
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 #v3.0.11
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -212,10 +249,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
 
       - name: Setup Node
-        uses: actions/setup-node@17f8bd926464a1afa4c6a11669539e9c1ba77048 # v3.2.0
+        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
         with:
           node-version: "16"
           cache: "yarn"
@@ -223,7 +260,7 @@ jobs:
 
       - name: Node modules cache
         id: modules-cache
-        uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09 #v3.0.2
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 #v3.0.11
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -253,7 +290,7 @@ jobs:
 
   end-to-end:
     name: End to End tests for ${{ matrix.config.db }}
-    needs: lint
+    needs: [lint, build]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -286,19 +323,15 @@ jobs:
         if: ${{ steps.modules-cache.outputs.cache-hit != 'true' }}
         run: yarn install
 
-      # This caching is breaking Lerna 6. Look into in more detail to see if we can fix.
-      # - name: Cache Build
-      #   uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 #v3.0.11
-      #   env:
-      #     cache-name: cache-build
-      #   with:
-      #     path: "**/dist/**"
-      #     key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/dist/**') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-build-${{ env.cache-name }}-
+      - name: Build Cache
+        id: build-cache
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 #v3.0.11
+        with:
+          path: "**/dist/**"
+          key: ${{ runner.os }}-build-${{ hashFiles('**/dist/**') }}
 
       - name: Build
-        # if: ${{ steps.cache-build.outputs.cache-hit != 'true' }}
+        if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
         run: yarn build
 
       - name: End to End tests for ${{matrix.config.db}}

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -148,17 +148,35 @@ jobs:
         if: ${{ steps.build-cache.outputs.cache-hit != 'true' }}
         run: yarn build
 
-  unit-test:
-    name: Unit Tests
+  tests:
+    name: ${{matrix.tests.type}} tests
     needs: lint
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tests:
+          [
+            {
+              type: "Unit",
+              command: "yarn test:unit:coverage --ci --config ./jest.ci-config.js",
+            },
+            {
+              type: "Integration",
+              command: "yarn test:integration --ci --config ./jest.ci-config.js",
+            },
+            {
+              type: "System",
+              command: "yarn test:system --ci --config ./jest.ci-config.js",
+            },
+          ]
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
+        uses: actions/setup-node@17f8bd926464a1afa4c6a11669539e9c1ba77048 # v3.2.0
         with:
           node-version: "16"
           cache: "yarn"
@@ -166,7 +184,7 @@ jobs:
 
       - name: Node modules cache
         id: modules-cache
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 #v3.0.11
+        uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09 #v3.0.2
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -175,12 +193,19 @@ jobs:
         if: ${{ steps.modules-cache.outputs.cache-hit != 'true' }}
         run: yarn install
 
-      - name: Unit tests with code coverage
-        run: yarn test:unit:coverage --ci --config ./jest.ci-config.js
+      - name: Configure postgres
+        if: ${{ matrix.tests.type != 'Unit' }}
+        run: |
+          sudo systemctl start postgresql.service
+          sudo -u postgres psql -U postgres -c "alter user postgres with password '${{env.POSTGRES_PASSWORD}}';"
+
+      - name: Run ${{matrix.tests.type}} Tests
+        run: ${{matrix.tests.command}}
         env:
-          JEST_JUNIT_OUTPUT_DIR: unit-tests
+          JEST_JUNIT_OUTPUT_DIR: ${{matrix.tests.type}}-tests
 
       - name: Archive coverage results
+        if: ${{ matrix.tests.type == 'Unit' }}
         uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
         with:
           name: code-coverage-report
@@ -192,99 +217,7 @@ jobs:
         with:
           name: test-results
           path: |
-            Meadowlark-js/unit-tests/junit.xml
-            Meadowlark-js/.prettierrc
-          retention-days: 1
-
-  integration-test:
-    name: Integration Tests
-    needs: lint
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
-
-      - name: Setup Node
-        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
-        with:
-          node-version: "16"
-          cache: "yarn"
-          cache-dependency-path: "**/yarn.lock"
-
-      - name: Node modules cache
-        id: modules-cache
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 #v3.0.11
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-
-      - name: Install dependencies
-        if: ${{ steps.modules-cache.outputs.cache-hit != 'true' }}
-        run: yarn install
-
-      - name: Configure postgres
-        run: |
-          sudo systemctl start postgresql.service
-          sudo -u postgres psql -U postgres -c "alter user postgres with password '${{env.POSTGRES_PASSWORD}}';"
-
-      - name: Integration tests
-        run: yarn test:integration --ci --config ./jest.ci-config.js
-        env:
-          JEST_JUNIT_OUTPUT_DIR: integration-tests
-
-      - name: Upload test results
-        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
-        with:
-          name: test-results
-          path: |
-            Meadowlark-js/integration-tests/junit.xml
-            Meadowlark-js/.prettierrc
-          retention-days: 1
-
-  system-test:
-    name: System Tests
-    needs: lint
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
-
-      - name: Setup Node
-        uses: actions/setup-node@8c91899e586c5b171469028077307d293428b516 # v3.5.1
-        with:
-          node-version: "16"
-          cache: "yarn"
-          cache-dependency-path: "**/yarn.lock"
-
-      - name: Node modules cache
-        id: modules-cache
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 #v3.0.11
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-
-      - name: Install dependencies
-        if: ${{ steps.modules-cache.outputs.cache-hit != 'true' }}
-        run: yarn install
-
-      - name: Configure postgres
-        run: |
-          sudo systemctl start postgresql.service
-          sudo -u postgres psql -U postgres -c "alter user postgres with password '${{env.POSTGRES_PASSWORD}}';"
-
-      - name: System tests
-        run: yarn test:system --ci --config ./jest.ci-config.js
-        env:
-          JEST_JUNIT_OUTPUT_DIR: system-tests
-
-      - name: Upload test results
-        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # v3.1.1
-        with:
-          name: test-results
-          path: |
-            Meadowlark-js/system-tests/junit.xml
+            Meadowlark-js/${{matrix.tests.type}}-tests/junit.xml
             Meadowlark-js/.prettierrc
           retention-days: 1
 

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SystemTestHelper.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SystemTestHelper.ts
@@ -6,18 +6,21 @@
 import { PoolClient } from 'pg';
 import { getSharedClient, resetSharedClient } from './Db';
 
+async function clearTables(client: PoolClient): Promise<void> {
+  const dbName = process.env.MEADOWLARK_DATABASE_NAME;
+  await client.query(`TRUNCATE TABLE ${dbName}.documents`);
+  await client.query(`TRUNCATE TABLE ${dbName}.references`);
+  await client.query(`TRUNCATE TABLE ${dbName}.aliases`);
+}
+
 export async function systemTestSetup(): Promise<PoolClient> {
   const client = (await getSharedClient()) as PoolClient;
-  await client.query('TRUNCATE TABLE meadowlark.documents');
-  await client.query('TRUNCATE TABLE meadowlark.references');
-  await client.query('TRUNCATE TABLE meadowlark.aliases');
+  await clearTables(client);
   return client;
 }
 
 export async function systemTestTeardown(client: PoolClient): Promise<void> {
-  await client.query('TRUNCATE TABLE meadowlark.documents');
-  await client.query('TRUNCATE TABLE meadowlark.references');
-  await client.query('TRUNCATE TABLE meadowlark.aliases');
+  await clearTables(client);
   client.release();
   await resetSharedClient();
 }

--- a/Meadowlark-js/tests/system/crud/SystemTestSetup.ts
+++ b/Meadowlark-js/tests/system/crud/SystemTestSetup.ts
@@ -16,7 +16,7 @@ import { Logger } from '@edfi/meadowlark-utilities';
 const TEST_SIGNING_KEY =
   'zE1mgVCZ01pO5gEioEp/ShcdVMcYjvGMMyE37Tu513WzSgDr4gtMKAFSWrprwXa825Eeu7xj2Ok35KFChE+6oyDF0PuVQdf9YaE9iTTs/nLXDbOJspDvQswYZ7Iq5Mx6lIcixgLbWcK/OckOin608ivPa5aLkJOJXDdl2cgwgf1E9rHWuRs0iYNWoMbqGN2iFH5af3wOF/RusrWJDLLJ9riWeIINeZwzE9cLq75hLBHLpQlcz9enU1zC49B93OTPWPwCqZIBaSqvbsgSULYANoU0JZa+NB5BsgrmlQgldfEPLQj73z09a7yqLAwlJJRYXuJQo6onYQ7RVVHD4PD2Sg==';
 process.env.OAUTH_SIGNING_KEY = TEST_SIGNING_KEY;
-process.env.MEADOWLARK_DATABASE_NAME = 'meadowlark_system_tests';
+process.env.MEADOWLARK_DATABASE_NAME = 'meadowlark';
 
 if (process.env.DOCUMENT_STORE_PLUGIN == null) process.env.DOCUMENT_STORE_PLUGIN = '@edfi/meadowlark-mongodb-backend';
 if (process.env.AUTHORIZATION_STORE_PLUGIN == null) process.env.AUTHORIZATION_STORE_PLUGIN = '@edfi/meadowlark-authz-server';


### PR DESCRIPTION
- Create build step as previous step to e2e to have packages ready for execution.
- Convert unit, integration and system tests into a matrix since behavior is similar for all.
- Save MongoDB in cache to run tests.
- Fix error when running system tests isolated given that it was depending on integration tests setup