### PR TITLE
[RND-481] Close all database connections when API exits

### DIFF
--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/BackendFacade.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/BackendFacade.ts
@@ -37,7 +37,7 @@ import * as GetAllAuthorizationClients from './repository/authorization/GetAllAu
 import * as UpdateAuthorizationClient from './repository/authorization/UpdateAuthorizationClient';
 import * as ResetAuthorizationClientSecret from './repository/authorization/ResetAuthorizationClientSecret';
 import * as SecurityMiddleware from './security/SecurityMiddleware';
-import { getSharedClient } from './repository/Db';
+import { getSharedClient, closeSharedConnection } from './repository/Db';
 
 // DocumentStore implementation
 export async function deleteDocumentById(request: DeleteRequest): Promise<DeleteResult> {
@@ -93,4 +93,8 @@ export async function resetAuthorizationClientSecret(
   request: ResetAuthorizationClientSecretRequest,
 ): Promise<ResetAuthorizationClientSecretResult> {
   return ResetAuthorizationClientSecret.resetAuthorizationClientSecret(request, await getSharedClient());
+}
+
+export async function closeConnection(): Promise<void> {
+  return closeSharedConnection();
 }

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/index.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/index.ts
@@ -17,6 +17,7 @@ import {
   getAllAuthorizationClientDocuments,
   resetAuthorizationClientSecret,
   tryCreateBootstrapAuthorizationAdminDocument,
+  closeConnection,
 } from './BackendFacade';
 
 export function initializeDocumentStore(): DocumentStorePlugin {
@@ -26,6 +27,7 @@ export function initializeDocumentStore(): DocumentStorePlugin {
     updateDocumentById,
     deleteDocumentById,
     securityMiddleware,
+    closeConnection,
   };
 }
 
@@ -41,5 +43,5 @@ export function initializeAuthorizationStore(): AuthorizationStorePlugin {
 }
 
 // Accessible for system testing - this may turn into a generic setup/teardown datastore interface
-export { getNewClient, getDocumentCollection, getAuthorizationCollection, resetSharedClient } from './repository/Db';
+export { getNewClient, getDocumentCollection, getAuthorizationCollection } from './repository/Db';
 export { systemTestSetup, systemTestTeardown } from './repository/SystemTestHelper';

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Db.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Db.ts
@@ -74,13 +74,23 @@ export async function resetSharedClient(): Promise<void> {
 }
 
 /**
+ * Close and discard the current shared client. Only use for testing purposes.
+ */
+export async function closeSharedConnection(): Promise<void> {
+  if (singletonClient != null) {
+    await singletonClient.close();
+  }
+  singletonClient = null;
+  Logger.info(`MongoDb connection: closed`, null);
+}
+
+/**
  * Return the shared client
  */
 export async function getSharedClient(): Promise<MongoClient> {
   if (singletonClient == null) {
     singletonClient = await getNewClient();
   }
-
   return singletonClient;
 }
 

--- a/Meadowlark-js/backends/meadowlark-opensearch-backend/src/BackendFacade.ts
+++ b/Meadowlark-js/backends/meadowlark-opensearch-backend/src/BackendFacade.ts
@@ -15,7 +15,7 @@ import {
 } from '@edfi/meadowlark-core';
 import * as QueryOpensearch from './repository/QueryOpensearch';
 import * as UpdateOpensearch from './repository/UpdateOpensearch';
-import { getSharedClient } from './repository/Db';
+import { getSharedClient, closeSharedConnection } from './repository/Db';
 
 export async function queryDocuments(request: QueryRequest): Promise<QueryResult> {
   return QueryOpensearch.queryDocuments(request, await getSharedClient());
@@ -31,4 +31,8 @@ export async function afterUpsertDocument(request: UpsertRequest, result: Upsert
 
 export async function afterUpdateDocumentById(request: UpdateRequest, result: UpdateResult): Promise<void> {
   return UpdateOpensearch.afterUpdateDocumentById(request, result, await getSharedClient());
+}
+
+export async function closeConnection(): Promise<void> {
+  return closeSharedConnection();
 }

--- a/Meadowlark-js/backends/meadowlark-opensearch-backend/src/index.ts
+++ b/Meadowlark-js/backends/meadowlark-opensearch-backend/src/index.ts
@@ -4,11 +4,18 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 import { QueryHandlerPlugin, Subscribe } from '@edfi/meadowlark-core';
-import { afterDeleteDocumentById, afterUpdateDocumentById, afterUpsertDocument, queryDocuments } from './BackendFacade';
+import {
+  afterDeleteDocumentById,
+  afterUpdateDocumentById,
+  afterUpsertDocument,
+  queryDocuments,
+  closeConnection,
+} from './BackendFacade';
 
 export function initializeQueryHandler(): QueryHandlerPlugin {
   return {
     queryDocuments,
+    closeConnection,
   };
 }
 

--- a/Meadowlark-js/backends/meadowlark-opensearch-backend/src/repository/Db.ts
+++ b/Meadowlark-js/backends/meadowlark-opensearch-backend/src/repository/Db.ts
@@ -44,3 +44,11 @@ export async function getSharedClient(): Promise<Client> {
 
   return singletonClient;
 }
+
+export async function closeSharedConnection(): Promise<void> {
+  if (singletonClient != null) {
+    await singletonClient.close();
+  }
+  singletonClient = null;
+  Logger.info(`Opensearch connection: closed`, null);
+}

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/BackendFacade.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/BackendFacade.ts
@@ -20,7 +20,7 @@ import * as Upsert from './repository/Upsert';
 import * as Delete from './repository/Delete';
 import * as Get from './repository/Get';
 import * as Update from './repository/Update';
-import { getSharedClient } from './repository/Db';
+import { getSharedClient, closeSharedConnection } from './repository/Db';
 import * as SecurityMiddleware from './security/SecurityMiddleware';
 
 export async function deleteDocumentById(request: DeleteRequest): Promise<DeleteResult> {
@@ -66,4 +66,8 @@ export async function securityMiddleware(middlewareModel: MiddlewareModel): Prom
   } finally {
     poolClient.release();
   }
+}
+
+export async function closeConnection(): Promise<void> {
+  return closeSharedConnection();
 }

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/index.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/index.ts
@@ -10,6 +10,7 @@ import {
   getDocumentById,
   updateDocumentById,
   securityMiddleware,
+  closeConnection,
 } from './BackendFacade';
 
 export function initializeDocumentStore(): DocumentStorePlugin {
@@ -19,6 +20,7 @@ export function initializeDocumentStore(): DocumentStorePlugin {
     updateDocumentById,
     deleteDocumentById,
     securityMiddleware,
+    closeConnection,
   };
 }
 

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Db.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Db.ts
@@ -138,3 +138,17 @@ export async function resetSharedClient() {
     }
   }
 }
