### PR TITLE
[RND-459] Invalid DateTime String in Winston Configuration

### DIFF
--- a/Meadowlark-js/package-lock.json
+++ b/Meadowlark-js/package-lock.json
@@ -2010,10 +2010,6 @@
       "resolved": "backends/meadowlark-postgresql-backend",
       "link": true
     },
-    "node_modules/@edfi/meadowlark-system-tests": {
-      "resolved": "tests/system",
-      "link": true
-    },
     "node_modules/@edfi/meadowlark-utilities": {
       "resolved": "packages/meadowlark-utilities",
       "link": true
@@ -20438,6 +20434,7 @@
     "tests/system": {
       "name": "@edfi/meadowlark-system-tests",
       "version": "0.2.0-dev.0",
+      "extraneous": true,
       "license": "Apache-2.0",
       "devDependencies": {
         "@edfi/meadowlark-core": "0.2.0-dev.0",
@@ -22063,19 +22060,12 @@
         "@types/pg": "^8.6.5",
         "@types/pg-format": "^1.0.2",
         "copyfiles": "^2.4.1",
-        "dotenv": "*",
+        "dotenv": "^16.0.3",
         "pg": "^8.8.0",
         "pg-format": "^1.0.4",
         "ramda": "0.27.2",
         "rimraf": "^3.0.2",
         "ts-invariant": "^0.10.3"
-      }
-    },
-    "@edfi/meadowlark-system-tests": {
-      "version": "file:tests/system",
-      "requires": {
-        "@edfi/meadowlark-core": "0.2.0-dev.0",
-        "@edfi/meadowlark-utilities": "0.2.0-dev.0"
       }
     },
     "@edfi/meadowlark-utilities": {

--- a/Meadowlark-js/packages/meadowlark-utilities/src/Logger.ts
+++ b/Meadowlark-js/packages/meadowlark-utilities/src/Logger.ts
@@ -6,7 +6,7 @@
 import winston from 'winston';
 import * as Config from './Config';
 
-const timestampFormat: string = 'YYYY-MM-DD HH:mm:SS';
+const timestampFormat: string = 'YYYY-MM-DD HH:mm:ss';
 
 const convertErrorToString = (err) => {
   // Preserve any dictionary, but otherwise convert to string

--- a/Meadowlark-js/packages/meadowlark-utilities/src/Logger.ts
+++ b/Meadowlark-js/packages/meadowlark-utilities/src/Logger.ts
@@ -6,7 +6,7 @@
 import winston from 'winston';
 import * as Config from './Config';
 
-const timestampFormat: string = 'YYYY-MM-DD HH:mm:ss';
+const timestampFormat: string = 'YYYY-MM-DD HH:mm:ss.SSS';
 
 const convertErrorToString = (err) => {
   // Preserve any dictionary, but otherwise convert to string


### PR DESCRIPTION
Update timestampFormat (Logger.ts) to use 'YYYY-MM-DD HH:mm:ss' instead of 'YYYY-MM-DD HH:mm:SS'

## Description

Update date format for the logger to include seconds and milliseconds.
```2023-01-31 15:53:46.025 debug not-applicable Spawning 12 worker threads 
2023-01-31 15:53:46.028 debug not-applicable Primary process ID 31364 is running 
2023-01-31 15:53:46.266 debug not-applicable Worker 25852 is listening 
2023-01-31 15:53:46.268 debug not-applicable Worker 10796 is listening 
2023-01-31 15:53:46.268 debug not-applicable Worker 24204 is listening 
2023-01-31 15:53:46.269 debug not-applicable Worker 38320 is listening 
2023-01-31 15:53:46.269 debug not-applicable Worker 31316 is listening 
2023-01-31 15:53:46.270 debug not-applicable Worker 37296 is listening 
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have signed all of the commits on this PR.
- [ x ] I have agreed to the Ed-Fi Individual Contributors' License
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
