### PR TITLE
[RND-509] A wrong connection string on mongo prints the user and password

### DIFF
--- a/Meadowlark-js/packages/meadowlark-utilities/src/Logger.ts
+++ b/Meadowlark-js/packages/meadowlark-utilities/src/Logger.ts
@@ -111,25 +111,20 @@ export const Logger = {
   // Fastify, so long as it continues to have definitions for: fatal, error, warn, info, debug, trace, child.
 
   fatal: (message: string, err?: any | null) => {
-    message = removeSensitiveData(message);
-    logger.error({ message, err: convertErrorToString(err) });
+    logger.error({ message: removeSensitiveData(message), err: convertErrorToString(err) });
     process.exit(1);
   },
   error: (message: string, traceId: string | null, err?: any | null) => {
-    message = removeSensitiveData(message);
-    logger.error({ message, error: convertErrorToString(err), traceId });
+    logger.error({ message: removeSensitiveData(message), error: convertErrorToString(err), traceId });
   },
   warn: (message: string, traceId: string | null) => {
-    message = removeSensitiveData(message);
-    logger.warn({ message, traceId });
+    logger.warn({ message: removeSensitiveData(message), traceId });
   },
   info: (message: string, traceId: string | null, extra?: any | null) => {
-    message = removeSensitiveData(message);
-    logger.info({ message, traceId, extra });
+    logger.info({ message: removeSensitiveData(message), traceId, extra });
   },
   debug: (message: string, traceId: string | null, extra?: any | null) => {
-    message = removeSensitiveData(message);
-    logger.debug({ message, traceId, extra });
+    logger.debug({ message: removeSensitiveData(message), traceId, extra });
   },
   trace: (message: string) => {
     logger.debug({ message: JSON.stringify(message) });

--- a/Meadowlark-js/packages/meadowlark-utilities/src/Logger.ts
+++ b/Meadowlark-js/packages/meadowlark-utilities/src/Logger.ts
@@ -8,6 +8,30 @@ import * as Config from './Config';
 
 const timestampFormat: string = 'YYYY-MM-DD HH:mm:ss.SSS';
 
+/*
+ * Function to remove sensitive from mongoDb connection string.
+ */
+function removeSensitiveDataFromMongoDbConnection(message: string): string {
+  const patternToProtect = /mongodb:\/\/.+:.+@/im;
+  const safeReplacementText = 'mongodb://*****:*****@';
+  return message.replace(patternToProtect, safeReplacementText);
+}
+/*
+ * Function to remove any sensitive information from the message being logged
+ */
+function removeSensitiveData(message: string): string {
+  let messageToProtect: string;
+  if (message === undefined) {
+    return message;
+  }
+  if (typeof message === 'object') {
+    messageToProtect = JSON.stringify(message);
+  } else {
+    messageToProtect = message;
+  }
+  return removeSensitiveDataFromMongoDbConnection(messageToProtect);
+}
+
 const convertErrorToString = (err) => {
   // Preserve any dictionary, but otherwise convert to string
   if (err != null && err.constructor !== Object) {
@@ -87,20 +111,20 @@ export const Logger = {
   // Fastify, so long as it continues to have definitions for: fatal, error, warn, info, debug, trace, child.
 
   fatal: (message: string, err?: any | null) => {
-    logger.error({ message, err: convertErrorToString(err) });
+    logger.error({ message: removeSensitiveData(message), err: convertErrorToString(err) });
     process.exit(1);
   },
   error: (message: string, traceId: string | null, err?: any | null) => {
-    logger.error({ message, error: convertErrorToString(err), traceId });
+    logger.error({ message: removeSensitiveData(message), error: convertErrorToString(err), traceId });
   },
   warn: (message: string, traceId: string | null) => {
-    logger.warn({ message, traceId });
+    logger.warn({ message: removeSensitiveData(message), traceId });
   },
   info: (message: string, traceId: string | null, extra?: any | null) => {
-    logger.info({ message, traceId, extra });
+    logger.info({ message: removeSensitiveData(message), traceId, extra });
   },
   debug: (message: string, traceId: string | null, extra?: any | null) => {
-    logger.debug({ message, traceId, extra });
+    logger.debug({ message: removeSensitiveData(message), traceId, extra });
   },
   trace: (message: string) => {
     logger.debug({ message: JSON.stringify(message) });

--- a/Meadowlark-js/packages/meadowlark-utilities/src/Logger.ts
+++ b/Meadowlark-js/packages/meadowlark-utilities/src/Logger.ts
@@ -12,7 +12,7 @@ const timestampFormat: string = 'YYYY-MM-DD HH:mm:ss.SSS';
  * Function to remove sensitive from mongoDb connection string.
  */
 function removeSensitiveDataFromMongoDbConnection(message: string): string {
-  const patternToProtect = /mongodb:\/\/.+:.+@/im;
+  const patternToProtect = /mongodb:\/\/[\w!@#$%\^&*)(+=.-]+:[\w!@#$%\^&*)(+=.-]+@/gis;
   const safeReplacementText = 'mongodb://*****:*****@';
   return message.replace(patternToProtect, safeReplacementText);
 }
@@ -111,20 +111,25 @@ export const Logger = {
   // Fastify, so long as it continues to have definitions for: fatal, error, warn, info, debug, trace, child.
 
   fatal: (message: string, err?: any | null) => {
-    logger.error({ message: removeSensitiveData(message), err: convertErrorToString(err) });
+    message = removeSensitiveData(message);
+    logger.error({ message, err: convertErrorToString(err) });
     process.exit(1);
   },
   error: (message: string, traceId: string | null, err?: any | null) => {
-    logger.error({ message: removeSensitiveData(message), error: convertErrorToString(err), traceId });
+    message = removeSensitiveData(message);
+    logger.error({ message, error: convertErrorToString(err), traceId });
   },
   warn: (message: string, traceId: string | null) => {
-    logger.warn({ message: removeSensitiveData(message), traceId });
+    message = removeSensitiveData(message);
+    logger.warn({ message, traceId });
   },
   info: (message: string, traceId: string | null, extra?: any | null) => {
-    logger.info({ message: removeSensitiveData(message), traceId, extra });
+    message = removeSensitiveData(message);
+    logger.info({ message, traceId, extra });
   },
   debug: (message: string, traceId: string | null, extra?: any | null) => {
-    logger.debug({ message: removeSensitiveData(message), traceId, extra });
+    message = removeSensitiveData(message);
+    logger.debug({ message, traceId, extra });
   },
   trace: (message: string) => {
     logger.debug({ message: JSON.stringify(message) });

--- a/Meadowlark-js/packages/meadowlark-utilities/src/Logger.ts
+++ b/Meadowlark-js/packages/meadowlark-utilities/src/Logger.ts
@@ -12,7 +12,7 @@ const timestampFormat: string = 'YYYY-MM-DD HH:mm:ss.SSS';
  * Function to remove sensitive from mongoDb connection string.
  */
 function removeSensitiveDataFromMongoDbConnection(message: string): string {
-  const patternToProtect = /mongodb:\/\/[\w!@#$%\^&*)(+=.-]+:[\w!@#$%\^&*)(+=.-]+@/gis;
+  const patternToProtect = /mongodb:\/\/[\w!@#$%^&*)(+=.-]+:[\w!@#$%^&*)(+=.-]+@/gis;
   const safeReplacementText = 'mongodb://*****:*****@';
   return message.replace(patternToProtect, safeReplacementText);
 }


### PR DESCRIPTION
Entering a wrong connection string on mongo prints the user and password

- Add function to remove sensitive data from logged message. Update Logger call.
- Result:
```
Error connecting MongoDb URL: "mongodb://*****:*****@mongo1:27017,mongo2:27018,mongo3:27019/?replicaSet=rs0". Error was Authentication failed.
```

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Provide a brief description of your changes. Additional detail -->
<!--- should be in an associated Ed-Fi Tracker ticket (https://tracker.ed-fi.org) -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have signed all of the commits on this PR.
- [x] I have agreed to the Ed-Fi Individual Contributors' License
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