+
+/**
+ * Nulls out the singleton pool, then closes it
+ */
+export async function closeSharedConnection() {
+  const savedDbPool: Pool | null = singletonDbPool;
+  if (singletonDbPool != null) {
+    singletonDbPool = null;
+    if (savedDbPool != null) {
+      await savedDbPool.end();
+    }
+  }
+  Logger.info(`Postgresql connection: closed`, null);
+}

--- a/Meadowlark-js/packages/meadowlark-core/src/handler/Connection.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/handler/Connection.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+import { writeErrorToLog } from '@edfi/meadowlark-utilities';
+import { getDocumentStore, getQueryHandler } from '../plugin/PluginLoader';
+
+const moduleName = 'core.handler.Connection';
+async function closeSharedConnection(): Promise<void> {
+  try {
+    await getDocumentStore().closeConnection();
+  } catch (e) {
+    writeErrorToLog(moduleName, '', 'closeConnection', 500, e);
+  }
+}
+
+async function closeQueryConnection(): Promise<void> {
+  return getQueryHandler().closeConnection();
+}
+
+export async function closeConnection(): Promise<void> {
+  // close all connections
+  await closeQueryConnection();
+  await closeSharedConnection();
+}

--- a/Meadowlark-js/packages/meadowlark-core/src/handler/Connection.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/handler/Connection.ts
@@ -8,19 +8,19 @@ import { getDocumentStore, getQueryHandler } from '../plugin/PluginLoader';
 
 const moduleName = 'core.handler.Connection';
 async function closeSharedConnection(): Promise<void> {
-  try {
-    await getDocumentStore().closeConnection();
-  } catch (e) {
-    writeErrorToLog(moduleName, '', 'closeConnection', 500, e);
-  }
+  await getDocumentStore().closeConnection();
 }
 
 async function closeQueryConnection(): Promise<void> {
-  return getQueryHandler().closeConnection();
+  await getQueryHandler().closeConnection();
 }
 
 export async function closeConnection(): Promise<void> {
-  // close all connections
-  await closeQueryConnection();
-  await closeSharedConnection();
+  try {
+    // close all connections
+    await closeQueryConnection();
+    await closeSharedConnection();
+  } catch (e) {
+    writeErrorToLog(moduleName, '', 'closeConnection', 500, e);
+  }
 }

