### PR TITLE
[RND-522] Add CreatedAt and LastModifiedDate to Meadowlark - MongoDB

### DIFF
--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/model/MeadowlarkDocument.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/model/MeadowlarkDocument.ts
@@ -95,6 +95,21 @@ export interface MeadowlarkDocument extends MeadowlarkDocumentId {
    */
   createdBy: string;
 
+  /*
+   * Creation date as  as Unix timestamp.
+   */
+  createdAt?: number | undefined;
+
+  /*
+   * Last modified date as  as Unix timestamp.
+   */
+  lastModifiedAt?: number | undefined;
+
+  /*
+   * Last modified date (UTC Format).
+   */
+  _lastModifiedDate?: string | undefined;
+
   /**
    * An ObjectId managed by Meadowlark transactions for read locking. Optional because it does not need to be
    * set in code. See https://www.mongodb.com/blog/post/how-to-select--for-update-inside-mongodb-transactions
@@ -117,6 +132,8 @@ export function meadowlarkDocumentFrom(
   edfiDoc: object,
   validate: boolean,
   createdBy: string,
+  createdAt: number,
+  lastModifiedAt: number,
 ): MeadowlarkDocument {
   const aliasIds: string[] = [meadowlarkId];
   if (documentInfo.superclassInfo != null) {
@@ -136,5 +153,7 @@ export function meadowlarkDocumentFrom(
     outboundRefs: referencedDocumentIdsFrom(documentInfo),
     validated: validate,
     createdBy,
+    createdAt,
+    lastModifiedAt,
   };
 }

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Db.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Db.ts
@@ -112,7 +112,7 @@ export const onlyReturnId = (session: ClientSession): FindOptions => ({ projecti
 
 // MongoDB FindOption to return only the indexed documentUuid field, making this a covered query (MongoDB will optimize)
 export const onlyReturnDocumentUuid = (session: ClientSession): FindOptions => ({
-  projection: { documentUuid: 1 },
+  projection: { documentUuid: 1, createdAt: 1 },
   session,
 });
 

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Get.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Get.ts
@@ -20,7 +20,11 @@ export async function getDocumentById({ documentUuid, traceId }: GetRequest, cli
     const result: WithId<MeadowlarkDocument> | null = await mongoCollection.findOne({ documentUuid });
     if (result === null) return { response: 'GET_FAILURE_NOT_EXISTS', document: {} };
     // eslint-disable-next-line no-underscore-dangle
-    return { response: 'GET_SUCCESS', document: { id: documentUuid, ...result.edfiDoc } };
+    const documentLastModifiedDate: string = result.lastModifiedAt ? new Date(result.lastModifiedAt).toISOString() : '';
+    return {
+      response: 'GET_SUCCESS',
+      document: { id: documentUuid, ...result.edfiDoc, _lastModifiedDate: documentLastModifiedDate },
+    };
   } catch (e) {
     Logger.error(`${moduleName}.getDocumentById exception`, traceId, e);
     return { response: 'UNKNOWN_FAILURE', document: {} };

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Get.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Get.ts
@@ -20,7 +20,9 @@ export async function getDocumentById({ documentUuid, traceId }: GetRequest, cli
     const result: WithId<MeadowlarkDocument> | null = await mongoCollection.findOne({ documentUuid });
     if (result === null) return { response: 'GET_FAILURE_NOT_EXISTS', document: {} };
     // eslint-disable-next-line no-underscore-dangle
-    const documentLastModifiedDate: string = result.lastModifiedAt ? new Date(result.lastModifiedAt).toISOString() : '';
+    const documentLastModifiedDate: string | null = result.lastModifiedAt
+      ? new Date(result.lastModifiedAt).toISOString()
+      : null;
     return {
       response: 'GET_SUCCESS',
       document: { id: documentUuid, ...result.edfiDoc, _lastModifiedDate: documentLastModifiedDate },

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Update.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Update.ts
@@ -10,7 +10,7 @@ import { Logger, Config } from '@edfi/meadowlark-utilities';
 import { Collection, ClientSession, MongoClient, WithId } from 'mongodb';
 import retry from 'async-retry';
 import { MeadowlarkDocument, meadowlarkDocumentFrom } from '../model/MeadowlarkDocument';
-import { getDocumentCollection, limitFive, onlyReturnDocumentUuid, onlyReturnId, writeLockReferencedDocuments } from './Db';
+import { getDocumentCollection, limitFive, onlyReturnId, writeLockReferencedDocuments } from './Db';
 import { deleteDocumentByIdTransaction } from './Delete';
 import { onlyDocumentsReferencing, validateReferences } from './ReferenceValidation';
 import { upsertDocumentTransaction } from './Upsert';
@@ -92,12 +92,25 @@ async function tryUpdateByReplacement(
   session: ClientSession,
 ): Promise<UpdateResult | null> {
   // Try to update - for a matching documentUuid and matching identity (via meadowlarkId)
-  const { acknowledged, matchedCount } = await mongoCollection.replaceOne(
+  const { acknowledged, matchedCount } = await mongoCollection.updateOne(
     {
       _id: meadowlarkId,
       documentUuid,
     },
-    document,
+    {
+      $set: {
+        documentIdentity: document.documentIdentity,
+        projectName: document.projectName,
+        resourceName: document.resourceName,
+        resourceVersion: document.resourceVersion,
+        isDescriptor: document.isDescriptor,
+        edfiDoc: document.edfiDoc,
+        aliasIds: document.aliasIds,
+        outboundRefs: document.outboundRefs,
+        validated: document.validated,
+        lastModifiedAt: document.lastModifiedAt,
+      },
+    },
     {
       session,
     },
@@ -281,11 +294,6 @@ async function updateDocumentByIdTransaction(
       return invalidReferenceResult;
     }
   }
-  // Get createdAt from the document.
-  const existingDocument: WithId<MeadowlarkDocument> | null = await mongoCollection.findOne(
-    { _id: meadowlarkId },
-    onlyReturnDocumentUuid(session),
-  );
   const document: MeadowlarkDocument = meadowlarkDocumentFrom(
     resourceInfo,
     documentInfo,
@@ -294,7 +302,7 @@ async function updateDocumentByIdTransaction(
     edfiDoc,
     validateDocumentReferencesExist,
     security.clientId,
-    existingDocument?.createdAt ?? Date.now(),
+    Date.now(),
     lastModifiedAt,
   );
   if (resourceInfo.allowIdentityUpdates) {

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Upsert.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Upsert.ts
@@ -36,7 +36,10 @@ export async function upsertDocumentTransaction(
 
   // the documentUuid of the existing document if this is an update, or a new one if this is an insert
   const documentUuid: DocumentUuid | null = existingDocument?.documentUuid ?? generateDocumentUuid();
-
+  // Unix timestamp
+  const createdAt: number = existingDocument?.createdAt ?? Date.now();
+  // last modified date as an Unix timestamp.
+  const lastModifiedAt: number = Date.now();
   // Check whether this is an insert or update
   const isInsert: boolean = existingDocument == null;
 
@@ -116,6 +119,8 @@ export async function upsertDocumentTransaction(
       edfiDoc,
       validateDocumentReferencesExist,
       security.clientId,
+      createdAt,
+      lastModifiedAt,
     );
 
   await writeLockReferencedDocuments(mongoCollection, document.outboundRefs, session);

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/locking/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/locking/Delete.test.ts
@@ -92,6 +92,8 @@ const academicWeekDocument: MeadowlarkDocument = meadowlarkDocumentFrom(
   {},
   true,
   '',
+  Date.now(),
+  Date.now(),
 );
 
 describe('given a delete concurrent with an insert referencing the to-be-deleted document - using read lock scheme', () => {

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/model/MeadowlarkDocument.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/model/MeadowlarkDocument.test.ts
@@ -32,6 +32,8 @@ describe('given non-superclass document info with no references', () => {
   const createdBy = 'createdBy';
 
   beforeAll(async () => {
+    const createdAt = new Date('2023-01-16').getTime();
+    const lastModifiedAt = new Date('2023-02-23').getTime();
     meadowlarkDocument = meadowlarkDocumentFrom(
       resourceInfo,
       documentInfo,
@@ -40,6 +42,8 @@ describe('given non-superclass document info with no references', () => {
       edfiDoc,
       validate,
       createdBy,
+      createdAt,
+      lastModifiedAt,
     );
   });
 
@@ -50,6 +54,7 @@ describe('given non-superclass document info with no references', () => {
         "aliasIds": [
           "Qw5FvPdKxAXWnGgh_UOwCVjZeWJb5MV0Gd-nQg",
         ],
+        "createdAt": 1673827200000,
         "createdBy": "createdBy",
         "documentIdentity": {
           "natural": "key",
@@ -59,6 +64,7 @@ describe('given non-superclass document info with no references', () => {
           "edfi": "doc",
         },
         "isDescriptor": false,
+        "lastModifiedAt": 1677110400000,
         "outboundRefs": [],
         "projectName": "",
         "resourceName": "School",
@@ -103,6 +109,8 @@ describe('given non-superclass document info with references', () => {
   const createdBy = 'createdBy';
 
   beforeAll(async () => {
+    const createdAt = new Date('2023-02-11').getTime();
+    const lastModifiedAt = new Date('2023-02-27').getTime();
     meadowlarkDocument = meadowlarkDocumentFrom(
       resourceInfo,
       documentInfo,
@@ -111,6 +119,8 @@ describe('given non-superclass document info with references', () => {
       edfiDoc,
       validate,
       createdBy,
+      createdAt,
+      lastModifiedAt,
     );
   });
 
@@ -143,6 +153,8 @@ describe('given superclass document info', () => {
   const createdBy = 'createdBy';
 
   beforeAll(async () => {
+    const createdAt = new Date('2023-01-21').getTime();
+    const lastModifiedAt = new Date('2023-01-31').getTime();
     meadowlarkDocument = meadowlarkDocumentFrom(
       resourceInfo,
       documentInfo,
@@ -151,6 +163,8 @@ describe('given superclass document info', () => {
       edfiDoc,
       validate,
       createdBy,
+      createdAt,
+      lastModifiedAt,
     );
   });
 

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/repository/Update.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/repository/Update.test.ts
@@ -14,18 +14,18 @@ import * as DB from '../../src/repository/Db';
 describe('given a transaction on a resource', () => {
   const retryNumberOfTimes = 2;
   let mongoClientMock = {};
-  let replaceOneMock = jest.fn();
+  let updateOneMock = jest.fn();
   const error = {
     codeName: 'WriteConflict',
   };
 
   beforeAll(() => {
-    replaceOneMock = jest.fn().mockImplementation(async () => Promise.reject(error));
+    updateOneMock = jest.fn().mockImplementation(async () => Promise.reject(error));
 
     jest.spyOn(DB, 'getDocumentCollection').mockReturnValue({
-      replaceOne: replaceOneMock,
       updateMany: jest.fn(),
       findOne: jest.fn(),
+      updateOne: updateOneMock,
     } as any);
 
     mongoClientMock = {
@@ -64,7 +64,7 @@ describe('given a transaction on a resource', () => {
       });
 
       it('should retry a number of times based on configuration', () => {
-        expect(replaceOneMock).toHaveBeenCalledTimes(retryNumberOfTimes + 1);
+        expect(updateOneMock).toHaveBeenCalledTimes(retryNumberOfTimes + 1);
       });
 
       afterAll(() => {
@@ -80,7 +80,7 @@ describe('given a transaction on a resource', () => {
       });
 
       it('should not retry', () => {
-        expect(replaceOneMock).toHaveBeenCalledTimes(1);
+        expect(updateOneMock).toHaveBeenCalledTimes(1);
       });
 
       afterAll(() => {
@@ -95,7 +95,7 @@ describe('given a transaction on a resource', () => {
       });
 
       it('should not retry', () => {
-        expect(replaceOneMock).toHaveBeenCalledTimes(1);
+        expect(updateOneMock).toHaveBeenCalledTimes(1);
       });
 
       afterAll(() => {

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/repository/Update.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/repository/Update.test.ts
@@ -25,6 +25,7 @@ describe('given a transaction on a resource', () => {
     jest.spyOn(DB, 'getDocumentCollection').mockReturnValue({
       replaceOne: replaceOneMock,
       updateMany: jest.fn(),
+      findOne: jest.fn(),
     } as any);
 
     mongoClientMock = {


### PR DESCRIPTION
- Add CreatedAt and LastModifiedDate as UNIX Timestamps
```
{
  "_id": "2_wmVcaVb7e8wDIWYsCSBJd4pR62uXOIM0F-fw",
  ...
  "createdBy": "meadowlark_verify-only_key_1",
  "createdAt": 1683304825911,
  "lastModifiedAt": 1683304850567
}
```
- Add _lastModifiedDate to mongoDb response.
```
{
    "id": "57cade80-76eb-45be-bdcd-478d2065adf1",
    "classroomIdentificationCode": "string",
    "schoolReference": {
        "schoolId": 255901107
    },
    "maximumNumberOfSeats": 28,
    "optimalNumberOfSeats": 11,
    "_lastModifiedDate": "2023-05-05T16:40:50.567Z"
}
```
- Update mongoDb tests.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Provide a brief description of your changes. Additional detail -->
<!--- should be in an associated Ed-Fi Tracker ticket (https://tracker.ed-fi.org) -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have signed all of the commits on this PR.
- [x] I have agreed to the Ed-Fi Individual Contributors' License
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
