### PR TITLE
[RND-267] Changes priority values on the docker mongo replica set configuration.

### DIFF
--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/docker/scripts/mongo-rs-setup.sh
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/docker/scripts/mongo-rs-setup.sh
@@ -9,17 +9,17 @@ var cfg = {
         {
             "_id": 0,
             "host": "mongo1:27017",
-            "priority": 2
+            "priority": 3
         },
         {
             "_id": 1,
             "host": "mongo2:27018",
-            "priority": 0
+            "priority": 2
         },
         {
             "_id": 2,
             "host": "mongo3:27019",
-            "priority": 0
+            "priority": 1
         }
     ],settings: {chainingAllowed: true}
 };


### PR DESCRIPTION
In order to have mongo2 and mongo3 working as secondary nodes, we need to change the priority value to something greater than 0. 
This is part of what the documentation says about the priority value:

```
A number that indicates the relative eligibility of a member to become a primary.
Specify higher values to make a member more eligible to become primary, and lower values to make the member less eligible. A member with a members[n].priority of 0 is ineligible to become primary.
```

Based on this, if the primary node (mongo1) fails, we currently don’t have a node to replace it as the primary one.


The arbiter is not actually required. Based on the documentation:

`In some circumstances (such as when you have a primary and a secondary, but cost constraints prohibit adding another secondary), you may choose to add an arbiter to your replica set. An arbiter participates in elections for primary.`