--- a/Meadowlark-js/packages/meadowlark-core/src/handler/FrontendFacade.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/handler/FrontendFacade.ts
@@ -17,6 +17,7 @@ import * as Update from './Update';
 import * as Delete from './Delete';
 import * as Query from './Query';
 import * as GetById from './GetById';
+import * as Connection from './Connection';
 import { ensurePluginsLoaded, getDocumentStore } from '../plugin/PluginLoader';
 import { queryValidation } from '../middleware/ValidateQueryMiddleware';
 import { documentInfoExtraction } from '../middleware/ExtractDocumentInfoMiddleware';
@@ -251,5 +252,14 @@ export async function deleteIt(frontendRequest: FrontendRequest): Promise<Fronte
   } catch (e) {
     writeErrorToLog(moduleName, frontendRequest.traceId, 'deleteIt', 500, e);
     return { statusCode: 500 };
+  }
+}
+
+export async function closeConnection(): Promise<void> {
+  try {
+    await initialize();
+    await Connection.closeConnection();
+  } catch (e) {
+    writeErrorToLog(moduleName, '', 'closeConnection', 500, e);
   }
 }

--- a/Meadowlark-js/packages/meadowlark-core/src/index.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/index.ts
@@ -46,7 +46,7 @@ export { doNothingMiddleware } from './middleware/DoNothingMiddleware';
 export { writeRequestToLog } from './Logger';
 
 // Handlers
-export { upsert, deleteIt, get, update } from './handler/FrontendFacade';
+export { upsert, deleteIt, get, update, closeConnection } from './handler/FrontendFacade';
 export { loadDescriptors } from './handler/DescriptorLoader';
 export {
   apiVersion,

--- a/Meadowlark-js/packages/meadowlark-core/src/plugin/backend/DocumentStorePlugin.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/plugin/backend/DocumentStorePlugin.ts
@@ -23,4 +23,6 @@ export interface DocumentStorePlugin {
   deleteDocumentById: (request: DeleteRequest) => Promise<DeleteResult>;
 
   securityMiddleware: (middlewareModel: MiddlewareModel) => Promise<MiddlewareModel>;
+
+  closeConnection: () => Promise<void>;
 }

--- a/Meadowlark-js/packages/meadowlark-core/src/plugin/backend/NoDocumentStorePlugin.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/plugin/backend/NoDocumentStorePlugin.ts
@@ -45,4 +45,11 @@ export const NoDocumentStorePlugin: DocumentStorePlugin = {
     );
     return Promise.resolve(middlewareModel);
   },
+
+  closeConnection: async (): Promise<void> => {
+    Logger.warn(
+      `${moduleName}.closeConnection No backend plugin has been configured`,
+      ''
+    );
+  },
 };

--- a/Meadowlark-js/packages/meadowlark-core/src/plugin/backend/NoDocumentStorePlugin.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/plugin/backend/NoDocumentStorePlugin.ts
@@ -47,9 +47,6 @@ export const NoDocumentStorePlugin: DocumentStorePlugin = {
   },
 
   closeConnection: async (): Promise<void> => {
-    Logger.warn(
-      `${moduleName}.closeConnection No backend plugin has been configured`,
-      ''
-    );
+    Logger.warn(`${moduleName}.closeConnection No backend plugin has been configured`, '');
   },
 };

--- a/Meadowlark-js/packages/meadowlark-core/src/plugin/backend/NoQueryHandlerPlugin.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/plugin/backend/NoQueryHandlerPlugin.ts
@@ -12,4 +12,7 @@ export const NoQueryHandlerPlugin: QueryHandlerPlugin = {
     Logger.warn('core.plugin.backend.NoQueryHandlerPlugin.queryDocuments(): No backend plugin has been configured', traceId);
     return Promise.resolve({ response: 'UNKNOWN_FAILURE', documents: [] });
   },
