### PR TITLE
[RND-496] Use global setup for jest

### DIFF
--- a/Meadowlark-js/.eslintignore
+++ b/Meadowlark-js/.eslintignore
@@ -7,3 +7,4 @@ jest.ci-config.js
 jest.e2e-config.js
 jest-mongodb-config.js
 jest.config.js
+global-setup.js

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/config/integration/jest.config.js
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/config/integration/jest.config.js
@@ -1,5 +1,6 @@
+const rootDir = '../../../../../';
 // eslint-disable-next-line import/no-extraneous-dependencies
-const defaultConfig = require('../../../../../tests/config/jest.config');
+const defaultConfig = require(`${rootDir}/tests/config/jest.config`);
 
 module.exports = {
   displayName: 'Integration Tests: Mongodb',
@@ -15,5 +16,6 @@ module.exports = {
       statements: 60,
     },
   },
+  rootDir,
   workerIdleMemoryLimit: '200MB',
 };

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Delete.test.ts
@@ -29,8 +29,6 @@ import { deleteDocumentById } from '../../src/repository/Delete';
 import { upsertDocument } from '../../src/repository/Upsert';
 import { setupConfigForIntegration } from './Config';
 
-jest.setTimeout(40000);
-
 const newUpsertRequest = (): UpsertRequest => ({
   meadowlarkId: '' as MeadowlarkId,
   resourceInfo: NoResourceInfo,

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/OwnershipSecurity.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/OwnershipSecurity.test.ts
@@ -26,8 +26,6 @@ import { rejectByOwnershipSecurity } from '../../src/repository/OwnershipSecurit
 import { upsertDocument } from '../../src/repository/Upsert';
 import { setupConfigForIntegration } from './Config';
 
-jest.setTimeout(40000);
-
 describe('given the getById where resource info is a Descriptor', () => {
   let client;
   let result;

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Read.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Read.test.ts
@@ -25,8 +25,6 @@ import { getDocumentById } from '../../src/repository/Get';
 import { upsertDocument } from '../../src/repository/Upsert';
 import { setupConfigForIntegration } from './Config';
 
-jest.setTimeout(40000);
-
 const newGetRequest = (): GetRequest => ({
   documentUuid: '' as DocumentUuid,
   resourceInfo: NoResourceInfo,

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/SecurityMiddleware.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/SecurityMiddleware.test.ts
@@ -26,8 +26,6 @@ import { securityMiddleware } from '../../src/security/SecurityMiddleware';
 import { upsertDocument } from '../../src/repository/Upsert';
 import { setupConfigForIntegration } from './Config';
 
-jest.setTimeout(40000);
-
 describe('given the upsert where no document id is specified', () => {
   let client;
   let result;

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Update.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Update.test.ts
@@ -30,8 +30,6 @@ import { updateDocumentById } from '../../src/repository/Update';
 import { upsertDocument } from '../../src/repository/Upsert';
 import { setupConfigForIntegration } from './Config';
 
-jest.setTimeout(40000);
-
 const newUpdateRequest = (): UpdateRequest => ({
   meadowlarkId: '' as MeadowlarkId,
   documentUuid: '' as DocumentUuid,

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Upsert.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Upsert.test.ts
@@ -28,8 +28,6 @@ import { getDocumentCollection, getNewClient } from '../../src/repository/Db';
 import { upsertDocument } from '../../src/repository/Upsert';
 import { setupConfigForIntegration } from './Config';
 
-jest.setTimeout(40000);
-
 const newUpsertRequest = (): UpsertRequest => ({
   meadowlarkId: '' as MeadowlarkId,
   resourceInfo: NoResourceInfo,

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/authorization/CreateAuthorizationClient.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/authorization/CreateAuthorizationClient.test.ts
@@ -10,8 +10,6 @@ import { getAuthorizationCollection, getNewClient } from '../../../src/repositor
 import { createAuthorizationClientDocument } from '../../../src/repository/authorization/CreateAuthorizationClient';
 import { setupConfigForIntegration } from '../Config';
 
-jest.setTimeout(40000);
-
 const clientId = 'clientId';
 
 const newCreateAuthorizationClientRequest = (): CreateAuthorizationClientRequest => ({

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/authorization/GetAllAuthorizationClients.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/authorization/GetAllAuthorizationClients.test.ts
@@ -10,8 +10,6 @@ import { createAuthorizationClientDocument } from '../../../src/repository/autho
 import { getAllAuthorizationClientDocuments } from '../../../src/repository/authorization/GetAllAuthorizationClients';
 import { setupConfigForIntegration } from '../Config';
 
-jest.setTimeout(40000);
-
 const clientId = 'clientId';
 
 const TRACE_ID = 'traceId';

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/authorization/GetAuthorizationClient.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/authorization/GetAuthorizationClient.test.ts
@@ -11,8 +11,6 @@ import { createAuthorizationClientDocument } from '../../../src/repository/autho
 import { getAuthorizationClientDocument } from '../../../src/repository/authorization/GetAuthorizationClient';
 import { setupConfigForIntegration } from '../Config';
 
-jest.setTimeout(40000);
-
 const clientId = 'clientId';
 
 const newCreateAuthorizationClientRequest = (): CreateAuthorizationClientRequest => ({

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/authorization/ResetAuthorizationClientSecret.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/authorization/ResetAuthorizationClientSecret.test.ts
@@ -11,8 +11,6 @@ import { createAuthorizationClientDocument } from '../../../src/repository/autho
 import { AuthorizationDocument } from '../../../src/model/AuthorizationDocument';
 import { setupConfigForIntegration } from '../Config';
 
-jest.setTimeout(40000);
-
 const clientId = 'clientId';
 const clientIdDifferent = 'clientIdDifferent';
 const clientIdSame = 'clientIdSame';

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/authorization/TryCreateBootstrapAuthorizationAdmin.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/authorization/TryCreateBootstrapAuthorizationAdmin.test.ts
@@ -10,8 +10,6 @@ import { getAuthorizationCollection, getNewClient } from '../../../src/repositor
 import { tryCreateBootstrapAuthorizationAdminDocument } from '../../../src/repository/authorization/TryCreateBootstrapAuthorizationAdmin';
 import { setupConfigForIntegration } from '../Config';
 
-jest.setTimeout(40000);
-
 const clientId = 'clientId';
 
 const newCreateAuthorizationClientRequest = (): CreateAuthorizationClientRequest => ({

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/authorization/UpdateAuthorizationClient.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/authorization/UpdateAuthorizationClient.test.ts
@@ -11,8 +11,6 @@ import { updateAuthorizationClientDocument } from '../../../src/repository/autho
 import { createAuthorizationClientDocument } from '../../../src/repository/authorization/CreateAuthorizationClient';
 import { setupConfigForIntegration } from '../Config';
 
-jest.setTimeout(40000);
-
 const clientIdSame = 'clientIdSame';
 const clientIdDifferent = 'clientIdDifferent';
 

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/locking/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/locking/Delete.test.ts
@@ -35,8 +35,6 @@ import {
 import { upsertDocument } from '../../../src/repository/Upsert';
 import { setupConfigForIntegration } from '../Config';
 
-jest.setTimeout(10000);
-
 const documentUuid = '2edb604f-eab0-412c-a242-508d6529214d' as DocumentUuid;
 
 // A bunch of setup stuff

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/middleware/SecurityMiddleware.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/middleware/SecurityMiddleware.test.ts
@@ -9,8 +9,6 @@ import { newPathComponents } from '@edfi/meadowlark-core/src/model/PathComponent
 import { securityMiddleware } from '../../src/security/SecurityMiddleware';
 import * as OwnershipSecurity from '../../src/repository/OwnershipSecurity';
 
-
-
 describe('given the upsert where response already posted', () => {
   let result;
   const mongoClientMock = {};

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/middleware/SecurityMiddleware.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/middleware/SecurityMiddleware.test.ts
@@ -9,7 +9,7 @@ import { newPathComponents } from '@edfi/meadowlark-core/src/model/PathComponent
 import { securityMiddleware } from '../../src/security/SecurityMiddleware';
 import * as OwnershipSecurity from '../../src/repository/OwnershipSecurity';
 
-jest.setTimeout(40000);
+
 
 describe('given the upsert where response already posted', () => {
   let result;

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/repository/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/repository/Delete.test.ts
@@ -3,8 +3,6 @@ import * as utilities from '@edfi/meadowlark-utilities';
 import { deleteDocumentById } from '../../src/repository/Delete';
 import * as DB from '../../src/repository/Db';
 
-
-
 describe('given a transaction on a resource', () => {
   const retryNumberOfTimes = 2;
   let mongoClientMock = {};

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/repository/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/repository/Delete.test.ts
@@ -3,7 +3,7 @@ import * as utilities from '@edfi/meadowlark-utilities';
 import { deleteDocumentById } from '../../src/repository/Delete';
 import * as DB from '../../src/repository/Db';
 
-jest.setTimeout(40000);
+
 
 describe('given a transaction on a resource', () => {
   const retryNumberOfTimes = 2;

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/repository/Update.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/repository/Update.test.ts
@@ -11,8 +11,6 @@ import * as utilities from '@edfi/meadowlark-utilities';
 import { updateDocumentById } from '../../src/repository/Update';
 import * as DB from '../../src/repository/Db';
 
-
-
 describe('given a transaction on a resource', () => {
   const retryNumberOfTimes = 2;
   let mongoClientMock = {};

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/repository/Update.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/repository/Update.test.ts
@@ -11,7 +11,7 @@ import * as utilities from '@edfi/meadowlark-utilities';
 import { updateDocumentById } from '../../src/repository/Update';
 import * as DB from '../../src/repository/Db';
 
-jest.setTimeout(40000);
+
 
 describe('given a transaction on a resource', () => {
   const retryNumberOfTimes = 2;

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/repository/Upsert.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/repository/Upsert.test.ts
@@ -3,8 +3,6 @@ import * as utilities from '@edfi/meadowlark-utilities';
 import { upsertDocument } from '../../src/repository/Upsert';
 import * as DB from '../../src/repository/Db';
 
-
-
 describe('given a transaction on a resource', () => {
   const retryNumberOfTimes = 2;
   let mongoClientMock = {};

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/repository/Upsert.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/repository/Upsert.test.ts
@@ -3,7 +3,7 @@ import * as utilities from '@edfi/meadowlark-utilities';
 import { upsertDocument } from '../../src/repository/Upsert';
 import * as DB from '../../src/repository/Db';
 
-jest.setTimeout(40000);
+
 
 describe('given a transaction on a resource', () => {
   const retryNumberOfTimes = 2;

--- a/Meadowlark-js/backends/meadowlark-opensearch-backend/test/config/integration/jest.config.js
+++ b/Meadowlark-js/backends/meadowlark-opensearch-backend/test/config/integration/jest.config.js
@@ -1,10 +1,11 @@
+const rootDir = '../../../../../';
 // eslint-disable-next-line import/no-extraneous-dependencies
-const defaultConfig = require('../../../../../tests/config/jest.config');
+const defaultConfig = require(`${rootDir}/tests/config/jest.config`);
 
 module.exports = {
   displayName: 'Integration Tests: OpenSearch',
-  globalSetup: './test/setup/Setup.ts',
-  globalTeardown: './test/setup/Teardown.ts',
+  globalSetup: '<rootDir>/backends/meadowlark-opensearch-backend/test/setup/Setup.ts',
+  globalTeardown: '<rootDir>/backends/meadowlark-opensearch-backend/test/setup/Teardown.ts',
   ...defaultConfig,
   testMatch: ['**/meadowlark-opensearch-backend/test/integration/**/*.(spec|test).[jt]s?(x)'],
   coverageThreshold: {
@@ -15,5 +16,6 @@ module.exports = {
       statements: 60,
     },
   },
+  rootDir,
   workerIdleMemoryLimit: '200MB',
 };

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/config/integration/jest.config.js
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/config/integration/jest.config.js
@@ -1,5 +1,6 @@
+const rootDir = '../../../../../';
 // eslint-disable-next-line import/no-extraneous-dependencies
-const defaultConfig = require('../../../../../tests/config/jest.config');
+const defaultConfig = require(`${rootDir}/tests/config/jest.config`);
 
 module.exports = {
   displayName: 'Integration Tests: Postgresql',
@@ -13,5 +14,6 @@ module.exports = {
       statements: 60,
     },
   },
+  rootDir,
   workerIdleMemoryLimit: '200MB',
 };

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Connection.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Connection.test.ts
@@ -7,7 +7,7 @@ import type { PoolClient, QueryResult } from 'pg';
 import { resetSharedClient, getSharedClient } from '../../src/repository/Db';
 import { setupConfigForIntegration } from './Config';
 
-jest.setTimeout(40000);
+
 
 describe('Test Connection to Postgres Successful', () => {
   let client: PoolClient;

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Connection.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Connection.test.ts
@@ -7,8 +7,6 @@ import type { PoolClient, QueryResult } from 'pg';
 import { resetSharedClient, getSharedClient } from '../../src/repository/Db';
 import { setupConfigForIntegration } from './Config';
 
-
-
 describe('Test Connection to Postgres Successful', () => {
   let client: PoolClient;
 

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
@@ -31,8 +31,6 @@ import { upsertDocument } from '../../src/repository/Upsert';
 import { findDocumentByIdSql } from '../../src/repository/SqlHelper';
 import { setupConfigForIntegration } from './Config';
 
-
-
 const newUpsertRequest = (): UpsertRequest => ({
   meadowlarkId: '' as MeadowlarkId,
   resourceInfo: NoResourceInfo,

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
@@ -31,7 +31,7 @@ import { upsertDocument } from '../../src/repository/Upsert';
 import { findDocumentByIdSql } from '../../src/repository/SqlHelper';
 import { setupConfigForIntegration } from './Config';
 
-jest.setTimeout(40000);
+
 
 const newUpsertRequest = (): UpsertRequest => ({
   meadowlarkId: '' as MeadowlarkId,

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/OwnershipSecurity.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/OwnershipSecurity.test.ts
@@ -27,7 +27,7 @@ import { upsertDocument } from '../../src/repository/Upsert';
 import { SecurityResult } from '../../src/security/SecurityResult';
 import { setupConfigForIntegration } from './Config';
 
-jest.setTimeout(40000);
+
 
 describe('given the upsert where no document id is specified', () => {
   let client: PoolClient;

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/OwnershipSecurity.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/OwnershipSecurity.test.ts
@@ -27,8 +27,6 @@ import { upsertDocument } from '../../src/repository/Upsert';
 import { SecurityResult } from '../../src/security/SecurityResult';
 import { setupConfigForIntegration } from './Config';
 
-
-
 describe('given the upsert where no document id is specified', () => {
   let client: PoolClient;
   let result: SecurityResult;

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Read.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Read.test.ts
@@ -27,7 +27,7 @@ import { findDocumentByIdSql } from '../../src/repository/SqlHelper';
 import { upsertDocument } from '../../src/repository/Upsert';
 import { setupConfigForIntegration } from './Config';
 
-jest.setTimeout(40000);
+
 
 const newGetRequest = (): GetRequest => ({
   documentUuid: 'deb6ea15-fa93-4389-89a8-1428fb617490' as DocumentUuid,

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Read.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Read.test.ts
@@ -27,8 +27,6 @@ import { findDocumentByIdSql } from '../../src/repository/SqlHelper';
 import { upsertDocument } from '../../src/repository/Upsert';
 import { setupConfigForIntegration } from './Config';
 
-
-
 const newGetRequest = (): GetRequest => ({
   documentUuid: 'deb6ea15-fa93-4389-89a8-1428fb617490' as DocumentUuid,
   resourceInfo: NoResourceInfo,

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/SecurityMiddleware.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/SecurityMiddleware.test.ts
@@ -28,7 +28,7 @@ import { upsertDocument } from '../../src/repository/Upsert';
 import { deleteAll } from './TestHelper';
 import { setupConfigForIntegration } from './Config';
 
-jest.setTimeout(40000);
+
 
 describe('given the upsert where no document id is specified', () => {
   let client: PoolClient;

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/SecurityMiddleware.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/SecurityMiddleware.test.ts
@@ -28,8 +28,6 @@ import { upsertDocument } from '../../src/repository/Upsert';
 import { deleteAll } from './TestHelper';
 import { setupConfigForIntegration } from './Config';
 
-
-
 describe('given the upsert where no document id is specified', () => {
   let client: PoolClient;
   let result: MiddlewareModel;

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
@@ -33,8 +33,6 @@ import { getDocumentById } from '../../src/repository/Get';
 import { findDocumentByIdSql } from '../../src/repository/SqlHelper';
 import { setupConfigForIntegration } from './Config';
 
-
-
 const newUpsertRequest = (): UpsertRequest => ({
   meadowlarkId: '' as MeadowlarkId,
   resourceInfo: NoResourceInfo,

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
@@ -33,7 +33,7 @@ import { getDocumentById } from '../../src/repository/Get';
 import { findDocumentByIdSql } from '../../src/repository/SqlHelper';
 import { setupConfigForIntegration } from './Config';
 
-jest.setTimeout(40000);
+
 
 const newUpsertRequest = (): UpsertRequest => ({
   meadowlarkId: '' as MeadowlarkId,

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Upsert.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Upsert.test.ts
@@ -28,8 +28,6 @@ import { upsertDocument } from '../../src/repository/Upsert';
 import { setupConfigForIntegration } from './Config';
 import { deleteAll, retrieveReferencesByDocumentIdSql, verifyAliasId } from './TestHelper';
 
-
-
 const newUpsertRequest = (): UpsertRequest => ({
   meadowlarkId: '' as MeadowlarkId,
   resourceInfo: NoResourceInfo,

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Upsert.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Upsert.test.ts
@@ -28,7 +28,7 @@ import { upsertDocument } from '../../src/repository/Upsert';
 import { setupConfigForIntegration } from './Config';
 import { deleteAll, retrieveReferencesByDocumentIdSql, verifyAliasId } from './TestHelper';
 
-jest.setTimeout(40000);
+
 
 const newUpsertRequest = (): UpsertRequest => ({
   meadowlarkId: '' as MeadowlarkId,

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/locking/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/locking/Delete.test.ts
@@ -35,8 +35,6 @@ import { upsertDocument } from '../../../src/repository/Upsert';
 import { deleteAll } from '../TestHelper';
 import { setupConfigForIntegration } from '../Config';
 
-jest.setTimeout(10000);
-
 // A bunch of setup stuff
 const newUpsertRequest = (): UpsertRequest => ({
   meadowlarkId: '' as MeadowlarkId,

--- a/Meadowlark-js/packages/meadowlark-core/test/middleware/AuthorizationMiddleware.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/middleware/AuthorizationMiddleware.test.ts
@@ -10,7 +10,7 @@ import { FrontendRequest, newFrontendRequest, newFrontendRequestMiddleware } fro
 import { MiddlewareModel } from '../../src/middleware/MiddlewareModel';
 import { setupMockConfiguration } from '../ConfigHelper';
 
-jest.setTimeout(40000);
+
 
 const newAxiosResponse = () => ({ status: 0, data: {}, headers: {}, config: {}, statusText: '' });
 

--- a/Meadowlark-js/packages/meadowlark-core/test/middleware/AuthorizationMiddleware.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/middleware/AuthorizationMiddleware.test.ts
@@ -10,8 +10,6 @@ import { FrontendRequest, newFrontendRequest, newFrontendRequestMiddleware } fro
 import { MiddlewareModel } from '../../src/middleware/MiddlewareModel';
 import { setupMockConfiguration } from '../ConfigHelper';
 
-
-
 const newAxiosResponse = () => ({ status: 0, data: {}, headers: {}, config: {}, statusText: '' });
 
 describe('given a previous middleware has created a response', () => {

--- a/Meadowlark-js/services/meadowlark-fastify/test/Delete.test.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/test/Delete.test.ts
@@ -11,8 +11,6 @@ import * as MeadowlarkConnection from '../src/handler/MeadowlarkConnection';
 import { buildService } from '../src/Service';
 import { setupMockConfiguration } from './ConfigHelper';
 
-
-
 describe('given a DELETE of a school by id', () => {
   const schoolDeleteByIdRequest: InjectOptions = {
     method: 'DELETE',

--- a/Meadowlark-js/services/meadowlark-fastify/test/Delete.test.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/test/Delete.test.ts
@@ -11,7 +11,7 @@ import * as MeadowlarkConnection from '../src/handler/MeadowlarkConnection';
 import { buildService } from '../src/Service';
 import { setupMockConfiguration } from './ConfigHelper';
 
-jest.setTimeout(40000);
+
 
 describe('given a DELETE of a school by id', () => {
   const schoolDeleteByIdRequest: InjectOptions = {

--- a/Meadowlark-js/services/meadowlark-fastify/test/Get.test.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/test/Get.test.ts
@@ -11,8 +11,6 @@ import * as MeadowlarkConnection from '../src/handler/MeadowlarkConnection';
 import { buildService } from '../src/Service';
 import { setupMockConfiguration } from './ConfigHelper';
 
-
-
 describe('given a GET', () => {
   let mockGet: any;
   let service: FastifyInstance;

--- a/Meadowlark-js/services/meadowlark-fastify/test/Get.test.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/test/Get.test.ts
@@ -11,7 +11,7 @@ import * as MeadowlarkConnection from '../src/handler/MeadowlarkConnection';
 import { buildService } from '../src/Service';
 import { setupMockConfiguration } from './ConfigHelper';
 
-jest.setTimeout(40000);
+
 
 describe('given a GET', () => {
   let mockGet: any;

--- a/Meadowlark-js/services/meadowlark-fastify/test/Post.test.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/test/Post.test.ts
@@ -11,7 +11,7 @@ import * as MeadowlarkConnection from '../src/handler/MeadowlarkConnection';
 import { buildService } from '../src/Service';
 import { setupMockConfiguration } from './ConfigHelper';
 
-jest.setTimeout(40000);
+
 
 const schoolPostRequest: InjectOptions = {
   method: 'POST',

--- a/Meadowlark-js/services/meadowlark-fastify/test/Post.test.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/test/Post.test.ts
@@ -11,8 +11,6 @@ import * as MeadowlarkConnection from '../src/handler/MeadowlarkConnection';
 import { buildService } from '../src/Service';
 import { setupMockConfiguration } from './ConfigHelper';
 
-
-
 const schoolPostRequest: InjectOptions = {
   method: 'POST',
   url: '/local/v3.3b/ed-fi/schools',

--- a/Meadowlark-js/services/meadowlark-fastify/test/Put.test.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/test/Put.test.ts
@@ -11,7 +11,7 @@ import { buildService } from '../src/Service';
 import { setupMockConfiguration } from './ConfigHelper';
 import * as MeadowlarkConnection from '../src/handler/MeadowlarkConnection';
 
-jest.setTimeout(40000);
+
 
 const schoolPutRequest: InjectOptions = {
   method: 'PUT',

--- a/Meadowlark-js/services/meadowlark-fastify/test/Put.test.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/test/Put.test.ts
@@ -11,8 +11,6 @@ import { buildService } from '../src/Service';
 import { setupMockConfiguration } from './ConfigHelper';
 import * as MeadowlarkConnection from '../src/handler/MeadowlarkConnection';
 
-
-
 const schoolPutRequest: InjectOptions = {
   method: 'PUT',
   url: '/local/v3.3b/ed-fi/schools',

--- a/Meadowlark-js/services/meadowlark-fastify/test/authorization/CreateClient.test.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/test/authorization/CreateClient.test.ts
@@ -9,8 +9,6 @@ import * as MeadowlarkConnection from '../../src/handler/MeadowlarkConnection';
 import { buildService } from '../../src/Service';
 import { setupMockConfiguration } from '../ConfigHelper';
 
-
-
 const createClientRequest: InjectOptions = {
   method: 'POST',
   url: '/local/oauth/clients',

--- a/Meadowlark-js/services/meadowlark-fastify/test/authorization/CreateClient.test.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/test/authorization/CreateClient.test.ts
@@ -9,7 +9,7 @@ import * as MeadowlarkConnection from '../../src/handler/MeadowlarkConnection';
 import { buildService } from '../../src/Service';
 import { setupMockConfiguration } from '../ConfigHelper';
 
-jest.setTimeout(40000);
+
 
 const createClientRequest: InjectOptions = {
   method: 'POST',

--- a/Meadowlark-js/services/meadowlark-fastify/test/authorization/RequestToken.test.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/test/authorization/RequestToken.test.ts
@@ -9,8 +9,6 @@ import * as MeadowlarkConnection from '../../src/handler/MeadowlarkConnection';
 import { buildService } from '../../src/Service';
 import { setupMockConfiguration } from '../ConfigHelper';
 
-
-
 const requestTokenRequest: InjectOptions = {
   method: 'POST',
   url: '/local/oauth/token',

--- a/Meadowlark-js/services/meadowlark-fastify/test/authorization/RequestToken.test.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/test/authorization/RequestToken.test.ts
@@ -9,7 +9,7 @@ import * as MeadowlarkConnection from '../../src/handler/MeadowlarkConnection';
 import { buildService } from '../../src/Service';
 import { setupMockConfiguration } from '../ConfigHelper';
 
-jest.setTimeout(40000);
+
 
 const requestTokenRequest: InjectOptions = {
   method: 'POST',

--- a/Meadowlark-js/services/meadowlark-fastify/test/authorization/UpdateClient.test.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/test/authorization/UpdateClient.test.ts
@@ -9,8 +9,6 @@ import * as MeadowlarkConnection from '../../src/handler/MeadowlarkConnection';
 import { buildService } from '../../src/Service';
 import { setupMockConfiguration } from '../ConfigHelper';
 
-
-
 const updateClientRequest: InjectOptions = {
   method: 'PUT',
   url: '/local/oauth/clients/890',

--- a/Meadowlark-js/services/meadowlark-fastify/test/authorization/UpdateClient.test.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/test/authorization/UpdateClient.test.ts
@@ -9,7 +9,7 @@ import * as MeadowlarkConnection from '../../src/handler/MeadowlarkConnection';
 import { buildService } from '../../src/Service';
 import { setupMockConfiguration } from '../ConfigHelper';
 
-jest.setTimeout(40000);
+
 
 const updateClientRequest: InjectOptions = {
   method: 'PUT',

--- a/Meadowlark-js/services/meadowlark-fastify/test/authorization/VerifyToken.test.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/test/authorization/VerifyToken.test.ts
@@ -9,8 +9,6 @@ import * as MeadowlarkConnection from '../../src/handler/MeadowlarkConnection';
 import { buildService } from '../../src/Service';
 import { setupMockConfiguration } from '../ConfigHelper';
 
-
-
 const verifyTokenRequest: InjectOptions = {
   method: 'POST',
   url: '/local/oauth/verify',

--- a/Meadowlark-js/services/meadowlark-fastify/test/authorization/VerifyToken.test.ts
+++ b/Meadowlark-js/services/meadowlark-fastify/test/authorization/VerifyToken.test.ts
@@ -9,7 +9,7 @@ import * as MeadowlarkConnection from '../../src/handler/MeadowlarkConnection';
 import { buildService } from '../../src/Service';
 import { setupMockConfiguration } from '../ConfigHelper';
 
-jest.setTimeout(40000);
+
 
 const verifyTokenRequest: InjectOptions = {
   method: 'POST',

--- a/Meadowlark-js/tests/config/e2e/jest.config.js
+++ b/Meadowlark-js/tests/config/e2e/jest.config.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-const defaultConfig = require('./../jest.config.js');
+const defaultConfig = require('../jest.config.js');
 
 module.exports = {
   displayName: 'E2E Tests',

--- a/Meadowlark-js/tests/config/global-setup.js
+++ b/Meadowlark-js/tests/config/global-setup.js
@@ -1,0 +1,1 @@
+jest.setTimeout(40000)

--- a/Meadowlark-js/tests/config/jest.config.js
+++ b/Meadowlark-js/tests/config/jest.config.js
@@ -5,6 +5,6 @@ module.exports = {
   transformIgnorePatterns: ['<rootDir>.*(node_modules)(?!.*meadowlark-.*).*$'],
   modulePathIgnorePatterns: ['dist*', 'docs*'],
   setupFiles: ['dotenv/config'],
-  setupFilesAfterEnv: ['./global-setup.js'],
+  setupFilesAfterEnv: ['<rootDir>/tests/config/global-setup.js'],
   rootDir: '../../..',
 };

--- a/Meadowlark-js/tests/config/jest.config.js
+++ b/Meadowlark-js/tests/config/jest.config.js
@@ -5,5 +5,6 @@ module.exports = {
   transformIgnorePatterns: ['<rootDir>.*(node_modules)(?!.*meadowlark-.*).*$'],
   modulePathIgnorePatterns: ['dist*', 'docs*'],
   setupFiles: ['dotenv/config'],
+  setupFilesAfterEnv: ['./global-setup.js'],
   rootDir: '../../..',
 };

--- a/Meadowlark-js/tests/e2e/helpers/Credentials.ts
+++ b/Meadowlark-js/tests/e2e/helpers/Credentials.ts
@@ -178,14 +178,16 @@ export async function createAutomationUsers(): Promise<void> {
 
 export async function authenticateAdmin(): Promise<void> {
   try {
-    if (process.env.DEVELOPER_MODE && process.env.ADMIN_KEY && process.env.ADMIN_SECRET) {
+    const hasExistingClient = process.env.ADMIN_KEY && process.env.ADMIN_SECRET;
+
+    if (process.env.DEVELOPER_MODE && hasExistingClient) {
+      console.info('INFO ℹ️: Using existing admin key and secret');
       await getAdminAccessToken();
     } else {
       const credentials = await createAdminClient();
-      if (!process.env.ADMIN_KEY && !process.env.ADMIN_SECRET) {
-        console.info(
-          'INFO ℹ️: Add the following values to the .env file. \nIf not saved, tests cannot be executed again until cleaning the environment',
-        );
+      if (process.env.DEVELOPER_MODE && !hasExistingClient) {
+        console.info('INFO ℹ️: Add the following values to the .env file.');
+        console.info('If not saved, tests cannot be executed again until cleaning the environment.');
         console.info(`ADMIN_KEY=${credentials.key}`);
         console.info(`ADMIN_SECRET=${credentials.secret}`);
       }

--- a/Meadowlark-js/tests/e2e/scenarios/MultipleEdorgTypesResourceAssociations.test.ts
+++ b/Meadowlark-js/tests/e2e/scenarios/MultipleEdorgTypesResourceAssociations.test.ts
@@ -8,8 +8,6 @@ import { createLocalEducationAgency, createProgram, createSchool, createStudent 
 import { deleteResourceByLocation } from '../helpers/Resources';
 import { baseURLRequest, generateRandomId, rootURLRequest } from '../helpers/Shared';
 
-
-
 describe('Given the existence of a student, a school, a local education agency and a program', () => {
   const schoolId = 100;
   const localEducationAgencyId = 101;

--- a/Meadowlark-js/tests/e2e/scenarios/MultipleEdorgTypesResourceAssociations.test.ts
+++ b/Meadowlark-js/tests/e2e/scenarios/MultipleEdorgTypesResourceAssociations.test.ts
@@ -8,7 +8,7 @@ import { createLocalEducationAgency, createProgram, createSchool, createStudent 
 import { deleteResourceByLocation } from '../helpers/Resources';
 import { baseURLRequest, generateRandomId, rootURLRequest } from '../helpers/Shared';
 
-jest.setTimeout(40000);
+
 
 describe('Given the existence of a student, a school, a local education agency and a program', () => {
   const schoolId = 100;

--- a/Meadowlark-js/tests/e2e/scenarios/QueryStringValidation.test.ts
+++ b/Meadowlark-js/tests/e2e/scenarios/QueryStringValidation.test.ts
@@ -8,8 +8,6 @@ import { getAccessToken } from '../helpers/Credentials';
 import { createResource, deleteResourceByLocation } from '../helpers/Resources';
 import { baseURLRequest } from '../helpers/Shared';
 
-
-
 describe('When retrieving information', () => {
   describe("given there's no data", () => {
     it('should return the total count', async () => {

--- a/Meadowlark-js/tests/e2e/scenarios/QueryStringValidation.test.ts
+++ b/Meadowlark-js/tests/e2e/scenarios/QueryStringValidation.test.ts
@@ -8,7 +8,7 @@ import { getAccessToken } from '../helpers/Credentials';
 import { createResource, deleteResourceByLocation } from '../helpers/Resources';
 import { baseURLRequest } from '../helpers/Shared';
 
-jest.setTimeout(40000);
+
 
 describe('When retrieving information', () => {
   describe("given there's no data", () => {

--- a/Meadowlark-js/tests/e2e/scenarios/SchoolYearScenarios.test.ts
+++ b/Meadowlark-js/tests/e2e/scenarios/SchoolYearScenarios.test.ts
@@ -16,8 +16,6 @@ import {
 import { deleteResourceByLocation } from '../helpers/Resources';
 import { generateRandomId } from '../helpers/Shared';
 
-
-
 describe('When posting a resource that contains a SchoolYear enumeration', () => {
   /*
     There are several different ways of representing school years. Sometimes testing one way of storing it requires saving

--- a/Meadowlark-js/tests/e2e/scenarios/SchoolYearScenarios.test.ts
+++ b/Meadowlark-js/tests/e2e/scenarios/SchoolYearScenarios.test.ts
@@ -16,7 +16,7 @@ import {
 import { deleteResourceByLocation } from '../helpers/Resources';
 import { generateRandomId } from '../helpers/Shared';
 
-jest.setTimeout(40000);
+
 
 describe('When posting a resource that contains a SchoolYear enumeration', () => {
   /*


### PR DESCRIPTION
Instead of defining the timeout per file, there's a global-setup file that is configured afterEnv to specify a greater default value.
This value can be overridden if necessary.

This requires some changes on the jest.config files to avoid confusion on the rootEnv value. 