### PR TITLE
[RND-386] Increase test coverage for meadowlark-core folder

### DIFF
--- a/Meadowlark-js/packages/meadowlark-core/src/handler/DescriptorLoader.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/handler/DescriptorLoader.ts
@@ -5,6 +5,7 @@
 
 /* eslint-disable no-continue */
 /* eslint-disable no-restricted-syntax */
+/* istanbul ignore file */
 import fs from 'fs';
 import path from 'path';
 import xml2js from 'xml2js';

--- a/Meadowlark-js/packages/meadowlark-core/src/handler/FrontendRequest.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/handler/FrontendRequest.ts
@@ -125,7 +125,7 @@ const removeDocumentIdentity: (f: FrontendRequest) => FrontendRequest = R.dissoc
 /**
  * Returns a copy of a FrontendRequest with the sensitive data 'documentIdentity' field in the document references removed
  */
-const removeReferencesDocumentIdentity: (f: FrontendRequest) => FrontendRequest = (f: FrontendRequest) => {
+export const removeReferencesDocumentIdentity: (f: FrontendRequest) => FrontendRequest = (f: FrontendRequest) => {
   const cloneOfFrontendRequest: FrontendRequest = R.clone(f);
   const { documentReferences } = cloneOfFrontendRequest.middleware.documentInfo;
   cloneOfFrontendRequest.middleware.documentInfo.documentReferences = documentReferences.map((reference) =>

--- a/Meadowlark-js/packages/meadowlark-core/test/extraction/DocumentInfoExtractor.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/extraction/DocumentInfoExtractor.test.ts
@@ -2,12 +2,11 @@
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
-import { newEntityProperty, newTopLevelEntity, TopLevelEntity } from '@edfi/metaed-core';
+import { DocumentIdentity, newEntityProperty, newTopLevelEntity, TopLevelEntity } from '@edfi/metaed-core';
 import { ResourceInfo, newResourceInfo } from '../../src/model/ResourceInfo';
 import { DocumentInfo } from '../../src/model/DocumentInfo';
 import { DescriptorDocument } from '../../src/model/DescriptorDocument';
 import { extractDocumentInfo } from '../../src/extraction/DocumentInfoExtractor';
-import { DocumentIdentity } from '../../dist';
 
 const testModel = (): TopLevelEntity => ({
   ...newTopLevelEntity(),

--- a/Meadowlark-js/packages/meadowlark-core/test/extraction/DocumentInfoExtractor.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/extraction/DocumentInfoExtractor.test.ts
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+import { newEntityProperty, newTopLevelEntity, TopLevelEntity } from '@edfi/metaed-core';
+import { ResourceInfo, newResourceInfo } from '../../src/model/ResourceInfo';
+import { DocumentInfo } from '../../src/model/DocumentInfo';
+import { DescriptorDocument } from '../../src/model/DescriptorDocument';
+import { extractDocumentInfo } from '../../src/extraction/DocumentInfoExtractor';
+import { DocumentIdentity } from '../../dist';
+/*
+import { extractDocumentReferences } from './DocumentReferenceExtractor';
+import { extractDocumentIdentity, deriveSuperclassInfoFrom } from './DocumentIdentityExtractor';
+
+import { extractDescriptorValues } from './DescriptorValueExtractor';
+import { SuperclassInfo } from '../model/SuperclassInfo';
+import { DocumentIdentity } from '../model/DocumentIdentity';
+*/
+/* const resourceInfo: ResourceInfo = {
+  ...newResourceInfo(),
+};
+const documentInfo: DocumentInfo = {
+  ...newDocumentInfo(),
+}; */
+
+const testModel = (): TopLevelEntity => ({
+  ...newTopLevelEntity(),
+  metaEdName: 'Student',
+  properties: [
+    { ...newEntityProperty(), metaEdName: 'uniqueId', isPartOfIdentity: true },
+    { ...newEntityProperty(), metaEdName: 'someBooleanParameter', isPartOfIdentity: false },
+    { ...newEntityProperty(), metaEdName: 'someIntegerParameter', isPartOfIdentity: false },
+    { ...newEntityProperty(), metaEdName: 'someDecimalParameter', isPartOfIdentity: false },
+  ],
+  data: {
+    meadowlark: {
+      apiMapping: {
+        identityReferenceComponents: [],
+        referenceGroups: [],
+        descriptorCollectedProperties: [],
+      },
+      jsonSchema: {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        additionalProperties: false,
+        description: 'doc',
+        properties: {
+          uniqueId: {
+            description: 'doc',
+            maxLength: 30,
+            type: 'string',
+          },
+          someBooleanParameter: {
+            description: 'doc',
+            type: 'boolean',
+          },
+          someIntegerParameter: {
+            description: 'doc',
+            type: 'integer',
+          },
+          someDecimalParameter: {
+            description: 'doc',
+            type: 'number',
+          },
+        },
+        required: ['uniqueId'],
+        title: 'EdFi.Student',
+        type: 'object',
+      },
+    },
+  },
+});
+
+const testSchoolModel = (): TopLevelEntity => ({
+  ...newTopLevelEntity(),
+  metaEdName: 'Student',
+  properties: [
+    { ...newEntityProperty(), metaEdName: 'uniqueId', isPartOfIdentity: true },
+    { ...newEntityProperty(), metaEdName: 'someBooleanParameter', isPartOfIdentity: false },
+    { ...newEntityProperty(), metaEdName: 'someIntegerParameter', isPartOfIdentity: false },
+    { ...newEntityProperty(), metaEdName: 'someDecimalParameter', isPartOfIdentity: false },
+  ],
+  data: {
+    meadowlark: {
+      apiMapping: {
+        identityReferenceComponents: [],
+        referenceGroups: [],
+        descriptorCollectedProperties: [],
+        superclass: {
+          metaEdName: 'School',
+          documentIdentity: { schoolYear: '2023' },
+          namespace: {
+            projectName: 'Testing',
+          },
+          resourceName: 'School',
+        },
+      },
+      jsonSchema: {
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        additionalProperties: false,
+        description: 'doc',
+        properties: {
+          uniqueId: {
+            description: 'doc',
+            maxLength: 30,
+            type: 'string',
+          },
+          someBooleanParameter: {
+            description: 'doc',
+            type: 'boolean',
+          },
+          someIntegerParameter: {
+            description: 'doc',
+            type: 'integer',
+          },
+          someDecimalParameter: {
+            description: 'doc',
+            type: 'number',
+          },
+        },
+        required: ['uniqueId'],
+        title: 'EdFi.Student',
+        type: 'object',
+      },
+    },
+  },
+});
+
+describe('given IsDescriptor equal true', () => {
+  const body: DocumentIdentity = { schoolYear: '2023' };
+  const matchingMetaEdModel: TopLevelEntity = {
+    ...testModel(),
+  };
+  let queryResult: DocumentInfo;
+  const resourceInfoRequest: ResourceInfo = {
+    ...newResourceInfo(),
+    isDescriptor: true,
+  };
+  beforeAll(async () => {
+    queryResult = await extractDocumentInfo(resourceInfoRequest, body, matchingMetaEdModel);
+  });
+  it('should return documentInfo.', async () => {
+    // Assert
+    expect(queryResult).toEqual({
+      descriptorReferences: [],
+      documentIdentity: {},
+      documentReferences: [],
+      superclassInfo: null,
+    });
+  });
+});
+
+describe('given isDescriptor False', () => {
+  const body: DescriptorDocument = {
+    namespace: 'namespace',
+    codeValue: 'codeValue',
+    shortDescription: 'shortDescription',
+  };
+  const matchingMetaEdModel: TopLevelEntity = {
+    ...testModel(),
+  };
+  let queryResult: DocumentInfo;
+  const resourceInfoRequest: ResourceInfo = {
+    ...newResourceInfo(),
+    isDescriptor: false,
+  };
+  beforeAll(async () => {
+    queryResult = await extractDocumentInfo(resourceInfoRequest, body, matchingMetaEdModel);
+  });
+  it('should return superclass null.', async () => {
+    // Assert
+    expect(queryResult).toEqual({
+      descriptorReferences: [],
+      documentIdentity: {},
+      documentReferences: [],
+      superclassInfo: null,
+    });
+  });
+});
+
+describe('given isDescriptor False', () => {
+  const body: DescriptorDocument = {
+    namespace: 'namespace',
+    codeValue: 'codeValue',
+    shortDescription: 'shortDescription',
+  };
+  const matchingMetaEdModel: TopLevelEntity = {
+    ...testSchoolModel(),
+  };
+  let queryResult: DocumentInfo;
+  const resourceInfoRequest: ResourceInfo = {
+    ...newResourceInfo(),
+    isDescriptor: false,
+  };
+  beforeAll(async () => {
+    queryResult = await extractDocumentInfo(resourceInfoRequest, body, matchingMetaEdModel);
+  });
+  it('should return superclass.', async () => {
+    // Assert
+    expect(queryResult).toEqual({
+      descriptorReferences: [],
+      documentIdentity: {},
+      documentReferences: [],
+      superclassInfo: {
+        documentIdentity: {},
+        projectName: 'Testing',
+        resourceName: 'School',
+      },
+    });
+  });
+});

--- a/Meadowlark-js/packages/meadowlark-core/test/extraction/DocumentInfoExtractor.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/extraction/DocumentInfoExtractor.test.ts
@@ -8,20 +8,6 @@ import { DocumentInfo } from '../../src/model/DocumentInfo';
 import { DescriptorDocument } from '../../src/model/DescriptorDocument';
 import { extractDocumentInfo } from '../../src/extraction/DocumentInfoExtractor';
 import { DocumentIdentity } from '../../dist';
-/*
-import { extractDocumentReferences } from './DocumentReferenceExtractor';
-import { extractDocumentIdentity, deriveSuperclassInfoFrom } from './DocumentIdentityExtractor';
-
-import { extractDescriptorValues } from './DescriptorValueExtractor';
-import { SuperclassInfo } from '../model/SuperclassInfo';
-import { DocumentIdentity } from '../model/DocumentIdentity';
-*/
-/* const resourceInfo: ResourceInfo = {
-  ...newResourceInfo(),
-};
-const documentInfo: DocumentInfo = {
-  ...newDocumentInfo(),
-}; */
 
 const testModel = (): TopLevelEntity => ({
   ...newTopLevelEntity(),

--- a/Meadowlark-js/packages/meadowlark-core/test/extraction/DocumentInfoExtractor.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/extraction/DocumentInfoExtractor.test.ts
@@ -2,11 +2,12 @@
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
-import { DocumentIdentity, newEntityProperty, newTopLevelEntity, TopLevelEntity } from '@edfi/metaed-core';
+import { newEntityProperty, newTopLevelEntity, TopLevelEntity } from '@edfi/metaed-core';
 import { ResourceInfo, newResourceInfo } from '../../src/model/ResourceInfo';
 import { DocumentInfo } from '../../src/model/DocumentInfo';
 import { DescriptorDocument } from '../../src/model/DescriptorDocument';
 import { extractDocumentInfo } from '../../src/extraction/DocumentInfoExtractor';
+import { DocumentIdentity } from '../../src/model/DocumentIdentity';
 
 const testModel = (): TopLevelEntity => ({
   ...newTopLevelEntity(),

--- a/Meadowlark-js/packages/meadowlark-core/test/handler/FrontendRequest.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/handler/FrontendRequest.test.ts
@@ -43,7 +43,11 @@ const frontendRequest: FrontendRequest = {
 
 describe('given a document with document references', () => {
   const request: FrontendRequest = frontendRequest;
-  const queryResult = removeReferencesDocumentIdentity(request);
+  let queryResult: FrontendRequest;
+  beforeAll(() => {
+    // Act
+    queryResult = removeReferencesDocumentIdentity(request);
+  });
   it('should remove documentIdentity from documentReferences', async () => {
     // Assert
     expect(queryResult.middleware.documentInfo.documentReferences[0].documentIdentity).toEqual(undefined);

--- a/Meadowlark-js/packages/meadowlark-core/test/handler/FrontendRequest.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/handler/FrontendRequest.test.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+import {
+  FrontendRequest,
+  newFrontendRequest,
+  newFrontendRequestMiddleware,
+  removeReferencesDocumentIdentity,
+} from '../../src/handler/FrontendRequest';
+
+const frontendRequest: FrontendRequest = {
+  ...newFrontendRequest(),
+  middleware: {
+    ...newFrontendRequestMiddleware(),
+    documentInfo: {
+      documentIdentity: { rootIdentity: 'keyRoot' },
+      documentReferences: [
+        {
+          documentIdentity: { documentReference: 'keySensitiveToBeRemoved' },
+          isDescriptor: false,
+          projectName: 'projectName',
+          resourceName: 'resourceName',
+        },
+      ],
+      descriptorReferences: [
+        {
+          documentIdentity: { descriptorReference: 'keyDescriptor' },
+          isDescriptor: true,
+          projectName: 'projectName',
+          resourceName: 'resourceName2',
+        },
+      ],
+      superclassInfo: {
+        documentIdentity: { superclassInfo: 'keySuperclassInfo' },
+        projectName: 'Test',
+        resourceName: 'resource',
+      },
+    },
+  },
+};
+
+describe('given a document with document references', () => {
+  const request: FrontendRequest = frontendRequest;
+  const queryResult = removeReferencesDocumentIdentity(request);
+  it('should remove documentIdentity from documentReferences', async () => {
+    // Assert
+    expect(queryResult.middleware.documentInfo.documentReferences[0].documentIdentity).toEqual(undefined);
+  });
+});

--- a/Meadowlark-js/packages/meadowlark-core/test/plugin/NoDocumentStorePlugin.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/plugin/NoDocumentStorePlugin.test.ts
@@ -3,20 +3,18 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-import {
-  NoDocumentInfo,
-  newSecurity,
-  DeleteRequest,
-  DeleteResult,
-  UpdateRequest,
-  UpdateResult,
-  UpsertRequest,
-  UpsertResult,
-  NoResourceInfo,
-} from '@edfi/meadowlark-core';
 import { NoDocumentStorePlugin } from '../../src/plugin/backend/NoDocumentStorePlugin';
 import { GetRequest } from '../../src/message/GetRequest';
 import { GetResult } from '../../src/message/GetResult';
+import { UpsertRequest } from '../../src/message/UpsertRequest';
+import { NoResourceInfo } from '../../src/model/ResourceInfo';
+import { NoDocumentInfo } from '../../src/model/DocumentInfo';
+import { newSecurity } from '../../src/security/Security';
+import { UpdateRequest } from '../../src/message/UpdateRequest';
+import { DeleteRequest } from '../../src/message/DeleteRequest';
+import { UpsertResult } from '../../src/message/UpsertResult';
+import { UpdateResult } from '../../src/message/UpdateResult';
+import { DeleteResult } from '../../src/message/DeleteResult';
 
 const newUpsertRequest = (): UpsertRequest => ({
   id: '',

--- a/Meadowlark-js/packages/meadowlark-core/test/plugin/NoDocumentStorePlugin.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/plugin/NoDocumentStorePlugin.test.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+import {
+  NoDocumentInfo,
+  newSecurity,
+  DeleteRequest,
+  DeleteResult,
+  UpdateRequest,
+  UpdateResult,
+  UpsertRequest,
+  UpsertResult,
+  NoResourceInfo,
+} from '@edfi/meadowlark-core';
+import { NoDocumentStorePlugin } from '../../src/plugin/backend/NoDocumentStorePlugin';
+import { GetRequest } from '../../src/message/GetRequest';
+import { GetResult } from '../../src/message/GetResult';
+
+const newUpsertRequest = (): UpsertRequest => ({
+  id: '',
+  resourceInfo: NoResourceInfo,
+  documentInfo: NoDocumentInfo,
+  edfiDoc: {},
+  validate: false,
+  security: { ...newSecurity() },
+  traceId: 'traceId',
+});
+
+const newGetRequest = (): GetRequest => ({
+  id: '',
+  resourceInfo: NoResourceInfo,
+  security: { ...newSecurity() },
+  traceId: 'traceId',
+});
+
+const newUpdateRequest = (): UpdateRequest => ({
+  id: '',
+  resourceInfo: NoResourceInfo,
+  documentInfo: NoDocumentInfo,
+  edfiDoc: {},
+  validate: false,
+  security: { ...newSecurity() },
+  traceId: 'traceId',
+});
+
+const newDeleteRequest = (): DeleteRequest => ({
+  id: '',
+  resourceInfo: NoResourceInfo,
+  validate: false,
+  security: { ...newSecurity() },
+  traceId: 'traceId',
+});
+
+describe('given upsert and no backend plugin has been configured', () => {
+  let result: UpsertResult;
+
+  beforeAll(async () => {
+    const request = newUpsertRequest();
+
+    result = await NoDocumentStorePlugin.upsertDocument(request);
+  });
+  it('should return failure', async () => {
+    // Assert
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "response": "UNKNOWN_FAILURE",
+      }
+    `);
+  });
+});
+
+describe('given getDocumentById and no backend plugin has been configured', () => {
+  let result: GetResult;
+
+  beforeAll(async () => {
+    const request = newGetRequest();
+
+    result = await NoDocumentStorePlugin.getDocumentById(request);
+  });
+  it('should return failure', async () => {
+    // Assert
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "document": {},
+        "response": "UNKNOWN_FAILURE",
+      }
+    `);
+  });
+});
+
+describe('given updateDocumentById and no backend plugin has been configured', () => {
+  let result: UpdateResult;
+
+  beforeAll(async () => {
+    const request = newUpdateRequest();
+
+    result = await NoDocumentStorePlugin.updateDocumentById(request);
+  });
+  it('should return failure', async () => {
+    // Assert
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "response": "UNKNOWN_FAILURE",
+      }
+    `);
+  });
+});
+
+describe('given deleteDocumentById and no backend plugin has been configured', () => {
+  let result: DeleteResult;
+
+  beforeAll(async () => {
+    const request = newDeleteRequest();
+
+    result = await NoDocumentStorePlugin.deleteDocumentById(request);
+  });
+  it('should return failure', async () => {
+    // Assert
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "failureMessage": "",
+        "response": "UNKNOWN_FAILURE",
+      }
+    `);
+  });
+});

--- a/Meadowlark-js/packages/meadowlark-core/test/plugin/NoQueryHandlerPlugin.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/plugin/NoQueryHandlerPlugin.test.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+import { NoQueryHandlerPlugin } from '../../src/plugin/backend/NoQueryHandlerPlugin';
+import { newResourceInfo } from '../../src/model/ResourceInfo';
+import { AuthorizationStrategy } from '../../src/security/AuthorizationStrategy';
+import { PaginationParameters } from '../../src/message/PaginationParameters';
+import { QueryRequest } from '../../src/message/QueryRequest';
+import { QueryResult } from '../../src/message/QueryResult';
+
+const setupQueryRequest = (
+  authorizationStrategy: AuthorizationStrategy,
+  queryParameters: any,
+  paginationParameters: PaginationParameters,
+  clientId = '',
+): QueryRequest => ({
+  resourceInfo: newResourceInfo(),
+  queryParameters,
+  paginationParameters,
+  security: { authorizationStrategy, clientId },
+  traceId: 'tracer',
+});
+
+describe('given query and no backend plugin has been configured', () => {
+  const authorizationStrategy: AuthorizationStrategy = { type: 'UNDEFINED' };
+  let queryResult: QueryResult;
+
+  beforeAll(async () => {
+    const request = setupQueryRequest(authorizationStrategy, {}, {});
+
+    queryResult = await NoQueryHandlerPlugin.queryDocuments(request);
+  });
+  it('should return failure', async () => {
+    // Assert
+    expect(queryResult).toMatchInlineSnapshot(`
+      {
+        "documents": [],
+        "response": "UNKNOWN_FAILURE",
+      }
+    `);
+  });
+});


### PR DESCRIPTION
- Add tests cases for Plugin\NoQueryHandlerPlugin and Plugin\NoDocumentStorePlugin
![image](https://user-images.githubusercontent.com/56046999/214211798-f68b6938-1793-4fa1-ad98-99d5dee8876e.png)

- Add comment to ignore DescriptorLoader.ts
- Update handler\FrontendRequest.ts. to export removeReferencesDocumentIdentity.
- Add unit test for Handler\FrontendRequest.ts.test
![image](https://user-images.githubusercontent.com/56046999/214211910-5ec5410d-4ffb-4b4d-9dd9-0c6253c9bdce.png)

- Add unit test for extraction\DocumentInfoExtractor.ts.test

![image](https://user-images.githubusercontent.com/56046999/214211847-791777bd-2e91-4358-a11f-b353f630d9a5.png)