+  closeConnection: async (): Promise<void> => {
+    Logger.warn('core.plugin.backend.NoQueryHandlerPlugin.closeConnection(): No backend plugin has been configured', null);
+  },
 };

--- a/Meadowlark-js/packages/meadowlark-core/src/plugin/backend/QueryHandlerPlugin.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/plugin/backend/QueryHandlerPlugin.ts
@@ -8,4 +8,6 @@ import { QueryResult } from '../../message/QueryResult';
 
 export interface QueryHandlerPlugin {
   queryDocuments: (request: QueryRequest) => Promise<QueryResult>;
+
+  closeConnection: () => Promise<void>;
 }

--- a/Meadowlark-js/services/meadowlark-fastify/src/Service.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/src/Service.ts
@@ -120,7 +120,7 @@ export function buildService(): FastifyInstance {
     fastify.get(`/${stage}/metaed`, metaed);
 
     // API version handler
-    fastify.get(`/${stage}`, closeConnection);
+    fastify.get(`/${stage}`, apiVersion);
     fastify.get(`/${stage}/`, apiVersion);
 
     // Swagger handlers

--- a/Meadowlark-js/services/meadowlark-fastify/src/Service.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/src/Service.ts
@@ -12,7 +12,8 @@ import Fastify from 'fastify';
 import FastifyRateLimit from '@fastify/rate-limit';
 import type { FastifyInstance, FastifyLoggerInstance } from 'fastify';
 import { Config, Logger } from '@edfi/meadowlark-utilities';
-import { closeConnection, deleteIt, get, update, upsert } from './handler/CrudHandler';
+import { deleteIt, get, update, upsert } from './handler/CrudHandler';
+import { closeMeadowlarkConnection } from './handler/MeadowlarkConnection';
 import {
   metaed,
   apiVersion,
@@ -77,7 +78,7 @@ export function buildService(): FastifyInstance {
 
     fastify.addHook('onClose', (_instance, done) => {
       Logger.info('Close signal received', null);
-      closeConnection();
+      closeMeadowlarkConnection();
       done();
     });
   }

--- a/Meadowlark-js/services/meadowlark-fastify/src/Service.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/src/Service.ts
@@ -12,7 +12,7 @@ import Fastify from 'fastify';
 import FastifyRateLimit from '@fastify/rate-limit';
 import type { FastifyInstance, FastifyLoggerInstance } from 'fastify';
 import { Config, Logger } from '@edfi/meadowlark-utilities';
-import { deleteIt, get, update, upsert } from './handler/CrudHandler';
+import { closeConnection, deleteIt, get, update, upsert } from './handler/CrudHandler';
 import {
   metaed,
   apiVersion,
@@ -77,7 +77,7 @@ export function buildService(): FastifyInstance {
 
     fastify.addHook('onClose', (_instance, done) => {
       Logger.info('Close signal received', null);
-
+      closeConnection();
       done();
     });
   }
@@ -120,7 +120,7 @@ export function buildService(): FastifyInstance {
     fastify.get(`/${stage}/metaed`, metaed);
 
     // API version handler
-    fastify.get(`/${stage}`, apiVersion);
+    fastify.get(`/${stage}`, closeConnection);
     fastify.get(`/${stage}/`, apiVersion);
 
     // Swagger handlers

--- a/Meadowlark-js/services/meadowlark-fastify/src/ServiceFactory.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/src/ServiceFactory.ts
@@ -6,7 +6,7 @@
 import { FastifyInstance } from 'fastify';
 import { Config, Logger } from '@edfi/meadowlark-utilities';
 import { buildService } from './Service';
-import { closeConnection } from './handler/CrudHandler';
+import { closeMeadowlarkConnection } from './handler/MeadowlarkConnection';
 
 export type ServiceFactory = (worker: number) => Promise<void>;
 /* istanbul ignore file */
@@ -15,7 +15,7 @@ export async function serviceFactory(worker: number) {
 
   const closeGracefully = async (signal: string | number | undefined) => {
     Logger.info(`Received signal to terminate: ${signal}`, null);
-    await closeConnection();
+    await closeMeadowlarkConnection();
     await service.close();
     Logger.info('Service closed', null);
     process.kill(process.pid, signal);

--- a/Meadowlark-js/services/meadowlark-fastify/src/ServiceFactory.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/src/ServiceFactory.ts
@@ -6,6 +6,7 @@
 import { FastifyInstance } from 'fastify';
 import { Config, Logger } from '@edfi/meadowlark-utilities';
 import { buildService } from './Service';
+import { closeConnection } from './handler/CrudHandler';
 
 export type ServiceFactory = (worker: number) => Promise<void>;
 /* istanbul ignore file */
@@ -14,11 +15,9 @@ export async function serviceFactory(worker: number) {
 
   const closeGracefully = async (signal: string | number | undefined) => {
     Logger.info(`Received signal to terminate: ${signal}`, null);
-
+    await closeConnection();
     await service.close();
-    // TODO RND-481: close database connections Initial thoughts: may need to
-    // have a global registry of backends to go through, manually closing any
-    // connections.
+    Logger.info('Service closed', null);
     process.kill(process.pid, signal);
   };
   // The code below works correctly, and is not a misuse of promises.

--- a/Meadowlark-js/services/meadowlark-fastify/src/handler/CrudHandler.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/src/handler/CrudHandler.ts
@@ -8,10 +8,8 @@ import {
   upsert as meadowlarkUpsert,
   get as meadowlarkGet,
   deleteIt as meadowlarkDelete,
-  closeConnection as meadowlarkCloseConnection,
 } from '@edfi/meadowlark-core';
 import { FastifyReply, FastifyRequest } from 'fastify';
-import { Logger } from '@edfi/meadowlark-utilities';
 import { respondWith, fromRequest } from './MeadowlarkConverter';
 
 /**
@@ -40,12 +38,4 @@ export async function update(request: FastifyRequest, reply: FastifyReply): Prom
  */
 export async function deleteIt(request: FastifyRequest, reply: FastifyReply): Promise<void> {
   respondWith(await meadowlarkDelete(fromRequest(request)), reply);
-}
-
-/**
- * Entry point for all API DELETE requests, which are "by id"
- */
-export async function closeConnection(): Promise<void> {
-  Logger.info(`Close connection.`, null);
-  await meadowlarkCloseConnection();
 }

--- a/Meadowlark-js/services/meadowlark-fastify/src/handler/CrudHandler.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/src/handler/CrudHandler.ts
@@ -8,8 +8,10 @@ import {
   upsert as meadowlarkUpsert,
   get as meadowlarkGet,
   deleteIt as meadowlarkDelete,
+  closeConnection as meadowlarkCloseConnection,
 } from '@edfi/meadowlark-core';
 import { FastifyReply, FastifyRequest } from 'fastify';
+import { Logger } from '@edfi/meadowlark-utilities';
 import { respondWith, fromRequest } from './MeadowlarkConverter';
 
 /**
@@ -38,4 +40,12 @@ export async function update(request: FastifyRequest, reply: FastifyReply): Prom
  */
 export async function deleteIt(request: FastifyRequest, reply: FastifyReply): Promise<void> {
   respondWith(await meadowlarkDelete(fromRequest(request)), reply);
+}
+
+/**
+ * Entry point for all API DELETE requests, which are "by id"
+ */
+export async function closeConnection(): Promise<void> {
+  Logger.info(`Close connection.`, null);
+  await meadowlarkCloseConnection();
 }

--- a/Meadowlark-js/services/meadowlark-fastify/src/handler/MeadowlarkConnection.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/src/handler/MeadowlarkConnection.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+import { closeConnection as meadowlarkCloseConnection } from '@edfi/meadowlark-core';
+import { Logger } from '@edfi/meadowlark-utilities';
+
+/**
+ * Close database connection
+ */
+export async function closeMeadowlarkConnection(): Promise<void> {
+  Logger.info(`Close database connection.`, null);
+  await meadowlarkCloseConnection();
+}


### PR DESCRIPTION
Add functions to close backend connections when the service is closed.

## Description

- Add closeConnection to every backend db.ts.
- Update interfaces to include the closeConnection function.
- Invoke closeConnection to API onClose.

Ex. MongoDb.

Number of connections:
![image](https://user-images.githubusercontent.com/56046999/222622373-f1aed479-4919-4836-9e85-5ed83dfeb309.png)


<!--- Provide a brief description of your changes. Additional detail -->
<!--- should be in an associated Ed-Fi Tracker ticket (https://tracker.ed-fi.org) -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have signed all of the commits on this PR.
- [x] I have agreed to the Ed-Fi Individual Contributors' License
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
