### PR TITLE
[RND-475] Update documentation to only support NodeJS v16

### DIFF
--- a/docs/LOCALHOST.md
+++ b/docs/LOCALHOST.md
@@ -2,7 +2,7 @@
 
 Instructions for running a local "developer" environment on localhost:
 
-1. Install [Node.js 16.x or higher](https://nodejs.org/en/download/releases/)
+1. Install [Node.js 16.x](https://nodejs.org/en/download/releases/)
 2. Install [Docker Desktop](https://www.docker.com)
 3. Review the [Docker Guidance for Meadowlark](../Meadowlark-js/docker/using-docker.md)
    to startup relevant backend services.


### PR DESCRIPTION
Remove the "or higher" mention on the NodeJS version to only support v16