### PR TITLE
[RND-467] Run Integration Tests for Postgres with TestContainers

### DIFF
--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -198,9 +198,8 @@ jobs:
       - name: Configure postgres
         if: ${{ matrix.tests.type != 'Unit' }}
         run: |
-            sudo systemctl start postgresql.service
-            sudo -u postgres psql -U postgres -c "alter user postgres with password '${{env.POSTGRES_PASSWORD}}';"
-
+          sudo systemctl start postgresql.service
+          sudo -u postgres psql -U postgres -c "alter user postgres with password '${{env.POSTGRES_PASSWORD}}';"
 
       - name: Create .env file
         run: |

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -195,6 +195,13 @@ jobs:
           path: /tmp/jest_rt
           key: ${{ runner.os }}-jest-${{ hashFiles('**/package-lock.json') }}
 
+      - name: Configure postgres
+        if: ${{ matrix.tests.type != 'Unit' }}
+        run: |
+            sudo systemctl start postgresql.service
+            sudo -u postgres psql -U postgres -c "alter user postgres with password '${{env.POSTGRES_PASSWORD}}';"
+
+
       - name: Create .env file
         run: |
           # Create a .env file with proper settings

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -195,12 +195,6 @@ jobs:
           path: /tmp/jest_rt
           key: ${{ runner.os }}-jest-${{ hashFiles('**/package-lock.json') }}
 
-      - name: Configure postgres
-        if: ${{ matrix.tests.type != 'Unit' }}
-        run: |
-          sudo systemctl start postgresql.service
-          sudo -u postgres psql -U postgres -c "alter user postgres with password '${{env.POSTGRES_PASSWORD}}';"
-
       - name: Create .env file
         run: |
           # Create a .env file with proper settings

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Config.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Config.ts
@@ -6,7 +6,7 @@
 import { existsSync } from 'fs';
 import dotenv from 'dotenv';
 import { CachedEnvironmentConfigProvider, Config } from '@edfi/meadowlark-utilities';
-import { join, resolve } from 'path';
+import { join } from 'path';
 
 let hasRunAlready = false;
 
@@ -15,8 +15,7 @@ export const setupConfigForIntegration = async () => {
     return;
   }
 
-  // Backup to the root directory to find a .env file
-  const path = resolve(join(__dirname, '..', '..', '..', '..', '.env'));
+  const path = join(process.cwd(), '.env');
 
   if (!existsSync(path)) {
     // eslint-disable-next-line no-console

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/package.json
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/package.json
@@ -31,6 +31,7 @@
     "@types/pg-format": "^1.0.2",
     "copyfiles": "^2.4.1",
     "dotenv": "^16.0.3",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "testcontainers": "^9.4.0"
   }
 }

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/config/integration/jest.config.js
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/config/integration/jest.config.js
@@ -5,6 +5,8 @@ const defaultConfig = require(`${rootDir}/tests/config/jest.config`);
 module.exports = {
   displayName: 'Integration Tests: Postgresql',
   ...defaultConfig,
+  globalSetup: '<rootDir>/backends/meadowlark-postgresql-backend/test/setup/Setup.ts',
+  globalTeardown: '<rootDir>/backends/meadowlark-postgresql-backend/test/setup/Teardown.ts',
   testMatch: ['**/meadowlark-postgresql-backend/test/integration/**/*.(spec|test).[jt]s?(x)'],
   coverageThreshold: {
     global: {

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/config/integration/jest.config.js
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/config/integration/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
   ...defaultConfig,
   globalSetup: '<rootDir>/backends/meadowlark-postgresql-backend/test/setup/Setup.ts',
   globalTeardown: '<rootDir>/backends/meadowlark-postgresql-backend/test/setup/Teardown.ts',
+  setupFilesAfterEnv: ['<rootDir>/backends/meadowlark-postgresql-backend/test/setup/Global.ts'],
   testMatch: ['**/meadowlark-postgresql-backend/test/integration/**/*.(spec|test).[jt]s?(x)'],
   coverageThreshold: {
     global: {

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Connection.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Connection.test.ts
@@ -5,14 +5,11 @@
 
 import type { PoolClient, QueryResult } from 'pg';
 import { resetSharedClient, getSharedClient } from '../../src/repository/Db';
-import { setupConfigForIntegration } from './Config';
 
 describe('Test Connection to Postgres Successful', () => {
   let client: PoolClient;
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = await getSharedClient();
   });
 

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
@@ -29,7 +29,6 @@ import { getSharedClient, resetSharedClient } from '../../src/repository/Db';
 import { deleteDocumentById } from '../../src/repository/Delete';
 import { upsertDocument } from '../../src/repository/Upsert';
 import { findDocumentByIdSql } from '../../src/repository/SqlHelper';
-import { setupConfigForIntegration } from './Config';
 
 const newUpsertRequest = (): UpsertRequest => ({
   meadowlarkId: '' as MeadowlarkId,
@@ -61,8 +60,6 @@ describe('given the delete of a non-existent document', () => {
   const documentUuid = generateDocumentUuid();
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = await getSharedClient();
 
     deleteResult = await deleteDocumentById(
@@ -98,8 +95,6 @@ describe('given the delete of an existing document', () => {
   const meadowlarkId = meadowlarkIdForDocumentIdentity(resourceInfo, documentInfo.documentIdentity);
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = await getSharedClient();
     const upsertRequest: UpsertRequest = {
       ...newUpsertRequest(),
@@ -173,8 +168,6 @@ describe('given an delete of a document referenced by an existing document with 
   );
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = (await getSharedClient()) as PoolClient;
 
     // The document that will be referenced
@@ -261,8 +254,6 @@ describe('given an delete of a document with an outbound reference only, with va
   );
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = (await getSharedClient()) as PoolClient;
 
     // The document that will be referenced
@@ -349,8 +340,6 @@ describe('given an delete of a document referenced by an existing document with 
   );
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = (await getSharedClient()) as PoolClient;
 
     // The document that will be referenced
@@ -451,8 +440,6 @@ describe('given the delete of a subclass document referenced by an existing docu
   );
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = (await getSharedClient()) as PoolClient;
     // The document that will be referenced
     await upsertDocument(

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/OwnershipSecurity.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/OwnershipSecurity.test.ts
@@ -25,7 +25,6 @@ import { deleteAll } from './TestHelper';
 import { rejectByOwnershipSecurity } from '../../src/repository/OwnershipSecurity';
 import { upsertDocument } from '../../src/repository/Upsert';
 import { SecurityResult } from '../../src/security/SecurityResult';
-import { setupConfigForIntegration } from './Config';
 
 describe('given the upsert where no document id is specified', () => {
   let client: PoolClient;
@@ -41,8 +40,6 @@ describe('given the upsert where no document id is specified', () => {
   };
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = await getSharedClient();
 
     // Act
@@ -74,8 +71,6 @@ describe('given the getById of a non-existent document', () => {
   };
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = await getSharedClient();
 
     // Act
@@ -132,8 +127,6 @@ describe('given the getById of a document owned by the requestor', () => {
   };
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = await getSharedClient();
 
     // Insert owned document
@@ -192,8 +185,6 @@ describe('given the getById of a document not owned by the requestor', () => {
   };
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = await getSharedClient();
 
     // Insert non-owned document

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Read.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Read.test.ts
@@ -25,7 +25,6 @@ import { deleteAll } from './TestHelper';
 import { getDocumentById } from '../../src/repository/Get';
 import { findDocumentByIdSql } from '../../src/repository/SqlHelper';
 import { upsertDocument } from '../../src/repository/Upsert';
-import { setupConfigForIntegration } from './Config';
 
 const newGetRequest = (): GetRequest => ({
   documentUuid: 'deb6ea15-fa93-4389-89a8-1428fb617490' as DocumentUuid,
@@ -59,8 +58,6 @@ describe('given the get of a non-existent document', () => {
   const meadowlarkId = meadowlarkIdForDocumentIdentity(resourceInfo, documentInfo.documentIdentity);
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = await getSharedClient();
 
     getResult = await getDocumentById(
@@ -101,8 +98,6 @@ describe('given the get of an existing document', () => {
   const meadowlarkId = meadowlarkIdForDocumentIdentity(resourceInfo, documentInfo.documentIdentity);
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = await getSharedClient();
     const upsertRequest: UpsertRequest = { ...newUpsertRequest(), meadowlarkId, documentInfo, edfiDoc: { inserted: 'yes' } };
 

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/SecurityMiddleware.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/SecurityMiddleware.test.ts
@@ -26,7 +26,6 @@ import { resetSharedClient, getSharedClient } from '../../src/repository/Db';
 import { securityMiddleware } from '../../src/security/SecurityMiddleware';
 import { upsertDocument } from '../../src/repository/Upsert';
 import { deleteAll } from './TestHelper';
-import { setupConfigForIntegration } from './Config';
 
 describe('given the upsert where no document id is specified', () => {
   let client: PoolClient;
@@ -42,8 +41,6 @@ describe('given the upsert where no document id is specified', () => {
   };
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = await getSharedClient();
 
     // Act
@@ -75,8 +72,6 @@ describe('given the getById of a non-existent document', () => {
   };
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = await getSharedClient();
 
     // Act
@@ -134,8 +129,6 @@ describe('given the getById of a document owned by the requestor', () => {
   };
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = await getSharedClient();
 
     // Insert owned document
@@ -194,8 +187,6 @@ describe('given the getById of a document not owned by the requestor', () => {
   };
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = await getSharedClient();
 
     // Insert non-owned document

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
@@ -31,7 +31,6 @@ import { upsertDocument } from '../../src/repository/Upsert';
 import { deleteAll, retrieveReferencesByDocumentIdSql, verifyAliasId } from './TestHelper';
 import { getDocumentById } from '../../src/repository/Get';
 import { findDocumentByIdSql } from '../../src/repository/SqlHelper';
-import { setupConfigForIntegration } from './Config';
 
 const newUpsertRequest = (): UpsertRequest => ({
   meadowlarkId: '' as MeadowlarkId,
@@ -76,8 +75,6 @@ describe('given the update of a non-existent document', () => {
   const meadowlarkId = meadowlarkIdForDocumentIdentity(resourceInfo, documentInfo.documentIdentity);
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = await getSharedClient();
 
     updateResult = await updateDocumentById(
@@ -128,8 +125,6 @@ describe('given the update of an existing document', () => {
   const meadowlarkId = meadowlarkIdForDocumentIdentity(resourceInfo, documentInfo.documentIdentity);
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = await getSharedClient();
     const upsertRequest: UpsertRequest = {
       ...newUpsertRequest(),
@@ -198,8 +193,6 @@ describe('given an update of a document that references a non-existent document 
   };
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = await getSharedClient();
 
     // Insert the original document with no reference
@@ -292,8 +285,6 @@ describe('given an update of a document that references an existing document wit
   );
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = (await getSharedClient()) as PoolClient;
 
     // The document that will be referenced
@@ -402,8 +393,6 @@ describe('given an update of a document with one existing and one non-existent r
   );
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = (await getSharedClient()) as PoolClient;
 
     //  The document that will be referenced
@@ -524,8 +513,6 @@ describe('given an update of a subclass document referenced by an existing docum
   );
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = (await getSharedClient()) as PoolClient;
     //  The document that will be referenced
     await upsertDocument(

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Upsert.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Upsert.test.ts
@@ -25,7 +25,6 @@ import type { PoolClient } from 'pg';
 import { getSharedClient, resetSharedClient } from '../../src/repository/Db';
 import { findDocumentByIdSql, findAliasIdsForDocumentSql } from '../../src/repository/SqlHelper';
 import { upsertDocument } from '../../src/repository/Upsert';
-import { setupConfigForIntegration } from './Config';
 import { deleteAll, retrieveReferencesByDocumentIdSql, verifyAliasId } from './TestHelper';
 
 const newUpsertRequest = (): UpsertRequest => ({
@@ -53,8 +52,6 @@ describe('given the upsert of a new document', () => {
   const meadowlarkId = meadowlarkIdForDocumentIdentity(resourceInfo, documentInfo.documentIdentity);
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = await getSharedClient();
 
     upsertResult = await upsertDocument(
@@ -104,8 +101,6 @@ describe('given the upsert of an existing document twice', () => {
   const meadowlarkId = meadowlarkIdForDocumentIdentity(resourceInfo, documentInfo.documentIdentity);
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = await getSharedClient();
     const upsertRequest: UpsertRequest = {
       ...newUpsertRequest(),
@@ -153,8 +148,6 @@ describe('given an upsert of an existing document that changes the edfiDoc', () 
   const meadowlarkId = meadowlarkIdForDocumentIdentity(resourceInfo, documentInfo.documentIdentity);
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     const upsertRequest: UpsertRequest = { ...newUpsertRequest(), meadowlarkId, resourceInfo, documentInfo };
 
     client = await getSharedClient();
@@ -203,8 +196,6 @@ describe('given an upsert of a new document that references a non-existent docum
   documentWithReferencesInfo.documentReferences = [invalidReference];
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = await getSharedClient();
 
     // The new document with an invalid reference
@@ -275,8 +266,6 @@ describe('given an upsert of a new document that references an existing document
   );
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = (await getSharedClient()) as PoolClient;
 
     //  The document that will be referenced
@@ -365,8 +354,6 @@ describe('given an upsert of a new document with one existing and one non-existe
   );
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = (await getSharedClient()) as PoolClient;
 
     //  The document that will be referenced
@@ -466,8 +453,6 @@ describe('given an upsert of a subclass document when a different subclass has t
   );
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = (await getSharedClient()) as PoolClient;
 
     //  The existing subclass
@@ -541,8 +526,6 @@ describe('given an update of a document that references a non-existent document 
   };
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = (await getSharedClient()) as PoolClient;
 
     // Insert the original document with no reference
@@ -633,8 +616,6 @@ describe('given an update of a document that references an existing document wit
   );
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = (await getSharedClient()) as PoolClient;
 
     // The document that will be referenced
@@ -744,8 +725,6 @@ describe('given an update of a document with one existing and one non-existent r
   );
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = (await getSharedClient()) as PoolClient;
 
     //  The document that will be referenced
@@ -868,8 +847,6 @@ describe('given an update of a subclass document referenced by an existing docum
   );
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     client = (await getSharedClient()) as PoolClient;
 
     //  The document that will be referenced

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/locking/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/locking/Delete.test.ts
@@ -33,7 +33,6 @@ import {
 } from '../../../src/repository/SqlHelper';
 import { upsertDocument } from '../../../src/repository/Upsert';
 import { deleteAll } from '../TestHelper';
-import { setupConfigForIntegration } from '../Config';
 
 // A bunch of setup stuff
 const newUpsertRequest = (): UpsertRequest => ({
@@ -87,8 +86,6 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
   let deleteClient: PoolClient;
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     insertClient = (await getSharedClient()) as PoolClient;
     deleteClient = (await getSharedClient()) as PoolClient;
 
@@ -193,8 +190,6 @@ describe('given an insert concurrent with a delete referencing the to-be-deleted
   let deleteClient: PoolClient;
 
   beforeAll(async () => {
-    await setupConfigForIntegration();
-
     insertClient = (await getSharedClient()) as PoolClient;
     deleteClient = (await getSharedClient()) as PoolClient;
 

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/setup/Config.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/setup/Config.ts
@@ -8,15 +8,8 @@ import dotenv from 'dotenv';
 import { CachedEnvironmentConfigProvider, Config } from '@edfi/meadowlark-utilities';
 import { join } from 'path';
 
-let hasRunAlready = false;
-
 export const setupConfigForIntegration = async () => {
-  if (hasRunAlready) {
-    return;
-  }
-
-  // Backup to the root directory to find a .env file
-  const path = join(__dirname, '..', '..', '..', '..', '.env');
+  const path = join(process.cwd(), '.env');
   if (!existsSync(path)) {
     throw new Error('Cannot run integration tests because there is no .env file in the repository root directory.');
   }
@@ -24,6 +17,4 @@ export const setupConfigForIntegration = async () => {
   dotenv.config({ path });
 
   await Config.initializeConfig(CachedEnvironmentConfigProvider);
-
-  hasRunAlready = true;
 };

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/setup/Global.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/setup/Global.ts
@@ -1,0 +1,5 @@
+import { setupConfigForIntegration } from './Config';
+
+global.beforeAll(async () => {
+  await setupConfigForIntegration();
+});

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/setup/PostgresqlContainer.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/setup/PostgresqlContainer.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+import { Logger } from '@edfi/meadowlark-utilities';
+import { PostgreSqlContainer, StartedTestContainer } from 'testcontainers';
+
+let startedContainer: StartedTestContainer;
+
+export async function setup() {
+  Logger.info('-- Setup PostgresqlContainer environment --', null);
+
+  process.env.POSTGRES_USER = process.env.POSTGRES_USER ?? 'postgres';
+  process.env.POSTGRES_PASSWORD = process.env.POSTGRES_PASSWORD ?? 'abcdefgh1!';
+  process.env.MEADOWLARK_DATABASE_NAME = process.env.MEADOWLARK_DATABASE_NAME ?? 'meadowlark-test';
+  const image = 'postgres:14.3-alpine@sha256:84c6ea4333ae18f25ea0fb18bb142156f2a2e545e0a779d93bbf08079e56bdaf';
+
+  try {
+    const container = new PostgreSqlContainer(image)
+      .withName('postgres-test')
+      .withReuse()
+      .withDatabase(process.env.MEADOWLARK_DATABASE_NAME)
+      .withUsername(process.env.POSTGRES_USER)
+      .withPassword(process.env.POSTGRES_PASSWORD);
+
+    startedContainer = await container.start();
+
+    process.env.POSTGRES_HOST = startedContainer.getHost();
+    process.env.POSTGRES_PORT = `${startedContainer.getFirstMappedPort()}`;
+  } catch (error) {
+    throw new Error(`\nUnexpected error setting up postgres container:\n${error}`);
+  }
+}
+
+export async function stop(): Promise<void> {
+  Logger.info('-- Tearing down PostgresqlContainer environment --', null);
+  await startedContainer.stop();
+}

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/setup/Setup.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/setup/Setup.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+const postgreSQLContainer = require('./PostgresqlContainer');
+
+async function setupPostgresIntegrationTestEnvironment() {
+  try {
+    await postgreSQLContainer.setup();
+  } catch (error) {
+    throw new Error(`Error setting up integration test environment: ${error}`);
+  }
+}
+
+module.exports = async () => setupPostgresIntegrationTestEnvironment();

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/setup/Setup.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/setup/Setup.ts
@@ -6,10 +6,12 @@
 const postgreSQLContainer = require('./PostgresqlContainer');
 
 async function setupPostgresIntegrationTestEnvironment() {
-  try {
-    await postgreSQLContainer.setup();
-  } catch (error) {
-    throw new Error(`Error setting up integration test environment: ${error}`);
+  if (!process.env.CI) {
+    try {
+      await postgreSQLContainer.setup();
+    } catch (error) {
+      throw new Error(`Error setting up integration test environment: ${error}`);
+    }
   }
 }
 

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/setup/Teardown.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/setup/Teardown.ts
@@ -5,9 +5,11 @@
 const postgreSQLContainerTeardown = require('./PostgresqlContainer');
 
 module.exports = async () => {
-  try {
-    await postgreSQLContainerTeardown.stop();
-  } catch (error) {
-    throw new Error(`Teardown Error: ${error}`);
+  if (!process.env.CI) {
+    try {
+      await postgreSQLContainerTeardown.stop();
+    } catch (error) {
+      throw new Error(`Teardown Error: ${error}`);
+    }
   }
 };

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/setup/Teardown.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/setup/Teardown.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+const postgreSQLContainerTeardown = require('./PostgresqlContainer');
+
+module.exports = async () => {
+  try {
+    await postgreSQLContainerTeardown.stop();
+  } catch (error) {
+    throw new Error(`Teardown Error: ${error}`);
+  }
+};

--- a/Meadowlark-js/package-lock.json
+++ b/Meadowlark-js/package-lock.json
@@ -98,7 +98,8 @@
         "@types/pg-format": "^1.0.2",
         "copyfiles": "^2.4.1",
         "dotenv": "^16.0.3",
-        "rimraf": "^3.0.2"
+        "rimraf": "^3.0.2",
+        "testcontainers": "^9.4.0"
       }
     },
     "node_modules/@ampproject/remapping": {


### PR DESCRIPTION
Running integration tests for Postgres required a local environment already set in order to run the tests in local.

## Description

- Setting up test containers for Postgres on integration tests
- Using current setup on GH Actions since running Postgres in Ubuntu can be done with built in service.
- Introducing a global beforeAll to do the setup and avoid requiring this before each test. (This should be used only in cases when the function is truly global, to avoid unexpected behavior on tests since it can be obscure),

