### PR TITLE
[RND-443] Resource Id as UUID for All Resources (PostgreSQL)

### DIFF
--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/model/MeadowlarkDocument.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/model/MeadowlarkDocument.ts
@@ -5,8 +5,8 @@
 
 import {
   DocumentIdentity,
-  documentIdForDocumentReference,
-  documentIdForSuperclassInfo,
+  getMeadowlarkIdForDocumentReference,
+  getMeadowlarkIdForSuperclassInfo,
   DocumentInfo,
   DocumentReference,
   MeadowlarkId,
@@ -59,7 +59,7 @@ export interface MeadowlarkDocument extends MeadowlarkDocumentId {
    * An array of ids extracted from the ODS/API document for all externally
    * referenced documents.
    */
-  outboundRefs: string[];
+  outboundRefs: MeadowlarkId[];
 
   /**
    * An array of ids this document will satisfy when reference validation performs existence checks.
@@ -78,7 +78,7 @@ export interface MeadowlarkDocument extends MeadowlarkDocumentId {
    *          a reference from ClassPeriod to a School with schoolId=123, as well as a reference from
    *          Assessment to EducationOrganization with educationOrganizationId=123.
    */
-  aliasIds: string[];
+  aliasIds: MeadowlarkId[];
 
   /**
    * True if this document has been reference and descriptor validated.
@@ -117,10 +117,10 @@ export interface MeadowlarkDocument extends MeadowlarkDocumentId {
   lock?: any;
 }
 
-function referencedDocumentIdsFrom(documentInfo: DocumentInfo): string[] {
+function referencedDocumentIdsFrom(documentInfo: DocumentInfo): MeadowlarkId[] {
   return [
-    ...documentInfo.documentReferences.map((dr: DocumentReference) => documentIdForDocumentReference(dr)),
-    ...documentInfo.descriptorReferences.map((dr: DocumentReference) => documentIdForDocumentReference(dr)),
+    ...documentInfo.documentReferences.map((dr: DocumentReference) => getMeadowlarkIdForDocumentReference(dr)),
+    ...documentInfo.descriptorReferences.map((dr: DocumentReference) => getMeadowlarkIdForDocumentReference(dr)),
   ];
 }
 
@@ -135,9 +135,9 @@ export function meadowlarkDocumentFrom(
   createdAt: number,
   lastModifiedAt: number,
 ): MeadowlarkDocument {
-  const aliasIds: string[] = [meadowlarkId];
+  const aliasIds: MeadowlarkId[] = [meadowlarkId];
   if (documentInfo.superclassInfo != null) {
-    aliasIds.push(documentIdForSuperclassInfo(documentInfo.superclassInfo));
+    aliasIds.push(getMeadowlarkIdForSuperclassInfo(documentInfo.superclassInfo));
   }
 
   return {

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Db.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Db.ts
@@ -5,6 +5,7 @@
 
 import { Collection, MongoClient, ReadConcernLevel, W, ClientSession, ObjectId, FindOptions, ReplaceOptions } from 'mongodb';
 import { Logger, Config } from '@edfi//meadowlark-utilities';
+import { MeadowlarkId } from 'packages/meadowlark-core/dist';
 import { MeadowlarkDocument } from '../model/MeadowlarkDocument';
 import { AuthorizationDocument } from '../model/AuthorizationDocument';
 
@@ -97,11 +98,11 @@ export function getAuthorizationCollection(client: MongoClient): Collection<Auth
  */
 export async function writeLockReferencedDocuments(
   mongoCollection: Collection<MeadowlarkDocument>,
-  referencedDocumentIds: string[],
+  referencedMeadowlarkIds: MeadowlarkId[],
   session: ClientSession,
 ): Promise<void> {
   await mongoCollection.updateMany(
-    { aliasIds: { $in: referencedDocumentIds } },
+    { aliasIds: { $in: referencedMeadowlarkIds } },
     { $set: { lock: new ObjectId() } },
     { session },
   );

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Db.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Db.ts
@@ -5,7 +5,7 @@
 
 import { Collection, MongoClient, ReadConcernLevel, W, ClientSession, ObjectId, FindOptions, ReplaceOptions } from 'mongodb';
 import { Logger, Config } from '@edfi//meadowlark-utilities';
-import { MeadowlarkId } from 'packages/meadowlark-core/dist';
+import { MeadowlarkId } from '@edfi/meadowlark-core';
 import { MeadowlarkDocument } from '../model/MeadowlarkDocument';
 import { AuthorizationDocument } from '../model/AuthorizationDocument';
 

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Delete.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Delete.ts
@@ -56,7 +56,8 @@ async function checkForReferencesToDocument(
     .toArray();
 
   const blockingDocuments: BlockingDocument[] = referringDocuments.map((document) => ({
-    documentUuid: document._id,
+    documentUuid: document.documentUuid,
+    meadowlarkId: document._id,
     resourceName: document.resourceName,
     projectName: document.projectName,
     resourceVersion: document.resourceVersion,

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/ReferenceValidation.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/ReferenceValidation.ts
@@ -12,7 +12,6 @@ import {
   MeadowlarkId,
 } from '@edfi/meadowlark-core';
 import { Logger } from '@edfi/meadowlark-utilities';
-import { MeadowlarkDocument } from '../model/MeadowlarkDocument';
 import { onlyReturnAliasId, onlyReturnId } from './Db';
 
 /**
@@ -44,7 +43,7 @@ async function findReferencedMeadowlarkIdsByMeadowlarkId(
  * @returns Failure message listing out the resource name and identity of missing document references.
  */
 export function findMissingReferences(
-  refsInDb: MeadowlarkDocument[],
+  refsInDb: MeadowlarkId[],
   documentOutboundRefs: string[],
   documentReferences: DocumentReference[],
 ): MissingIdentity[] {

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/ReferenceValidation.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/ReferenceValidation.ts
@@ -13,6 +13,7 @@ import {
 } from '@edfi/meadowlark-core';
 import { Logger } from '@edfi/meadowlark-utilities';
 import { onlyReturnAliasId, onlyReturnId } from './Db';
+import { MeadowlarkDocument } from '../model/MeadowlarkDocument';
 
 /**
  * Finds whether the given reference ids are actually documents in the db. Uses the aliasIds
@@ -43,12 +44,13 @@ async function findReferencedMeadowlarkIdsByMeadowlarkId(
  * @returns Failure message listing out the resource name and identity of missing document references.
  */
 export function findMissingReferences(
-  refsInDb: MeadowlarkId[],
+  refsInDb: MeadowlarkDocument[],
   documentOutboundRefs: string[],
   documentReferences: DocumentReference[],
 ): MissingIdentity[] {
   // eslint-disable-next-line no-underscore-dangle
   const idsOfRefsInDb: MeadowlarkId[] = refsInDb.map((outRef) =>
+    // eslint-disable-next-line no-underscore-dangle
     outRef.aliasIds.length > 0 ? outRef.aliasIds[0] : outRef._id,
   );
   const outRefIdsNotInDb: string[] = R.difference(documentOutboundRefs, idsOfRefsInDb);

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Update.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Update.ts
@@ -262,7 +262,8 @@ async function checkForInvalidReferences(
     .toArray();
 
   const blockingDocuments: BlockingDocument[] = referringDocuments.map((document) => ({
-    documentUuid: document._id,
+    documentUuid: document.documentUuid,
+    meadowlarkId: document._id,
     resourceName: document.resourceName,
     projectName: document.projectName,
     resourceVersion: document.resourceVersion,

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Upsert.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Upsert.ts
@@ -66,6 +66,7 @@ export async function upsertDocumentTransaction(
         blockingDocuments: [
           {
             documentUuid: superclassAliasIdInUse.documentUuid,
+            meadowlarkId: superclassAliasIdInUse._id,
             resourceName: superclassAliasIdInUse.resourceName,
             projectName: superclassAliasIdInUse.projectName,
             resourceVersion: superclassAliasIdInUse.resourceVersion,
@@ -96,7 +97,8 @@ export async function upsertDocumentTransaction(
         .toArray();
 
       const blockingDocuments: BlockingDocument[] = referringDocuments.map((document) => ({
-        documentUuid: document._id,
+        documentUuid: document.documentUuid,
+        meadowlarkId: document._id,
         resourceName: document.resourceName,
         projectName: document.projectName,
         resourceVersion: document.resourceVersion,

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Upsert.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Upsert.ts
@@ -9,10 +9,11 @@ import { Collection, ClientSession, MongoClient, WithId } from 'mongodb';
 import {
   UpsertResult,
   UpsertRequest,
-  documentIdForSuperclassInfo,
+  getMeadowlarkIdForSuperclassInfo,
   BlockingDocument,
   DocumentUuid,
   generateDocumentUuid,
+  MeadowlarkId,
 } from '@edfi/meadowlark-core';
 import { Logger, Config } from '@edfi/meadowlark-utilities';
 import retry from 'async-retry';
@@ -45,7 +46,7 @@ export async function upsertDocumentTransaction(
 
   // If inserting a subclass, check whether the superclass identity is already claimed by a different subclass
   if (isInsert && documentInfo.superclassInfo != null) {
-    const superclassAliasId: string = documentIdForSuperclassInfo(documentInfo.superclassInfo);
+    const superclassAliasId: MeadowlarkId = getMeadowlarkIdForSuperclassInfo(documentInfo.superclassInfo);
     const superclassAliasIdInUse: WithId<MeadowlarkDocument> | null = await mongoCollection.findOne(
       {
         aliasIds: superclassAliasId,

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Delete.test.ts
@@ -142,7 +142,7 @@ describe('given the delete of a document referenced by an existing document with
     ...newDocumentInfo(),
     documentIdentity: { natural: 'delete5' },
   };
-  const referencedDocumentId = meadowlarkIdForDocumentIdentity(
+  const referencedMeadowlarkId = meadowlarkIdForDocumentIdentity(
     referencedResourceInfo,
     referencedDocumentInfo.documentIdentity,
   );
@@ -163,7 +163,7 @@ describe('given the delete of a document referenced by an existing document with
     documentIdentity: { natural: 'delete6' },
     documentReferences: [validReference],
   };
-  const documentWithReferencesId = meadowlarkIdForDocumentIdentity(
+  const documentWithReferencesMeadowlarkId = meadowlarkIdForDocumentIdentity(
     documentWithReferencesResourceInfo,
     documentWithReferencesInfo.documentIdentity,
   );
@@ -177,7 +177,7 @@ describe('given the delete of a document referenced by an existing document with
     upsertResult = await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: referencedDocumentId,
+        meadowlarkId: referencedMeadowlarkId,
         documentInfo: referencedDocumentInfo,
       },
       client,
@@ -188,7 +188,7 @@ describe('given the delete of a document referenced by an existing document with
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         documentInfo: documentWithReferencesInfo,
         validateDocumentReferencesExist: true,
       },
@@ -217,7 +217,7 @@ describe('given the delete of a document referenced by an existing document with
 
   it('should still have the referenced document in the db', async () => {
     const collection: Collection<MeadowlarkDocument> = getDocumentCollection(client);
-    const result: any = await collection.findOne({ _id: referencedDocumentId });
+    const result: any = await collection.findOne({ _id: referencedMeadowlarkId });
     expect(result.documentIdentity.natural).toBe('delete5');
   });
 });
@@ -236,7 +236,7 @@ describe('given an delete of a document with an outbound reference only, with va
     ...newDocumentInfo(),
     documentIdentity: { natural: 'delete15' },
   };
-  const referencedDocumentId = meadowlarkIdForDocumentIdentity(
+  const referencedMeadowlarkId = meadowlarkIdForDocumentIdentity(
     referencedResourceInfo,
     referencedDocumentInfo.documentIdentity,
   );
@@ -257,7 +257,7 @@ describe('given an delete of a document with an outbound reference only, with va
     documentIdentity: { natural: 'delete16' },
     documentReferences: [validReference],
   };
-  const documentWithReferencesId = meadowlarkIdForDocumentIdentity(
+  const documentWithReferencesMeadowlarkId = meadowlarkIdForDocumentIdentity(
     documentWithReferencesResourceInfo,
     documentWithReferencesInfo.documentIdentity,
   );
@@ -271,7 +271,7 @@ describe('given an delete of a document with an outbound reference only, with va
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: referencedDocumentId,
+        meadowlarkId: referencedMeadowlarkId,
         documentInfo: referencedDocumentInfo,
       },
       client,
@@ -281,7 +281,7 @@ describe('given an delete of a document with an outbound reference only, with va
     upsertResult2 = await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         documentInfo: documentWithReferencesInfo,
         validateDocumentReferencesExist: true,
       },
@@ -311,7 +311,7 @@ describe('given an delete of a document with an outbound reference only, with va
 
   it('should have deleted the document in the db', async () => {
     const collection: Collection<MeadowlarkDocument> = getDocumentCollection(client);
-    const result: any = await collection.findOne({ _id: documentWithReferencesId });
+    const result: any = await collection.findOne({ _id: documentWithReferencesMeadowlarkId });
     expect(result).toBeNull();
   });
 });
@@ -329,7 +329,7 @@ describe('given the delete of a document referenced by an existing document with
     ...newDocumentInfo(),
     documentIdentity: { natural: 'delete5' },
   };
-  const referencedDocumentId = meadowlarkIdForDocumentIdentity(
+  const referencedMeadowlarkId = meadowlarkIdForDocumentIdentity(
     referencedResourceInfo,
     referencedDocumentInfo.documentIdentity,
   );
@@ -350,7 +350,7 @@ describe('given the delete of a document referenced by an existing document with
     documentIdentity: { natural: 'delete6' },
     documentReferences: [validReference],
   };
-  const documentWithReferencesId = meadowlarkIdForDocumentIdentity(
+  const documentWithReferencesMeadowlarkId = meadowlarkIdForDocumentIdentity(
     documentWithReferencesResourceInfo,
     documentWithReferencesInfo.documentIdentity,
   );
@@ -364,7 +364,7 @@ describe('given the delete of a document referenced by an existing document with
     upsertResult = await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: referencedDocumentId,
+        meadowlarkId: referencedMeadowlarkId,
         documentInfo: referencedDocumentInfo,
       },
       client,
@@ -375,7 +375,7 @@ describe('given the delete of a document referenced by an existing document with
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         documentInfo: documentWithReferencesInfo,
         validateDocumentReferencesExist: true,
       },
@@ -404,7 +404,7 @@ describe('given the delete of a document referenced by an existing document with
 
   it('should not have the referenced document in the db', async () => {
     const collection: Collection<MeadowlarkDocument> = getDocumentCollection(client);
-    const result: any = await collection.findOne({ _id: referencedDocumentId });
+    const result: any = await collection.findOne({ _id: referencedMeadowlarkId });
     expect(result).toBeNull();
   });
 });
@@ -453,7 +453,7 @@ describe('given the delete of a subclass document referenced by an existing docu
     documentIdentity: { week: 'delete6' },
     documentReferences: [referenceAsSuperclass],
   };
-  const documentWithReferencesId = meadowlarkIdForDocumentIdentity(
+  const documentWithReferencesMeadowlarkId = meadowlarkIdForDocumentIdentity(
     documentWithReferenceResourceInfo,
     documentWithReferenceDocumentInfo.documentIdentity,
   );
@@ -477,7 +477,7 @@ describe('given the delete of a subclass document referenced by an existing docu
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         documentInfo: documentWithReferenceDocumentInfo,
         validateDocumentReferencesExist: true,
       },

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Update.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Update.test.ts
@@ -173,7 +173,7 @@ describe('given an update of a document that references a non-existent document 
     documentIdentity: { natural: 'update4' },
   };
 
-  const documentWithReferencesId = meadowlarkIdForDocumentIdentity(
+  const documentWithReferencesMeadowlarkId = meadowlarkIdForDocumentIdentity(
     documentWithReferencesResourceInfo,
     documentWithReferencesInfo.documentIdentity,
   );
@@ -194,7 +194,7 @@ describe('given an update of a document that references a non-existent document 
     upsertResult = await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         resourceInfo: documentWithReferencesResourceInfo,
         documentInfo: documentWithReferencesInfo,
         validateDocumentReferencesExist: false,
@@ -210,7 +210,7 @@ describe('given an update of a document that references a non-existent document 
       {
         ...newUpdateRequest(),
         documentUuid: upsertResult.newDocumentUuid,
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         resourceInfo: documentWithReferencesResourceInfo,
         documentInfo: documentWithReferencesInfo,
         validateDocumentReferencesExist: false,
@@ -230,7 +230,7 @@ describe('given an update of a document that references a non-existent document 
 
   it('should have updated the document with an invalid reference in the db', async () => {
     const collection: Collection<MeadowlarkDocument> = getDocumentCollection(client);
-    const result: any = await collection.findOne({ _id: documentWithReferencesId });
+    const result: any = await collection.findOne({ _id: documentWithReferencesMeadowlarkId });
     expect(result.documentIdentity.natural).toBe('update4');
     expect(result.outboundRefs).toMatchInlineSnapshot(`
       [
@@ -253,7 +253,7 @@ describe('given an update of a document that references an existing document wit
     ...newDocumentInfo(),
     documentIdentity: { natural: 'update5' },
   };
-  const referencedDocumentId = meadowlarkIdForDocumentIdentity(
+  const referencedMeadowlarkId = meadowlarkIdForDocumentIdentity(
     referencedResourceInfo,
     referencedDocumentInfo.documentIdentity,
   );
@@ -273,7 +273,7 @@ describe('given an update of a document that references an existing document wit
     ...newDocumentInfo(),
     documentIdentity: { natural: 'update6' },
   };
-  const documentWithReferencesId = meadowlarkIdForDocumentIdentity(
+  const documentWithReferencesMeadowlarkId: MeadowlarkId = meadowlarkIdForDocumentIdentity(
     documentWithReferencesResourceInfo,
     documentWithReferencesInfo.documentIdentity,
   );
@@ -287,7 +287,7 @@ describe('given an update of a document that references an existing document wit
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: referencedDocumentId,
+        meadowlarkId: referencedMeadowlarkId,
         resourceInfo: referencedResourceInfo,
         documentInfo: referencedDocumentInfo,
       },
@@ -298,7 +298,7 @@ describe('given an update of a document that references an existing document wit
     upsertResult = await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         resourceInfo: documentWithReferencesResourceInfo,
         documentInfo: documentWithReferencesInfo,
         validateDocumentReferencesExist: true,
@@ -312,7 +312,7 @@ describe('given an update of a document that references an existing document wit
     updateResult = await updateDocumentById(
       {
         ...newUpdateRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         documentUuid: upsertResult.newDocumentUuid,
         resourceInfo: documentWithReferencesResourceInfo,
         documentInfo: documentWithReferencesInfo,
@@ -333,7 +333,7 @@ describe('given an update of a document that references an existing document wit
 
   it('should have updated the document with a valid reference in the db', async () => {
     const collection: Collection<MeadowlarkDocument> = getDocumentCollection(client);
-    const result: any = await collection.findOne({ _id: documentWithReferencesId });
+    const result: any = await collection.findOne({ _id: documentWithReferencesMeadowlarkId });
     expect(result.documentIdentity.natural).toBe('update6');
     expect(result.outboundRefs).toMatchInlineSnapshot(`
       [
@@ -356,7 +356,7 @@ describe('given an update of a document with one existing and one non-existent r
     ...newDocumentInfo(),
     documentIdentity: { natural: 'update7' },
   };
-  const referencedDocumentId = meadowlarkIdForDocumentIdentity(
+  const referencedMeadowlarkId = meadowlarkIdForDocumentIdentity(
     referencedResourceInfo,
     referencedDocumentInfo.documentIdentity,
   );
@@ -383,7 +383,7 @@ describe('given an update of a document with one existing and one non-existent r
     ...newDocumentInfo(),
     documentIdentity: { natural: 'update8' },
   };
-  const documentWithReferencesId = meadowlarkIdForDocumentIdentity(
+  const documentWithReferencesMeadowlarkId = meadowlarkIdForDocumentIdentity(
     documentWithReferencesResourceInfo,
     documentWithReferencesInfo.documentIdentity,
   );
@@ -397,7 +397,7 @@ describe('given an update of a document with one existing and one non-existent r
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: referencedDocumentId,
+        meadowlarkId: referencedMeadowlarkId,
         resourceInfo: referencedResourceInfo,
         documentInfo: referencedDocumentInfo,
       },
@@ -408,7 +408,7 @@ describe('given an update of a document with one existing and one non-existent r
     upsertResult = await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         resourceInfo: documentWithReferencesResourceInfo,
         documentInfo: documentWithReferencesInfo,
         validateDocumentReferencesExist: true,
@@ -423,7 +423,7 @@ describe('given an update of a document with one existing and one non-existent r
       {
         ...newUpdateRequest(),
         documentUuid: upsertResult.newDocumentUuid,
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         resourceInfo: documentWithReferencesResourceInfo,
         documentInfo: documentWithReferencesInfo,
         validateDocumentReferencesExist: true,
@@ -456,7 +456,7 @@ describe('given an update of a document with one existing and one non-existent r
 
   it('should not have updated the document with an invalid reference in the db', async () => {
     const collection: Collection<MeadowlarkDocument> = getDocumentCollection(client);
-    const result: any = await collection.findOne({ _id: documentWithReferencesId });
+    const result: any = await collection.findOne({ _id: documentWithReferencesMeadowlarkId });
     expect(result.outboundRefs).toHaveLength(0);
   });
 });
@@ -484,7 +484,7 @@ describe('given an update of a subclass document referenced by an existing docum
     documentIdentity: { schoolId: '123' },
     superclassInfo,
   };
-  const referencedDocumentId = meadowlarkIdForDocumentIdentity(
+  const referencedMeadowlarkId = meadowlarkIdForDocumentIdentity(
     referencedResourceInfo,
     referencedDocumentInfo.documentIdentity,
   );
@@ -504,7 +504,7 @@ describe('given an update of a subclass document referenced by an existing docum
     ...newDocumentInfo(),
     documentIdentity: { week: 'update6' },
   };
-  const documentWithReferencesId = meadowlarkIdForDocumentIdentity(
+  const documentWithReferencesMeadowlarkId = meadowlarkIdForDocumentIdentity(
     documentWithReferenceResourceInfo,
     documentWithReferenceDocumentInfo.documentIdentity,
   );
@@ -518,7 +518,7 @@ describe('given an update of a subclass document referenced by an existing docum
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: referencedDocumentId,
+        meadowlarkId: referencedMeadowlarkId,
         resourceInfo: referencedResourceInfo,
         documentInfo: referencedDocumentInfo,
       },
@@ -529,7 +529,7 @@ describe('given an update of a subclass document referenced by an existing docum
     upsertResult = await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         resourceInfo: documentWithReferenceResourceInfo,
         documentInfo: documentWithReferenceDocumentInfo,
         validateDocumentReferencesExist: true,
@@ -544,7 +544,7 @@ describe('given an update of a subclass document referenced by an existing docum
       {
         ...newUpdateRequest(),
         documentUuid: upsertResult.newDocumentUuid,
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         resourceInfo: documentWithReferenceResourceInfo,
         documentInfo: documentWithReferenceDocumentInfo,
         validateDocumentReferencesExist: true,
@@ -564,7 +564,7 @@ describe('given an update of a subclass document referenced by an existing docum
 
   it('should have updated the document with a valid reference to superclass in the db', async () => {
     const collection: Collection<MeadowlarkDocument> = getDocumentCollection(client);
-    const result: any = await collection.findOne({ _id: documentWithReferencesId });
+    const result: any = await collection.findOne({ _id: documentWithReferencesMeadowlarkId });
     expect(result.outboundRefs).toMatchInlineSnapshot(`
       [
         "BS3Ub80H5FHOD2j0qzdjhJXZsGSfcZtPWaiepA",

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Upsert.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Upsert.test.ts
@@ -494,7 +494,7 @@ describe('given an upsert of a new document that references an existing document
     ...newDocumentInfo(),
     documentIdentity: { natural: 'upsert5' },
   };
-  const referencedDocumentId = meadowlarkIdForDocumentIdentity(
+  const referencedMeadowlarkId = meadowlarkIdForDocumentIdentity(
     referencedResourceInfo,
     referencedDocumentInfo.documentIdentity,
   );
@@ -529,7 +529,7 @@ describe('given an upsert of a new document that references an existing document
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: referencedDocumentId,
+        meadowlarkId: referencedMeadowlarkId,
         resourceInfo: referencedResourceInfo,
         documentInfo: referencedDocumentInfo,
       },
@@ -577,7 +577,7 @@ describe('given an upsert of a new document with one existing and one non-existe
     ...newDocumentInfo(),
     documentIdentity: { natural: 'upsert7' },
   };
-  const referencedDocumentId = meadowlarkIdForDocumentIdentity(
+  const referencedMeadowlarkId = meadowlarkIdForDocumentIdentity(
     referencedResourceInfo,
     referencedDocumentInfo.documentIdentity,
   );
@@ -619,7 +619,7 @@ describe('given an upsert of a new document with one existing and one non-existe
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: referencedDocumentId,
+        meadowlarkId: referencedMeadowlarkId,
         resourceInfo: referencedResourceInfo,
         documentInfo: referencedDocumentInfo,
       },
@@ -692,7 +692,7 @@ describe('given an upsert of a subclass document referenced by an existing docum
     documentIdentity: { schoolId: '123' },
     superclassInfo,
   };
-  const referencedDocumentId = meadowlarkIdForDocumentIdentity(
+  const referencedMeadowlarkId = meadowlarkIdForDocumentIdentity(
     referencedResourceInfo,
     referencedDocumentInfo.documentIdentity,
   );
@@ -727,7 +727,7 @@ describe('given an upsert of a subclass document referenced by an existing docum
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: referencedDocumentId,
+        meadowlarkId: referencedMeadowlarkId,
         resourceInfo: referencedResourceInfo,
         documentInfo: referencedDocumentInfo,
       },
@@ -947,7 +947,7 @@ describe('given an update of a document that references an existing document wit
     ...newDocumentInfo(),
     documentIdentity: { natural: 'upsert5' },
   };
-  const referencedDocumentId = meadowlarkIdForDocumentIdentity(
+  const referencedMeadowlarkId = meadowlarkIdForDocumentIdentity(
     referencedResourceInfo,
     referencedDocumentInfo.documentIdentity,
   );
@@ -981,7 +981,7 @@ describe('given an update of a document that references an existing document wit
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: referencedDocumentId,
+        meadowlarkId: referencedMeadowlarkId,
         resourceInfo: referencedResourceInfo,
         documentInfo: referencedDocumentInfo,
       },
@@ -1047,7 +1047,7 @@ describe('given an update of a document with one existing and one non-existent r
     ...newDocumentInfo(),
     documentIdentity: { natural: 'upsert7' },
   };
-  const referencedDocumentId = meadowlarkIdForDocumentIdentity(
+  const referencedMeadowlarkId = meadowlarkIdForDocumentIdentity(
     referencedResourceInfo,
     referencedDocumentInfo.documentIdentity,
   );
@@ -1088,7 +1088,7 @@ describe('given an update of a document with one existing and one non-existent r
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: referencedDocumentId,
+        meadowlarkId: referencedMeadowlarkId,
         resourceInfo: referencedResourceInfo,
         documentInfo: referencedDocumentInfo,
       },
@@ -1174,7 +1174,7 @@ describe('given an update of a subclass document referenced by an existing docum
     documentIdentity: { schoolId: '123' },
     superclassInfo,
   };
-  const referencedDocumentId = meadowlarkIdForDocumentIdentity(
+  const referencedMeadowlarkId = meadowlarkIdForDocumentIdentity(
     referencedResourceInfo,
     referencedDocumentInfo.documentIdentity,
   );
@@ -1208,7 +1208,7 @@ describe('given an update of a subclass document referenced by an existing docum
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: referencedDocumentId,
+        meadowlarkId: referencedMeadowlarkId,
         resourceInfo: referencedResourceInfo,
         documentInfo: referencedDocumentInfo,
       },

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/locking/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/locking/Delete.test.ts
@@ -57,7 +57,7 @@ const schoolDocumentInfo: DocumentInfo = {
   ...newDocumentInfo(),
   documentIdentity: { schoolId: '123' },
 };
-const schoolDocumentId = meadowlarkIdForDocumentIdentity(schoolResourceInfo, schoolDocumentInfo.documentIdentity);
+const schoolMeadowlarkId = meadowlarkIdForDocumentIdentity(schoolResourceInfo, schoolDocumentInfo.documentIdentity);
 
 const referenceToSchool: DocumentReference = {
   projectName: schoolResourceInfo.projectName,
@@ -79,7 +79,7 @@ const academicWeekDocumentInfo: DocumentInfo = {
 
   documentReferences: [referenceToSchool],
 };
-const academicWeekDocumentId = meadowlarkIdForDocumentIdentity(
+const academicWeekMeadowlarkId = meadowlarkIdForDocumentIdentity(
   academicWeekResourceInfo,
   academicWeekDocumentInfo.documentIdentity,
 );
@@ -88,7 +88,7 @@ const academicWeekDocument: MeadowlarkDocument = meadowlarkDocumentFrom(
   academicWeekResourceInfo,
   academicWeekDocumentInfo,
   documentUuid,
-  academicWeekDocumentId,
+  academicWeekMeadowlarkId,
   {},
   true,
   '',
@@ -107,7 +107,7 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
 
     // Insert a School document - it will be referenced by an AcademicWeek document while being deleted
     await upsertDocument(
-      { ...newUpsertRequest(), meadowlarkId: schoolDocumentId, documentInfo: schoolDocumentInfo },
+      { ...newUpsertRequest(), meadowlarkId: schoolMeadowlarkId, documentInfo: schoolDocumentInfo },
       client,
     );
 
@@ -140,7 +140,10 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
     deleteSession.startTransaction();
 
     // Get the aliasIds for the School document, used to check for references to it as School or as EducationOrganization
-    const deleteCandidate: any = await mongoCollection.findOne({ _id: schoolDocumentId }, onlyReturnAliasIds(deleteSession));
+    const deleteCandidate: any = await mongoCollection.findOne(
+      { _id: schoolMeadowlarkId },
+      onlyReturnAliasIds(deleteSession),
+    );
 
     // Check for any references to the School document
     const anyReferences = await mongoCollection.findOne(
@@ -153,7 +156,7 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
 
     // Perform the insert of AcademicWeek document, adding a reference to to to-be-deleted document
     const { upsertedCount } = await mongoCollection.replaceOne(
-      { _id: academicWeekDocumentId },
+      { _id: academicWeekMeadowlarkId },
       academicWeekDocument,
       asUpsert(upsertSession),
     );
@@ -168,7 +171,7 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
 
     // Try deleting the School document - should fail thanks to AcademicWeek's read-for-write lock
     try {
-      await mongoCollection.deleteOne({ _id: schoolDocumentId }, { session: deleteSession });
+      await mongoCollection.deleteOne({ _id: schoolMeadowlarkId }, { session: deleteSession });
     } catch (e) {
       expect(e).toMatchInlineSnapshot(
         `[MongoServerError: WriteConflict error: this operation conflicted with another operation. Please retry your operation or multi-document transaction.]`,
@@ -188,7 +191,7 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
 
   it('should have still have the School document in the db - a success', async () => {
     const collection: Collection<MeadowlarkDocument> = getDocumentCollection(client);
-    const result: any = await collection.findOne({ _id: schoolDocumentId });
+    const result: any = await collection.findOne({ _id: schoolMeadowlarkId });
     expect(result.documentIdentity.schoolId).toBe('123');
   });
 });

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/BackendFacade.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/BackendFacade.ts
@@ -26,7 +26,7 @@ import * as SecurityMiddleware from './security/SecurityMiddleware';
 export async function deleteDocumentById(request: DeleteRequest): Promise<DeleteResult> {
   const poolClient: PoolClient = await getSharedClient();
   try {
-    return Delete.deleteDocumentById(request, poolClient);
+    return Delete.deleteDocumentByDocumentUuid(request, poolClient);
   } finally {
     poolClient.release();
   }
@@ -35,7 +35,7 @@ export async function deleteDocumentById(request: DeleteRequest): Promise<Delete
 export async function getDocumentById(request: GetRequest): Promise<GetResult> {
   const poolClient: PoolClient = await getSharedClient();
   try {
-    return Get.getDocumentById(request, poolClient);
+    return Get.getDocumentByDocumentUuid(request, poolClient);
   } finally {
     poolClient.release();
   }
@@ -53,7 +53,7 @@ export async function upsertDocument(request: UpsertRequest): Promise<UpsertResu
 export async function updateDocumentById(request: UpdateRequest): Promise<UpdateResult> {
   const poolClient: PoolClient = await getSharedClient();
   try {
-    return Update.updateDocumentById(request, poolClient);
+    return Update.updateDocumentByDocumentUuid(request, poolClient);
   } finally {
     poolClient.release();
   }

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
@@ -77,8 +77,9 @@ export async function deleteDocumentByDocumentUuid(
         }
 
         const blockingDocuments: BlockingDocument[] = referringDocuments.rows.map((document) => ({
+          documentUuid: document.documentUuid,
+          meadowlarkId: document.document_id,
           resourceName: document.resource_name,
-          documentUuid: document.document_id,
           projectName: document.project_name,
           resourceVersion: document.resource_version,
         }));

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
@@ -7,7 +7,7 @@ import { Logger } from '@edfi/meadowlark-utilities';
 import type { DeleteResult, DeleteRequest, BlockingDocument, MeadowlarkId } from '@edfi/meadowlark-core';
 import type { PoolClient, QueryResult } from 'pg';
 import {
-  deleteDocumentByIdSql,
+  deleteDocumentByDocumentUuIdSql,
   deleteOutboundReferencesOfDocumentSql,
   findReferringDocumentInfoForErrorReportingSql,
   deleteAliasesForDocumentSql,
@@ -96,7 +96,7 @@ export async function deleteDocumentById(
 
     // Perform the document delete
     Logger.debug(`${moduleName}.deleteDocumentById: Deleting document meadowlarkId ${meadowlarkId}`, traceId);
-    const deleteQueryResult: QueryResult = await client.query(deleteDocumentByIdSql(documentUuid));
+    const deleteQueryResult: QueryResult = await client.query(deleteDocumentByDocumentUuIdSql(documentUuid));
 
     if (deleteQueryResult.rowCount === 0 || deleteQueryResult.rows == null) {
       await client.query('ROLLBACK');

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
@@ -11,7 +11,7 @@ import {
   deleteOutboundReferencesOfDocumentSql,
   findReferringDocumentInfoForErrorReportingSql,
   deleteAliasesForDocumentSql,
-  findReferencingDocumentIdsSql,
+  findReferencingMeadowlarkIdsSql,
   findAliasIdsForDocumentByDocumentUuidSql,
 } from './SqlHelper';
 
@@ -45,7 +45,7 @@ export async function deleteDocumentByDocumentUuid(
       const documentAliasIds: string[] = documentAliasIdsResult.rows.map((ref) => ref.alias_id);
 
       // Find any documents that reference this document, either it's own id or an alias
-      const referenceResult: QueryResult<any> = await client.query(findReferencingDocumentIdsSql(documentAliasIds));
+      const referenceResult: QueryResult<any> = await client.query(findReferencingMeadowlarkIdsSql(documentAliasIds));
 
       if (referenceResult.rows == null) {
         await client.query('ROLLBACK');

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
@@ -96,7 +96,7 @@ export async function deleteDocumentById(
 
     // Perform the document delete
     Logger.debug(`${moduleName}.deleteDocumentById: Deleting document meadowlarkId ${meadowlarkId}`, traceId);
-    const deleteQueryResult: QueryResult = await client.query(deleteDocumentByIdSql(meadowlarkId));
+    const deleteQueryResult: QueryResult = await client.query(deleteDocumentByIdSql(documentUuid));
 
     if (deleteQueryResult.rowCount === 0 || deleteQueryResult.rows == null) {
       await client.query('ROLLBACK');

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Get.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Get.ts
@@ -4,9 +4,9 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 import type { PoolClient, QueryResult } from 'pg';
-import { GetResult, GetRequest, MeadowlarkId } from '@edfi/meadowlark-core';
+import { GetResult, GetRequest } from '@edfi/meadowlark-core';
 import { Logger } from '@edfi/meadowlark-utilities';
-import { findDocumentByIdSql } from './SqlHelper';
+import { findDocumentByDocumentUuidSql } from './SqlHelper';
 
 const moduleName = 'postgresql.repository.Get';
 
@@ -14,15 +14,13 @@ export async function getDocumentByDocumentUuid(
   { documentUuid, traceId }: GetRequest,
   client: PoolClient,
 ): Promise<GetResult> {
-  // TODO *** cast to unknown is an invalid mixing of meadowlarkId and documentUuid
-  const meadowlarkId: MeadowlarkId = documentUuid as unknown as MeadowlarkId;
   try {
-    Logger.debug(`${moduleName}.getDocumentById ${meadowlarkId}`, traceId);
-    const queryResult: QueryResult = await client.query(findDocumentByIdSql(meadowlarkId));
+    Logger.debug(`${moduleName}.getDocumentById ${documentUuid}`, traceId);
+    const queryResult: QueryResult = await client.query(findDocumentByDocumentUuidSql(documentUuid));
 
     // Postgres will return an empty row set if no results are returned, if we have no rows, there is a problem
     if (queryResult.rows == null) {
-      const errorMessage = `Could not retrieve document ${meadowlarkId}
+      const errorMessage = `Could not retrieve document ${documentUuid}
       a null result set was returned, indicating system failure`;
       Logger.error(errorMessage, traceId);
       return {
@@ -40,7 +38,7 @@ export async function getDocumentByDocumentUuid(
     };
     return response;
   } catch (e) {
-    Logger.error(`${moduleName}.getDocumentById Error retrieving document ${meadowlarkId}`, traceId, e);
+    Logger.error(`${moduleName}.getDocumentById Error retrieving document ${documentUuid}`, traceId, e);
     return { response: 'UNKNOWN_FAILURE', document: [] };
   }
 }

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Get.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Get.ts
@@ -10,7 +10,10 @@ import { findDocumentByIdSql } from './SqlHelper';
 
 const moduleName = 'postgresql.repository.Get';
 
-export async function getDocumentById({ documentUuid, traceId }: GetRequest, client: PoolClient): Promise<GetResult> {
+export async function getDocumentByDocumentUuid(
+  { documentUuid, traceId }: GetRequest,
+  client: PoolClient,
+): Promise<GetResult> {
   // TODO *** cast to unknown is an invalid mixing of meadowlarkId and documentUuid
   const meadowlarkId: MeadowlarkId = documentUuid as unknown as MeadowlarkId;
   try {

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/OwnershipSecurity.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/OwnershipSecurity.ts
@@ -13,7 +13,7 @@ import {
 import { Logger } from '@edfi/meadowlark-utilities';
 import type { PoolClient, QueryResult } from 'pg';
 import { SecurityResult } from '../security/SecurityResult';
-import { findOwnershipForDocumentSql } from './SqlHelper';
+import { findOwnershipForDocumentByDocumentUuidSql } from './SqlHelper';
 
 function extractIdIfUpsert(frontendRequest: FrontendRequest): MeadowlarkId | null {
   if (frontendRequest.action !== 'upsert') return null;
@@ -53,7 +53,7 @@ export async function rejectByOwnershipSecurity(
   }
 
   try {
-    const result: QueryResult = await client.query(findOwnershipForDocumentSql(id));
+    const result: QueryResult = await client.query(findOwnershipForDocumentByDocumentUuidSql(id));
 
     if (result.rows == null) {
       Logger.error(`${functionName} Unknown Error determining access`, frontendRequest.traceId);

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/OwnershipSecurity.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/OwnershipSecurity.ts
@@ -3,26 +3,11 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-import {
-  meadowlarkIdForDocumentIdentity,
-  FrontendRequest,
-  writeRequestToLog,
-  MeadowlarkId,
-  DocumentUuid,
-} from '@edfi/meadowlark-core';
+import { FrontendRequest, writeRequestToLog, DocumentUuid } from '@edfi/meadowlark-core';
 import { Logger } from '@edfi/meadowlark-utilities';
 import type { PoolClient, QueryResult } from 'pg';
 import { SecurityResult } from '../security/SecurityResult';
 import { findOwnershipForDocumentByDocumentUuidSql } from './SqlHelper';
-
-function extractIdIfUpsert(frontendRequest: FrontendRequest): MeadowlarkId | null {
-  if (frontendRequest.action !== 'upsert') return null;
-
-  return meadowlarkIdForDocumentIdentity(
-    frontendRequest.middleware.resourceInfo,
-    frontendRequest.middleware.documentInfo.documentIdentity,
-  );
-}
 
 export async function rejectByOwnershipSecurity(
   frontendRequest: FrontendRequest,
@@ -42,10 +27,7 @@ export async function rejectByOwnershipSecurity(
     return 'NOT_APPLICABLE';
   }
 
-  let id: DocumentUuid | undefined = frontendRequest.middleware.pathComponents.documentUuid;
-
-  // TODO *** cast to unknown is an invalid mixing of meadowlarkId and documentUuid
-  if (id == null) id = extractIdIfUpsert(frontendRequest) as unknown as DocumentUuid;
+  const id: DocumentUuid | undefined = frontendRequest.middleware.pathComponents.documentUuid;
 
   if (id == null) {
     Logger.error(`${functionName} no id to secure against`, frontendRequest.traceId);

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/ReferenceValidation.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/ReferenceValidation.ts
@@ -87,7 +87,7 @@ export function findMissingReferences(
 export async function validateReferences(
   documentReferences: DocumentReference[],
   descriptorReferences: DocumentReference[],
-  outboundRefs: string[],
+  outboundRefs: MeadowlarkId[],
   client: PoolClient,
   traceId: string,
 ): Promise<MissingIdentity[]> {
@@ -100,7 +100,7 @@ export async function validateReferences(
   }
 
   // Validate descriptor references
-  const descriptorReferenceMeadowlarkIds: string[] = descriptorReferences.map((dr: DocumentReference) =>
+  const descriptorReferenceMeadowlarkIds: MeadowlarkId[] = descriptorReferences.map((dr: DocumentReference) =>
     getMeadowlarkIdForDocumentReference(dr),
   );
   const descriptorsInDb = await findReferencedMeadowlarkIdsByMeadowlarkId(descriptorReferenceMeadowlarkIds, traceId, client);

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/ReferenceValidation.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/ReferenceValidation.ts
@@ -4,7 +4,12 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 import R from 'ramda';
-import { MeadowlarkId, MissingIdentity, getMeadowlarkIdForDocumentReference, DocumentReference } from '@edfi/meadowlark-core';
+import {
+  MeadowlarkId,
+  MissingIdentity,
+  getMeadowlarkIdForDocumentReference,
+  DocumentReference,
+} from '@edfi/meadowlark-core';
 import { Logger } from '@edfi/meadowlark-utilities';
 import { PoolClient } from 'pg';
 import { validateReferenceExistenceSql } from './SqlHelper';

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/ReferenceValidation.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/ReferenceValidation.ts
@@ -4,10 +4,9 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 import R from 'ramda';
-import { MissingIdentity, documentIdForDocumentReference, DocumentReference } from '@edfi/meadowlark-core';
+import { MeadowlarkId, MissingIdentity, documentIdForDocumentReference, DocumentReference } from '@edfi/meadowlark-core';
 import { Logger } from '@edfi/meadowlark-utilities';
 import { PoolClient } from 'pg';
-import { MeadowlarkId } from 'packages/meadowlark-core/dist';
 import { validateReferenceExistenceSql } from './SqlHelper';
 
 const moduleName = 'postgresql.repository.ReferenceValidation';

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/ReferenceValidation.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/ReferenceValidation.ts
@@ -24,7 +24,7 @@ const moduleName = 'postgresql.repository.ReferenceValidation';
  * @returns The subset of the given reference ids that are actually documents in the db
  */
 async function findReferencedMeadowlarkIdsByMeadowlarkId(
-  referenceIds: string[],
+  referenceIds: MeadowlarkId[],
   traceId: string,
   client: PoolClient,
 ): Promise<string[]> {

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/ReferenceValidation.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/ReferenceValidation.ts
@@ -7,6 +7,7 @@ import R from 'ramda';
 import { MissingIdentity, documentIdForDocumentReference, DocumentReference } from '@edfi/meadowlark-core';
 import { Logger } from '@edfi/meadowlark-utilities';
 import { PoolClient } from 'pg';
+import { MeadowlarkId } from 'packages/meadowlark-core/dist';
 import { validateReferenceExistenceSql } from './SqlHelper';
 
 const moduleName = 'postgresql.repository.ReferenceValidation';
@@ -29,7 +30,7 @@ async function findReferencedDocumentIdsById(
     return [];
   }
 
-  const referenceExistenceResult = await client.query(validateReferenceExistenceSql(referenceIds));
+  const referenceExistenceResult = await client.query(validateReferenceExistenceSql(referenceIds as MeadowlarkId[]));
 
   if (referenceExistenceResult.rows == null) {
     Logger.error(`${moduleName}.findReferencedDocumentIdsById Database error parsing references`, traceId);

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
@@ -10,13 +10,13 @@ import format from 'pg-format';
 /**
  * Returns the SQL query that does a reverse lookup to find the ids of documents that reference the given ids.
  *
- * @param referencedDocumentIds the ids of the documents that are being referenced
+ * @param referencedMeadowlarkIds the ids of the documents that are being referenced
  * @returns a SQL query to find the ids of the documents referencing the given ids
  */
-export function findReferencingDocumentIdsSql(referencedDocumentIds: string[]): string {
+export function findReferencingMeadowlarkIdsSql(referencedMeadowlarkIds: string[]): string {
   return format(
     `SELECT parent_document_id FROM meadowlark.references WHERE referenced_document_id IN (%L)`,
-    referencedDocumentIds,
+    referencedMeadowlarkIds,
   );
 }
 
@@ -118,11 +118,11 @@ export function findOwnershipForDocumentSql(meadowlarkId: MeadowlarkId): string 
  * documents. This allows for checking for the existence of documents from the aliases table for deletes
  * and general reference validation.
  *
- * @param documentIds the id of the document we're checking references for
+ * @param meadowlarkIds the id of the document we're checking references for
  * @returns SQL query string to retrieve existing alias ids
  */
-export function validateReferenceExistenceSql(documentIds: MeadowlarkId[]): string {
-  return format(`SELECT alias_id FROM meadowlark.aliases WHERE alias_id IN (%L) FOR NO KEY UPDATE NOWAIT`, documentIds);
+export function validateReferenceExistenceSql(meadowlarkIds: MeadowlarkId[]): string {
+  return format(`SELECT alias_id FROM meadowlark.aliases WHERE alias_id IN (%L) FOR NO KEY UPDATE NOWAIT`, meadowlarkIds);
 }
 
 /**
@@ -130,7 +130,7 @@ export function validateReferenceExistenceSql(documentIds: MeadowlarkId[]): stri
  * documents. This allows for checking for the existence of documents from the aliases table for deletes
  * and general reference validation.
  *
- * @param documentIds the id of the document we're checking references for
+ * @param meadowlarkIds the id of the document we're checking references for
  * @returns SQL query string to retrieve existing alias ids
  */
 export function validateReferenceExistenceByDocumentUuidSql(documentUuids: DocumentUuid[]): string {
@@ -144,13 +144,13 @@ export function validateReferenceExistenceByDocumentUuidSql(documentUuids: Docum
  * Returns the SQL statement to find up to five documents that reference this document.
  * This is for error reporting when an attempt is made to delete the document.
  *
- * @param referringDocumentIds The referring documents
+ * @param referringMeadowlarkIds The referring documents
  * @returns SQL query string to retrieve the document_id and resource_name of the referring documents
  */
-export function findReferringDocumentInfoForErrorReportingSql(referringDocumentIds: MeadowlarkId[]): string {
+export function findReferringDocumentInfoForErrorReportingSql(referringMeadowlarkIds: MeadowlarkId[]): string {
   return format(
     `SELECT project_name, resource_name, resource_version, document_id FROM meadowlark.documents WHERE document_id IN (%L) LIMIT 5`,
-    referringDocumentIds,
+    referringMeadowlarkIds,
   );
 }
 
@@ -174,13 +174,13 @@ export function insertAliasSql(documentUuid: DocumentUuid, meadowlarkId: Meadowl
 /**
  * Returns the SQL statement to insert an outbound reference for a document into the references table
  * @param meadowlarkId The parent document of the reference
- * @param referencedDocumentId The document that is referenced
+ * @param referencedMeadowlarkId The document that is referenced
  * @returns SQL query string to insert reference into references table
  */
-export function insertOutboundReferencesSql(meadowlarkId: MeadowlarkId, referencedDocumentId: MeadowlarkId): string {
+export function insertOutboundReferencesSql(meadowlarkId: MeadowlarkId, referencedMeadowlarkId: MeadowlarkId): string {
   return format('INSERT INTO meadowlark.references (parent_document_id, referenced_document_id) VALUES (%L);', [
     meadowlarkId,
-    referencedDocumentId,
+    referencedMeadowlarkId,
   ]);
 }
 

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
@@ -149,7 +149,7 @@ export function validateReferenceExistenceByDocumentUuidSql(documentUuids: Docum
  */
 export function findReferringDocumentInfoForErrorReportingSql(referringMeadowlarkIds: MeadowlarkId[]): string {
   return format(
-    `SELECT project_name, resource_name, resource_version, document_id FROM meadowlark.documents WHERE document_id IN (%L) LIMIT 5`,
+    `SELECT project_name, resource_name, resource_version, document_id, document_uuid FROM meadowlark.documents WHERE document_id IN (%L) LIMIT 5`,
     referringMeadowlarkIds,
   );
 }

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
@@ -2,7 +2,7 @@
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
-import { DocumentUuid, MeadowlarkId } from 'packages/meadowlark-core';
+import { DocumentUuid, MeadowlarkId } from '@edfi/meadowlark-core';
 import format from 'pg-format';
 
 // SQL for Selects

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
@@ -46,7 +46,7 @@ export function findAliasIdsForDocumentSql(documentId: MeadowlarkId): string {
  */
 export function findAliasIdsForDocumentByDocumentUuidSql(documentUuid: DocumentUuid): string {
   return format(
-    `SELECT alias_id, aliases.document_id 
+    `SELECT alias_id, aliases.document_id
   FROM meadowlark.aliases
   INNER JOIN meadowlark.documents
   ON aliases.document_id = documents.document_id
@@ -264,18 +264,6 @@ export function deleteDocumentByDocumentUuIdSql(documentUuid: DocumentUuid): str
   return format(
     'with del as (DELETE FROM meadowlark.documents WHERE document_uuid = %L RETURNING id) SELECT COUNT(*) FROM del;',
     [documentUuid],
-  );
-}
-
-/**
- * Returns the SQL query for deleting a document from the database
- * @param documentId the document to delete from the documents table
- * @returns SQL query string to delete the document
- */
-export function deleteDocumentByIdSql(documentId: MeadowlarkId): string {
-  return format(
-    'with del as (DELETE FROM meadowlark.documents WHERE document_id = %L RETURNING id) SELECT COUNT(*) FROM del;',
-    [documentId],
   );
 }
 

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
@@ -8,8 +8,8 @@ import {
   UpdateResult,
   UpdateRequest,
   DocumentReference,
-  documentIdForDocumentReference,
-  documentIdForSuperclassInfo,
+  getMeadowlarkIdForDocumentReference,
+  getMeadowlarkIdForSuperclassInfo,
   BlockingDocument,
 } from '@edfi/meadowlark-core';
 import { Logger } from '@edfi/meadowlark-utilities';
@@ -42,7 +42,7 @@ export async function updateDocumentByDocumentUuid(updateRequest: UpdateRequest,
   let updateResult: UpdateResult = { response: 'UNKNOWN_FAILURE' };
 
   const outboundRefs: string[] = documentInfo.documentReferences.map((dr: DocumentReference) =>
-    documentIdForDocumentReference(dr),
+    getMeadowlarkIdForDocumentReference(dr),
   );
 
   try {
@@ -102,7 +102,7 @@ export async function updateDocumentByDocumentUuid(updateRequest: UpdateRequest,
     // Perform insert of alias ids
     await client.query(insertAliasSql(documentUuid, meadowlarkId, meadowlarkId));
     if (documentInfo.superclassInfo != null) {
-      const superclassAliasId: MeadowlarkId = documentIdForSuperclassInfo(documentInfo.superclassInfo) as MeadowlarkId;
+      const superclassAliasId: MeadowlarkId = getMeadowlarkIdForSuperclassInfo(documentInfo.superclassInfo) as MeadowlarkId;
       await client.query(insertAliasSql(documentUuid, meadowlarkId, superclassAliasId));
     }
 
@@ -112,7 +112,7 @@ export async function updateDocumentByDocumentUuid(updateRequest: UpdateRequest,
 
     // Adding descriptors to outboundRefs for reference checking
     const descriptorOutboundRefs = documentInfo.descriptorReferences.map((dr: DocumentReference) =>
-      documentIdForDocumentReference(dr),
+      getMeadowlarkIdForDocumentReference(dr),
     );
     outboundRefs.push(...descriptorOutboundRefs);
 

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
@@ -41,7 +41,7 @@ export async function updateDocumentByDocumentUuid(updateRequest: UpdateRequest,
   Logger.info(`${moduleName}.updateDocumentById ${documentUuid}`, traceId);
   let updateResult: UpdateResult = { response: 'UNKNOWN_FAILURE' };
 
-  const outboundRefs: string[] = documentInfo.documentReferences.map((dr: DocumentReference) =>
+  const outboundRefs: MeadowlarkId[] = documentInfo.documentReferences.map((dr: DocumentReference) =>
     getMeadowlarkIdForDocumentReference(dr),
   );
 

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
@@ -4,6 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 import {
+  MeadowlarkId,
   UpdateResult,
   UpdateRequest,
   DocumentReference,
@@ -101,7 +102,7 @@ export async function updateDocumentById(updateRequest: UpdateRequest, client: P
     // Perform insert of alias ids
     await client.query(insertAliasSql(meadowlarkId, meadowlarkId));
     if (documentInfo.superclassInfo != null) {
-      const superclassAliasId = documentIdForSuperclassInfo(documentInfo.superclassInfo);
+      const superclassAliasId: MeadowlarkId = documentIdForSuperclassInfo(documentInfo.superclassInfo) as MeadowlarkId;
       await client.query(insertAliasSql(meadowlarkId, superclassAliasId));
     }
 
@@ -122,7 +123,7 @@ export async function updateDocumentById(updateRequest: UpdateRequest, client: P
         `${moduleName}.upsertDocument: Inserting reference meadowlarkId ${ref} for document meadowlarkId ${meadowlarkId}`,
         ref,
       );
-      await client.query(insertOutboundReferencesSql(meadowlarkId, ref));
+      await client.query(insertOutboundReferencesSql(meadowlarkId, ref as MeadowlarkId));
     }
 
     await client.query('COMMIT');

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
@@ -74,7 +74,8 @@ export async function updateDocumentByDocumentUuid(updateRequest: UpdateRequest,
 
         const blockingDocuments: BlockingDocument[] = referringDocuments.rows.map((document) => ({
           resourceName: document.resource_name,
-          documentUuid: document.document_id,
+          meadowlarkId: document.document_id,
+          documentUuid: document.document_uuid,
           projectName: document.project_name,
           resourceVersion: document.resource_version,
         }));

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
@@ -26,12 +26,18 @@ import { validateReferences } from './ReferenceValidation';
 
 const moduleName = 'postgresql.repository.Update';
 
-export async function updateDocumentById(
-  { meadowlarkId, resourceInfo, documentInfo, edfiDoc, validateDocumentReferencesExist, traceId, security }: UpdateRequest,
-  client: PoolClient,
-): Promise<UpdateResult> {
-  Logger.info(`${moduleName}.updateDocumentById ${meadowlarkId}`, traceId);
-
+export async function updateDocumentById(updateRequest: UpdateRequest, client: PoolClient): Promise<UpdateResult> {
+  const {
+    meadowlarkId,
+    documentUuid,
+    resourceInfo,
+    documentInfo,
+    edfiDoc,
+    validateDocumentReferencesExist,
+    traceId,
+    security,
+  } = updateRequest;
+  Logger.info(`${moduleName}.updateDocumentById ${documentUuid}`, traceId);
   let updateResult: UpdateResult = { response: 'UNKNOWN_FAILURE' };
 
   const outboundRefs: string[] = documentInfo.documentReferences.map((dr: DocumentReference) =>
@@ -84,7 +90,7 @@ export async function updateDocumentById(
 
     // Perform the document update
     const documentSql: string = documentInsertOrUpdateSql(
-      { id: meadowlarkId, resourceInfo, documentInfo, edfiDoc, validateDocumentReferencesExist, security },
+      { id: meadowlarkId, documentUuid, resourceInfo, documentInfo, edfiDoc, validateDocumentReferencesExist, security },
       false,
     );
     const result: QueryResult = await client.query(documentSql);

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
@@ -95,9 +95,9 @@ export async function updateDocumentById(updateRequest: UpdateRequest, client: P
       false,
     );
     const result: QueryResult = await client.query(documentSql);
-
+    const deleteAliaseSql = deleteAliasesForDocumentSql(meadowlarkId);
     // Delete existing values from the aliases table
-    await client.query(deleteAliasesForDocumentSql(meadowlarkId));
+    await client.query(deleteAliaseSql);
 
     // Perform insert of alias ids
     await client.query(insertAliasSql(meadowlarkId, meadowlarkId));

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
@@ -16,7 +16,7 @@ import { Logger } from '@edfi/meadowlark-utilities';
 import type { PoolClient, QueryResult } from 'pg';
 import {
   documentInsertOrUpdateSql,
-  findAliasIdsForDocumentSql,
+  findAliasIdsForDocumentByMeadowlarkIdSql,
   deleteAliasesForDocumentSql,
   insertAliasSql,
   deleteOutboundReferencesOfDocumentSql,
@@ -48,7 +48,7 @@ export async function updateDocumentByDocumentUuid(updateRequest: UpdateRequest,
   try {
     await client.query('BEGIN');
 
-    const recordExistsResult = await client.query(findAliasIdsForDocumentSql(meadowlarkId));
+    const recordExistsResult = await client.query(findAliasIdsForDocumentByMeadowlarkIdSql(meadowlarkId));
 
     if (recordExistsResult.rowCount === 0) {
       updateResult = { response: 'UPDATE_FAILURE_NOT_EXISTS' };
@@ -100,10 +100,10 @@ export async function updateDocumentByDocumentUuid(updateRequest: UpdateRequest,
     await client.query(deleteAliaseSql);
 
     // Perform insert of alias ids
-    await client.query(insertAliasSql(meadowlarkId, meadowlarkId));
+    await client.query(insertAliasSql(documentUuid, meadowlarkId, meadowlarkId));
     if (documentInfo.superclassInfo != null) {
       const superclassAliasId: MeadowlarkId = documentIdForSuperclassInfo(documentInfo.superclassInfo) as MeadowlarkId;
-      await client.query(insertAliasSql(meadowlarkId, superclassAliasId));
+      await client.query(insertAliasSql(documentUuid, meadowlarkId, superclassAliasId));
     }
 
     // Delete existing references in references table

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
@@ -27,7 +27,7 @@ import { validateReferences } from './ReferenceValidation';
 
 const moduleName = 'postgresql.repository.Update';
 
-export async function updateDocumentById(updateRequest: UpdateRequest, client: PoolClient): Promise<UpdateResult> {
+export async function updateDocumentByDocumentUuid(updateRequest: UpdateRequest, client: PoolClient): Promise<UpdateResult> {
   const {
     meadowlarkId,
     documentUuid,

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
@@ -36,7 +36,9 @@ export async function upsertDocument(
 ): Promise<UpsertResult> {
   Logger.info(`${moduleName}.upsertDocument`, traceId);
 
-  const outboundRefs = documentInfo.documentReferences.map((dr: DocumentReference) => getMeadowlarkIdForDocumentReference(dr));
+  const outboundRefs = documentInfo.documentReferences.map((dr: DocumentReference) =>
+    getMeadowlarkIdForDocumentReference(dr),
+  );
   try {
     await client.query('BEGIN');
 
@@ -58,7 +60,9 @@ export async function upsertDocument(
           traceId,
         );
 
-        const superclassAliasId: MeadowlarkId = getMeadowlarkIdForSuperclassInfo(documentInfo.superclassInfo) as MeadowlarkId;
+        const superclassAliasId: MeadowlarkId = getMeadowlarkIdForSuperclassInfo(
+          documentInfo.superclassInfo,
+        ) as MeadowlarkId;
 
         const referringDocuments = await client.query(findReferringDocumentInfoForErrorReportingSql([superclassAliasId]));
 

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
@@ -8,8 +8,8 @@ import {
   UpsertResult,
   UpsertRequest,
   DocumentReference,
-  documentIdForDocumentReference,
-  documentIdForSuperclassInfo,
+  getMeadowlarkIdForDocumentReference,
+  getMeadowlarkIdForSuperclassInfo,
   BlockingDocument,
   generateDocumentUuid,
   DocumentUuid,
@@ -36,7 +36,7 @@ export async function upsertDocument(
 ): Promise<UpsertResult> {
   Logger.info(`${moduleName}.upsertDocument`, traceId);
 
-  const outboundRefs = documentInfo.documentReferences.map((dr: DocumentReference) => documentIdForDocumentReference(dr));
+  const outboundRefs = documentInfo.documentReferences.map((dr: DocumentReference) => getMeadowlarkIdForDocumentReference(dr));
   try {
     await client.query('BEGIN');
 
@@ -48,7 +48,7 @@ export async function upsertDocument(
     // If inserting a subclass, check whether the superclass identity is already claimed by a different subclass
     if (isInsert && documentInfo.superclassInfo != null) {
       const superclassAliasIdInUseResult = await client.query(
-        findAliasIdSql(documentIdForSuperclassInfo(documentInfo.superclassInfo) as MeadowlarkId),
+        findAliasIdSql(getMeadowlarkIdForSuperclassInfo(documentInfo.superclassInfo) as MeadowlarkId),
       );
       const superclassAliasIdInUse: boolean = superclassAliasIdInUseResult.rowCount !== 0;
 
@@ -58,7 +58,7 @@ export async function upsertDocument(
           traceId,
         );
 
-        const superclassAliasId: MeadowlarkId = documentIdForSuperclassInfo(documentInfo.superclassInfo) as MeadowlarkId;
+        const superclassAliasId: MeadowlarkId = getMeadowlarkIdForSuperclassInfo(documentInfo.superclassInfo) as MeadowlarkId;
 
         const referringDocuments = await client.query(findReferringDocumentInfoForErrorReportingSql([superclassAliasId]));
 
@@ -125,7 +125,7 @@ export async function upsertDocument(
     // Perform insert of alias ids
     await client.query(insertAliasSql(documentUuid, meadowlarkId, meadowlarkId));
     if (documentInfo.superclassInfo != null) {
-      const superclassAliasId: MeadowlarkId = documentIdForSuperclassInfo(documentInfo.superclassInfo) as MeadowlarkId;
+      const superclassAliasId: MeadowlarkId = getMeadowlarkIdForSuperclassInfo(documentInfo.superclassInfo) as MeadowlarkId;
       await client.query(insertAliasSql(documentUuid, meadowlarkId, superclassAliasId));
     }
 
@@ -135,7 +135,7 @@ export async function upsertDocument(
 
     // Adding descriptors to outboundRefs for reference checking
     const descriptorOutboundRefs = documentInfo.descriptorReferences.map((dr: DocumentReference) =>
-      documentIdForDocumentReference(dr),
+      getMeadowlarkIdForDocumentReference(dr),
     );
     outboundRefs.push(...descriptorOutboundRefs);
 

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
@@ -15,6 +15,7 @@ import {
   DocumentUuid,
 } from '@edfi/meadowlark-core';
 import { Logger } from '@edfi/meadowlark-utilities';
+import { MeadowlarkId } from 'packages/meadowlark-core/dist';
 import {
   deleteOutboundReferencesOfDocumentSql,
   documentInsertOrUpdateSql,
@@ -47,7 +48,7 @@ export async function upsertDocument(
     // If inserting a subclass, check whether the superclass identity is already claimed by a different subclass
     if (isInsert && documentInfo.superclassInfo != null) {
       const superclassAliasIdInUseResult = await client.query(
-        findAliasIdSql(documentIdForSuperclassInfo(documentInfo.superclassInfo)),
+        findAliasIdSql(documentIdForSuperclassInfo(documentInfo.superclassInfo) as MeadowlarkId),
       );
       const superclassAliasIdInUse: boolean = superclassAliasIdInUseResult.rowCount !== 0;
 
@@ -57,7 +58,7 @@ export async function upsertDocument(
           traceId,
         );
 
-        const superclassAliasId: string = documentIdForSuperclassInfo(documentInfo.superclassInfo);
+        const superclassAliasId: MeadowlarkId = documentIdForSuperclassInfo(documentInfo.superclassInfo) as MeadowlarkId;
 
         const referringDocuments = await client.query(findReferringDocumentInfoForErrorReportingSql([superclassAliasId]));
 
@@ -125,7 +126,7 @@ export async function upsertDocument(
     // Perform insert of alias ids
     await client.query(insertAliasSql(meadowlarkId, meadowlarkId));
     if (documentInfo.superclassInfo != null) {
-      const superclassAliasId = documentIdForSuperclassInfo(documentInfo.superclassInfo);
+      const superclassAliasId: MeadowlarkId = documentIdForSuperclassInfo(documentInfo.superclassInfo) as MeadowlarkId;
       await client.query(insertAliasSql(meadowlarkId, superclassAliasId));
     }
 
@@ -143,7 +144,7 @@ export async function upsertDocument(
     // eslint-disable-next-line no-restricted-syntax
     for (const ref of outboundRefs) {
       Logger.debug(`post${moduleName}.upsertDocument: Inserting reference id ${ref} for document id ${meadowlarkId}`, ref);
-      await client.query(insertOutboundReferencesSql(meadowlarkId, ref));
+      await client.query(insertOutboundReferencesSql(meadowlarkId, ref as MeadowlarkId));
     }
 
     await client.query('COMMIT');

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
@@ -69,6 +69,7 @@ export async function upsertDocument(
         const blockingDocuments: BlockingDocument[] = referringDocuments.rows.map((document) => ({
           resourceName: document.resource_name,
           documentUuid: document.document_uuid,
+          meadowlarkId: document.document_id,
           projectName: document.project_name,
           resourceVersion: document.resource_version,
         }));
@@ -106,7 +107,8 @@ export async function upsertDocument(
 
         const blockingDocuments: BlockingDocument[] = referringDocuments.rows.map((document) => ({
           resourceName: document.resource_name,
-          documentUuid: document.document_id,
+          documentUuid: document.document_uuid,
+          meadowlarkId: document.document_id,
           projectName: document.project_name,
           resourceVersion: document.resource_version,
         }));

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
@@ -44,7 +44,7 @@ export async function upsertDocument(
     const documentExistsResult: QueryResult = await client.query(findDocumentByIdSql(meadowlarkId));
     const isInsert: boolean = documentExistsResult.rowCount === 0;
     const documentUuid: DocumentUuid =
-      documentExistsResult.rowCount > 0 ? documentExistsResult.rows[0].fields[0] : generateDocumentUuid();
+      documentExistsResult.rowCount > 0 ? documentExistsResult.rows[0].document_uuid : generateDocumentUuid();
     // If inserting a subclass, check whether the superclass identity is already claimed by a different subclass
     if (isInsert && documentInfo.superclassInfo != null) {
       const superclassAliasIdInUseResult = await client.query(
@@ -118,11 +118,10 @@ export async function upsertDocument(
 
     // Perform the document upsert
     Logger.debug(`${moduleName}.upsertDocument: Upserting document meadowlarkId ${meadowlarkId}`, traceId);
-    await client.query(documentUpsertSql);
-
+    const insertResult = await client.query(documentUpsertSql);
+    Logger.debug(`${moduleName}.upsertDocument: insert ${insertResult}`, traceId);
     // Delete existing values from the aliases table
     await client.query(deleteAliasesForDocumentSql(meadowlarkId));
-
     // Perform insert of alias ids
     await client.query(insertAliasSql(meadowlarkId, meadowlarkId));
     if (documentInfo.superclassInfo != null) {

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
@@ -24,7 +24,7 @@ import {
   insertAliasSql,
   findAliasIdSql,
   findReferringDocumentInfoForErrorReportingSql,
-  findDocumentByIdSql,
+  findDocumentByMeadowlarkIdSql,
 } from './SqlHelper';
 import { validateReferences } from './ReferenceValidation';
 
@@ -41,7 +41,7 @@ export async function upsertDocument(
     await client.query('BEGIN');
 
     // Check whether this is an insert or update
-    const documentExistsResult: QueryResult = await client.query(findDocumentByIdSql(meadowlarkId));
+    const documentExistsResult: QueryResult = await client.query(findDocumentByMeadowlarkIdSql(meadowlarkId));
     const isInsert: boolean = documentExistsResult.rowCount === 0;
     const documentUuid: DocumentUuid =
       documentExistsResult.rowCount > 0 ? documentExistsResult.rows[0].document_uuid : generateDocumentUuid();
@@ -123,10 +123,10 @@ export async function upsertDocument(
     // Delete existing values from the aliases table
     await client.query(deleteAliasesForDocumentSql(meadowlarkId));
     // Perform insert of alias ids
-    await client.query(insertAliasSql(meadowlarkId, meadowlarkId));
+    await client.query(insertAliasSql(documentUuid, meadowlarkId, meadowlarkId));
     if (documentInfo.superclassInfo != null) {
       const superclassAliasId: MeadowlarkId = documentIdForSuperclassInfo(documentInfo.superclassInfo) as MeadowlarkId;
-      await client.query(insertAliasSql(meadowlarkId, superclassAliasId));
+      await client.query(insertAliasSql(documentUuid, meadowlarkId, superclassAliasId));
     }
 
     // Delete existing references in references table

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
@@ -13,9 +13,9 @@ import {
   BlockingDocument,
   generateDocumentUuid,
   DocumentUuid,
+  MeadowlarkId,
 } from '@edfi/meadowlark-core';
 import { Logger } from '@edfi/meadowlark-utilities';
-import { MeadowlarkId } from 'packages/meadowlark-core/dist';
 import {
   deleteOutboundReferencesOfDocumentSql,
   documentInsertOrUpdateSql,

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
@@ -25,7 +25,7 @@ import {
   UpsertResult,
 } from '@edfi/meadowlark-core';
 import type { PoolClient } from 'pg';
-import { deleteAll, retrieveReferencesByDocumentIdSql } from './TestHelper';
+import { deleteAll, retrieveReferencesByMeadowlarkIdSql } from './TestHelper';
 import { getSharedClient, resetSharedClient } from '../../src/repository/Db';
 import { deleteDocumentByDocumentUuid } from '../../src/repository/Delete';
 import { upsertDocument } from '../../src/repository/Upsert';
@@ -394,7 +394,7 @@ describe('given an delete of a document referenced by an existing document with 
   });
 
   it('should not be the parent document in the references table', async () => {
-    const docResult: any = await client.query(retrieveReferencesByDocumentIdSql(referencedDocumentId));
+    const docResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(referencedDocumentId));
     expect(docResult.rowCount).toEqual(0);
   });
 });

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
@@ -29,7 +29,7 @@ import { deleteAll, retrieveReferencesByDocumentIdSql } from './TestHelper';
 import { getSharedClient, resetSharedClient } from '../../src/repository/Db';
 import { deleteDocumentByDocumentUuid } from '../../src/repository/Delete';
 import { upsertDocument } from '../../src/repository/Upsert';
-import { findDocumentByDocumentUuidSql, findDocumentByIdSql } from '../../src/repository/SqlHelper';
+import { findDocumentByDocumentUuidSql, findDocumentByMeadowlarkIdSql } from '../../src/repository/SqlHelper';
 
 const newUpsertRequest = (): UpsertRequest => ({
   meadowlarkId: '' as MeadowlarkId,
@@ -211,7 +211,7 @@ describe('given an delete of a document referenced by an existing document with 
   });
 
   it('should still have the referenced document in the db', async () => {
-    const docResult: any = await client.query(findDocumentByIdSql(referencedDocumentId));
+    const docResult: any = await client.query(findDocumentByMeadowlarkIdSql(referencedDocumentId));
     expect(docResult.rows[0].document_identity.natural).toBe('delete5');
   });
 });
@@ -300,7 +300,7 @@ describe('given an delete of a document with an outbound reference only, with va
   });
 
   it('should have deleted the document in the db', async () => {
-    const result: any = await client.query(findDocumentByIdSql(documentWithReferencesId));
+    const result: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
 
     expect(result.rowCount).toEqual(0);
   });
@@ -389,7 +389,7 @@ describe('given an delete of a document referenced by an existing document with 
   });
 
   it('should not have the referenced document in the db', async () => {
-    const docResult: any = await client.query(findDocumentByIdSql(referencedDocumentId));
+    const docResult: any = await client.query(findDocumentByMeadowlarkIdSql(referencedDocumentId));
     expect(docResult.rowCount).toEqual(0);
   });
 
@@ -493,7 +493,7 @@ describe('given the delete of a subclass document referenced by an existing docu
   });
 
   it('should still have the referenced document in the db', async () => {
-    const result: any = await client.query(findDocumentByIdSql(referencedDocumentId));
+    const result: any = await client.query(findDocumentByMeadowlarkIdSql(referencedDocumentId));
     expect(result.rows[0].document_identity.schoolId).toBe('123');
   });
 });

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
@@ -27,7 +27,7 @@ import {
 import type { PoolClient } from 'pg';
 import { deleteAll, retrieveReferencesByDocumentIdSql } from './TestHelper';
 import { getSharedClient, resetSharedClient } from '../../src/repository/Db';
-import { deleteDocumentById } from '../../src/repository/Delete';
+import { deleteDocumentByDocumentUuid } from '../../src/repository/Delete';
 import { upsertDocument } from '../../src/repository/Upsert';
 import { findDocumentByDocumentUuidSql, findDocumentByIdSql } from '../../src/repository/SqlHelper';
 
@@ -63,7 +63,7 @@ describe('given the delete of a non-existent document', () => {
   beforeAll(async () => {
     client = await getSharedClient();
 
-    deleteResult = await deleteDocumentById(
+    deleteResult = await deleteDocumentByDocumentUuid(
       { ...newDeleteRequest(), documentUuid, resourceInfo, validateNoReferencesToDocument: false },
       client,
     );
@@ -107,7 +107,7 @@ describe('given the delete of an existing document', () => {
     const upsertResult: UpsertResult = await upsertDocument(upsertRequest, client);
     const upsertDocumentUuid: DocumentUuid =
       upsertResult.response === 'INSERT_SUCCESS' ? upsertResult?.newDocumentUuid : ('' as DocumentUuid);
-    deleteResult = await deleteDocumentById(
+    deleteResult = await deleteDocumentByDocumentUuid(
       { ...newDeleteRequest(), documentUuid: upsertDocumentUuid, resourceInfo },
       client,
     );
@@ -189,7 +189,7 @@ describe('given an delete of a document referenced by an existing document with 
     );
     const referencedDocumentUuid: DocumentUuid =
       referencedUpsertResult.response === 'INSERT_SUCCESS' ? referencedUpsertResult?.newDocumentUuid : ('' as DocumentUuid);
-    deleteResult = await deleteDocumentById(
+    deleteResult = await deleteDocumentByDocumentUuid(
       {
         ...newDeleteRequest(),
         documentUuid: referencedDocumentUuid,
@@ -278,7 +278,7 @@ describe('given an delete of a document with an outbound reference only, with va
       documentWithReferenceUpsertResult.response === 'INSERT_SUCCESS'
         ? documentWithReferenceUpsertResult?.newDocumentUuid
         : ('' as DocumentUuid);
-    deleteResult = await deleteDocumentById(
+    deleteResult = await deleteDocumentByDocumentUuid(
       {
         ...newDeleteRequest(),
         documentUuid: documentWithReferencesDocumentUuid,
@@ -367,7 +367,7 @@ describe('given an delete of a document referenced by an existing document with 
       referencedDocumentUpsertResult.response === 'INSERT_SUCCESS'
         ? referencedDocumentUpsertResult?.newDocumentUuid
         : ('' as DocumentUuid);
-    deleteResult = await deleteDocumentById(
+    deleteResult = await deleteDocumentByDocumentUuid(
       {
         ...newDeleteRequest(),
         documentUuid: referencedDocumentUuid,
@@ -471,7 +471,7 @@ describe('given the delete of a subclass document referenced by an existing docu
       referencedDocumentUuid = referencedDocumentUpsertResult.existingDocumentUuid;
     }
 
-    deleteResult = await deleteDocumentById(
+    deleteResult = await deleteDocumentByDocumentUuid(
       {
         ...newDeleteRequest(),
         documentUuid: referencedDocumentUuid,

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/OwnershipSecurity.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/OwnershipSecurity.test.ts
@@ -115,23 +115,24 @@ describe('given the getById of a document owned by the requestor', () => {
     traceId: 'traceId' as TraceId,
   };
 
-  const frontendRequest: FrontendRequest = {
-    ...newFrontendRequest(),
-    action: 'getById',
-    middleware: {
-      ...newFrontendRequestMiddleware(),
-      pathComponents: { ...newPathComponents(), documentUuid: meadowlarkId as unknown as DocumentUuid },
-      security: { authorizationStrategy, clientId },
-      validateResources: true,
-    },
-  };
-
   beforeAll(async () => {
     client = await getSharedClient();
 
     // Insert owned document
-    await upsertDocument(upsertRequest, client);
+    const upsertResult = await upsertDocument(upsertRequest, client);
 
+    const documentUuid: DocumentUuid =
+      upsertResult.response === 'INSERT_SUCCESS' ? upsertResult.newDocumentUuid : ('' as DocumentUuid);
+    const frontendRequest: FrontendRequest = {
+      ...newFrontendRequest(),
+      action: 'getById',
+      middleware: {
+        ...newFrontendRequestMiddleware(),
+        pathComponents: { ...newPathComponents(), documentUuid },
+        security: { authorizationStrategy, clientId },
+        validateResources: true,
+      },
+    };
     // Act
     result = await rejectByOwnershipSecurity(frontendRequest, client);
   });
@@ -173,22 +174,24 @@ describe('given the getById of a document not owned by the requestor', () => {
     traceId: 'traceId' as TraceId,
   };
 
-  const frontendRequest: FrontendRequest = {
-    ...newFrontendRequest(),
-    action: 'getById',
-    middleware: {
-      ...newFrontendRequestMiddleware(),
-      pathComponents: { ...newPathComponents(), documentUuid: meadowlarkId as unknown as DocumentUuid },
-      security: { authorizationStrategy, clientId: 'NotTheDocumentOwner' },
-      validateResources: true,
-    },
-  };
-
   beforeAll(async () => {
     client = await getSharedClient();
 
     // Insert non-owned document
-    await upsertDocument(upsertRequest, client);
+    const upsertResult = await upsertDocument(upsertRequest, client);
+
+    const documentUuid: DocumentUuid =
+      upsertResult.response === 'INSERT_SUCCESS' ? upsertResult.newDocumentUuid : ('' as DocumentUuid);
+    const frontendRequest: FrontendRequest = {
+      ...newFrontendRequest(),
+      action: 'getById',
+      middleware: {
+        ...newFrontendRequestMiddleware(),
+        pathComponents: { ...newPathComponents(), documentUuid },
+        security: { authorizationStrategy, clientId: 'NotTheDocumentOwner' },
+        validateResources: true,
+      },
+    };
 
     // Act
     result = await rejectByOwnershipSecurity(frontendRequest, client);

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Read.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Read.test.ts
@@ -23,7 +23,7 @@ import type { PoolClient } from 'pg';
 import { resetSharedClient, getSharedClient } from '../../src/repository/Db';
 import { deleteAll } from './TestHelper';
 import { getDocumentByDocumentUuid } from '../../src/repository/Get';
-import { findDocumentByIdSql } from '../../src/repository/SqlHelper';
+import { findDocumentByMeadowlarkIdSql } from '../../src/repository/SqlHelper';
 import { upsertDocument } from '../../src/repository/Upsert';
 
 const newGetRequest = (): GetRequest => ({
@@ -56,14 +56,12 @@ describe('given the get of a non-existent document', () => {
     documentIdentity: { natural: 'get1' },
   };
   const meadowlarkId = meadowlarkIdForDocumentIdentity(resourceInfo, documentInfo.documentIdentity);
+  const documentUuid = 'ffb6ea15-fa93-4389-89a8-1428fb617490' as DocumentUuid;
 
   beforeAll(async () => {
     client = await getSharedClient();
 
-    getResult = await getDocumentByDocumentUuid(
-      { ...newGetRequest(), documentUuid: meadowlarkId as unknown as DocumentUuid, resourceInfo },
-      client,
-    );
+    getResult = await getDocumentByDocumentUuid({ ...newGetRequest(), documentUuid, resourceInfo }, client);
   });
 
   afterAll(async () => {
@@ -73,7 +71,7 @@ describe('given the get of a non-existent document', () => {
   });
 
   it('should not exist in the db', async () => {
-    const result = await client.query(findDocumentByIdSql(meadowlarkId));
+    const result = await client.query(findDocumentByMeadowlarkIdSql(meadowlarkId));
 
     expect(result.rowCount).toBe(0);
   });
@@ -100,12 +98,18 @@ describe('given the get of an existing document', () => {
   beforeAll(async () => {
     client = await getSharedClient();
     const upsertRequest: UpsertRequest = { ...newUpsertRequest(), meadowlarkId, documentInfo, edfiDoc: { inserted: 'yes' } };
-
+    let resultDocumentUuid: DocumentUuid;
     // insert the initial version
-    await upsertDocument(upsertRequest, client);
-
+    const upsertResult = await upsertDocument(upsertRequest, client);
+    if (upsertResult.response === 'INSERT_SUCCESS') {
+      resultDocumentUuid = upsertResult.newDocumentUuid;
+    } else if (upsertResult.response === 'UPDATE_SUCCESS') {
+      resultDocumentUuid = upsertResult.existingDocumentUuid;
+    } else {
+      resultDocumentUuid = '' as DocumentUuid;
+    }
     getResult = await getDocumentByDocumentUuid(
-      { ...newGetRequest(), documentUuid: meadowlarkId as unknown as DocumentUuid, resourceInfo },
+      { ...newGetRequest(), documentUuid: resultDocumentUuid, resourceInfo },
       client,
     );
   });

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Read.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Read.test.ts
@@ -22,7 +22,7 @@ import {
 import type { PoolClient } from 'pg';
 import { resetSharedClient, getSharedClient } from '../../src/repository/Db';
 import { deleteAll } from './TestHelper';
-import { getDocumentById } from '../../src/repository/Get';
+import { getDocumentByDocumentUuid } from '../../src/repository/Get';
 import { findDocumentByIdSql } from '../../src/repository/SqlHelper';
 import { upsertDocument } from '../../src/repository/Upsert';
 
@@ -60,7 +60,7 @@ describe('given the get of a non-existent document', () => {
   beforeAll(async () => {
     client = await getSharedClient();
 
-    getResult = await getDocumentById(
+    getResult = await getDocumentByDocumentUuid(
       { ...newGetRequest(), documentUuid: meadowlarkId as unknown as DocumentUuid, resourceInfo },
       client,
     );
@@ -104,7 +104,7 @@ describe('given the get of an existing document', () => {
     // insert the initial version
     await upsertDocument(upsertRequest, client);
 
-    getResult = await getDocumentById(
+    getResult = await getDocumentByDocumentUuid(
       { ...newGetRequest(), documentUuid: meadowlarkId as unknown as DocumentUuid, resourceInfo },
       client,
     );

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/TestHelper.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/TestHelper.ts
@@ -2,6 +2,7 @@
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
+import { MeadowlarkId } from '@edfi/meadowlark-core/dist/model/BrandedTypes';
 import { PoolClient } from 'pg';
 import format from 'pg-format';
 
@@ -20,9 +21,9 @@ export const verifyAliasId = (aliasId: string): string =>
 
 /**
  * Function that produces a parametrized SQL query for retrieving the references for a given document
- * @param documentId The identifier of the document
+ * @param meadowlarkId The identifier of the document
  * @returns SQL query string to retrieve references
  */
-export function retrieveReferencesByDocumentIdSql(documentId: string): string {
-  return format('SELECT referenced_document_id FROM meadowlark.references WHERE parent_document_id=%L', [documentId]);
+export function retrieveReferencesByMeadowlarkIdSql(meadowlarkId: MeadowlarkId): string {
+  return format('SELECT referenced_document_id FROM meadowlark.references WHERE parent_document_id=%L', [meadowlarkId]);
 }

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/TestHelper.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/TestHelper.ts
@@ -2,7 +2,7 @@
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
-import { MeadowlarkId } from '@edfi/meadowlark-core/dist/model/BrandedTypes';
+import { MeadowlarkId } from '@edfi/meadowlark-core';
 import { PoolClient } from 'pg';
 import format from 'pg-format';
 

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
@@ -26,10 +26,10 @@ import {
 } from '@edfi/meadowlark-core';
 import type { PoolClient } from 'pg';
 import { resetSharedClient, getSharedClient } from '../../src/repository/Db';
-import { updateDocumentById } from '../../src/repository/Update';
+import { updateDocumentByDocumentUuid } from '../../src/repository/Update';
 import { upsertDocument } from '../../src/repository/Upsert';
 import { deleteAll, retrieveReferencesByDocumentIdSql, verifyAliasId } from './TestHelper';
-import { getDocumentById } from '../../src/repository/Get';
+import { getDocumentByDocumentUuid } from '../../src/repository/Get';
 import { findDocumentByDocumentUuidSql, findDocumentByIdSql } from '../../src/repository/SqlHelper';
 
 const documentUuid: DocumentUuid = 'feb82f3e-3685-4868-86cf-f4b91749a799' as DocumentUuid;
@@ -80,7 +80,7 @@ describe('given the update of a non-existent document', () => {
   beforeAll(async () => {
     client = await getSharedClient();
     const nonExistentDocumentUuid: DocumentUuid = 'documentUuid' as DocumentUuid;
-    updateResult = await updateDocumentById(
+    updateResult = await updateDocumentByDocumentUuid(
       {
         ...newUpdateRequest(),
         documentUuid: nonExistentDocumentUuid,
@@ -101,7 +101,7 @@ describe('given the update of a non-existent document', () => {
   });
 
   it('should not exist in the db', async () => {
-    const result: GetResult = await getDocumentById({ ...newGetRequest(), documentUuid }, client);
+    const result: GetResult = await getDocumentByDocumentUuid({ ...newGetRequest(), documentUuid }, client);
 
     expect(result.response).toBe('GET_FAILURE_NOT_EXISTS');
   });
@@ -152,7 +152,7 @@ describe('given the update of an existing document', () => {
     } else {
       resultDocumentUuid = '' as DocumentUuid;
     }
-    updateResult = await updateDocumentById(
+    updateResult = await updateDocumentByDocumentUuid(
       { ...updateRequest, documentUuid: resultDocumentUuid, edfiDoc: { changeToDoc: true } },
       client,
     );
@@ -170,7 +170,6 @@ describe('given the update of an existing document', () => {
 
   it('should have updated the document in the db', async () => {
     const result: any = await client.query(findDocumentByDocumentUuidSql(resultDocumentUuid));
-    // await getDocumentById({ ...newGetRequest(), meadowlarkId }, client);
 
     expect(result.rows[0].document_identity.natural).toBe('update2');
 
@@ -221,7 +220,7 @@ describe('given an update of a document that references a non-existent document 
       upsertResult.response === 'INSERT_SUCCESS' ? upsertResult?.newDocumentUuid : ('' as DocumentUuid);
     // Update the document with an invalid reference
     documentWithReferencesInfo.documentReferences = [invalidReference];
-    updateResult = await updateDocumentById(
+    updateResult = await updateDocumentByDocumentUuid(
       {
         ...newUpdateRequest(),
         documentUuid: upsertDocumentUuid,
@@ -326,7 +325,7 @@ describe('given an update of a document that references an existing document wit
       upsertResult.response === 'INSERT_SUCCESS' ? upsertResult?.newDocumentUuid : ('' as DocumentUuid);
     // The updated document with a valid reference
     documentWithReferencesInfo.documentReferences = [validReference];
-    updateResult = await updateDocumentById(
+    updateResult = await updateDocumentByDocumentUuid(
       {
         ...newUpdateRequest(),
         meadowlarkId: documentWithReferencesId,
@@ -436,7 +435,7 @@ describe('given an update of a document with one existing and one non-existent r
       upsertResult.response === 'INSERT_SUCCESS' ? upsertResult?.newDocumentUuid : ('' as DocumentUuid);
     // The updated document with both valid and invalid references
     documentWithReferencesInfo.documentReferences = [validReference, invalidReference];
-    updateResult = await updateDocumentById(
+    updateResult = await updateDocumentByDocumentUuid(
       {
         ...newUpdateRequest(),
         meadowlarkId: documentWithReferencesId,
@@ -556,7 +555,7 @@ describe('given an update of a subclass document referenced by an existing docum
       upsertResult.response === 'INSERT_SUCCESS' ? upsertResult?.newDocumentUuid : ('' as DocumentUuid);
     // The updated document with reference as superclass
     documentWithReferenceDocumentInfo.documentReferences = [referenceAsSuperclass];
-    updateResult = await updateDocumentById(
+    updateResult = await updateDocumentByDocumentUuid(
       {
         ...newUpdateRequest(),
         meadowlarkId: documentWithReferencesId,

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
@@ -30,7 +30,7 @@ import { updateDocumentByDocumentUuid } from '../../src/repository/Update';
 import { upsertDocument } from '../../src/repository/Upsert';
 import { deleteAll, retrieveReferencesByDocumentIdSql, verifyAliasId } from './TestHelper';
 import { getDocumentByDocumentUuid } from '../../src/repository/Get';
-import { findDocumentByDocumentUuidSql, findDocumentByIdSql } from '../../src/repository/SqlHelper';
+import { findDocumentByDocumentUuidSql, findDocumentByMeadowlarkIdSql } from '../../src/repository/SqlHelper';
 
 const documentUuid: DocumentUuid = 'feb82f3e-3685-4868-86cf-f4b91749a799' as DocumentUuid;
 let resultDocumentUuid: DocumentUuid;
@@ -244,7 +244,7 @@ describe('given an update of a document that references a non-existent document 
   });
 
   it('should have updated the document with an invalid reference in the db', async () => {
-    const docResult: any = await client.query(findDocumentByIdSql(documentWithReferencesId));
+    const docResult: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
     const refsResult: any = await client.query(retrieveReferencesByDocumentIdSql(documentWithReferencesId));
 
     const outboundRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
@@ -349,7 +349,7 @@ describe('given an update of a document that references an existing document wit
   });
 
   it('should have updated the document with a valid reference in the db', async () => {
-    const docResult: any = await client.query(findDocumentByIdSql(documentWithReferencesId));
+    const docResult: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
     const refsResult: any = await client.query(retrieveReferencesByDocumentIdSql(documentWithReferencesId));
 
     const outboundRefs = refsResult.rows.map((ref) => ref.referenced_document_id);

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
@@ -28,7 +28,7 @@ import type { PoolClient } from 'pg';
 import { resetSharedClient, getSharedClient } from '../../src/repository/Db';
 import { updateDocumentByDocumentUuid } from '../../src/repository/Update';
 import { upsertDocument } from '../../src/repository/Upsert';
-import { deleteAll, retrieveReferencesByDocumentIdSql, verifyAliasId } from './TestHelper';
+import { deleteAll, retrieveReferencesByMeadowlarkIdSql, verifyAliasId } from './TestHelper';
 import { getDocumentByDocumentUuid } from '../../src/repository/Get';
 import { findDocumentByDocumentUuidSql, findDocumentByMeadowlarkIdSql } from '../../src/repository/SqlHelper';
 
@@ -245,7 +245,7 @@ describe('given an update of a document that references a non-existent document 
 
   it('should have updated the document with an invalid reference in the db', async () => {
     const docResult: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
-    const refsResult: any = await client.query(retrieveReferencesByDocumentIdSql(documentWithReferencesId));
+    const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesId));
 
     const outboundRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
 
@@ -271,7 +271,7 @@ describe('given an update of a document that references an existing document wit
     ...newDocumentInfo(),
     documentIdentity: { natural: 'update5' },
   };
-  const referencedDocumentId = meadowlarkIdForDocumentIdentity(
+  const referencedMeadowlarkId = meadowlarkIdForDocumentIdentity(
     referencedResourceInfo,
     referencedDocumentInfo.documentIdentity,
   );
@@ -303,7 +303,7 @@ describe('given an update of a document that references an existing document wit
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: referencedDocumentId,
+        meadowlarkId: referencedMeadowlarkId,
         resourceInfo: referencedResourceInfo,
         documentInfo: referencedDocumentInfo,
       },
@@ -350,7 +350,7 @@ describe('given an update of a document that references an existing document wit
 
   it('should have updated the document with a valid reference in the db', async () => {
     const docResult: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
-    const refsResult: any = await client.query(retrieveReferencesByDocumentIdSql(documentWithReferencesId));
+    const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesId));
 
     const outboundRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
     expect(docResult.rows[0].document_identity.natural).toBe('update6');
@@ -374,7 +374,7 @@ describe('given an update of a document with one existing and one non-existent r
     ...newDocumentInfo(),
     documentIdentity: { natural: 'update7' },
   };
-  const referencedDocumentId = meadowlarkIdForDocumentIdentity(
+  const referencedMeadowlarkId = meadowlarkIdForDocumentIdentity(
     referencedResourceInfo,
     referencedDocumentInfo.documentIdentity,
   );
@@ -413,7 +413,7 @@ describe('given an update of a document with one existing and one non-existent r
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: referencedDocumentId,
+        meadowlarkId: referencedMeadowlarkId,
         resourceInfo: referencedResourceInfo,
         documentInfo: referencedDocumentInfo,
       },
@@ -474,7 +474,7 @@ describe('given an update of a document with one existing and one non-existent r
   });
 
   it('should not have updated the document with an invalid reference in the db', async () => {
-    const refsResult: any = await client.query(retrieveReferencesByDocumentIdSql(documentWithReferencesId));
+    const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesId));
 
     const outboundRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
     expect(outboundRefs).toHaveLength(0);
@@ -503,7 +503,7 @@ describe('given an update of a subclass document referenced by an existing docum
     documentIdentity: { schoolId: '123' },
     superclassInfo,
   };
-  const referencedDocumentId = meadowlarkIdForDocumentIdentity(
+  const referencedMeadowlarkId = meadowlarkIdForDocumentIdentity(
     referencedResourceInfo,
     referencedDocumentInfo.documentIdentity,
   );
@@ -534,7 +534,7 @@ describe('given an update of a subclass document referenced by an existing docum
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: referencedDocumentId,
+        meadowlarkId: referencedMeadowlarkId,
         resourceInfo: referencedResourceInfo,
         documentInfo: referencedDocumentInfo,
       },
@@ -579,7 +579,7 @@ describe('given an update of a subclass document referenced by an existing docum
   });
 
   it('should have updated the document with a valid reference to superclass in the db', async () => {
-    const result: any = await client.query(verifyAliasId(referencedDocumentId));
+    const result: any = await client.query(verifyAliasId(referencedMeadowlarkId));
     const outboundRefs = result.rows.map((row) => row.alias_id);
     expect(outboundRefs).toMatchInlineSnapshot(`
       [

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Upsert.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Upsert.test.ts
@@ -25,7 +25,7 @@ import type { PoolClient } from 'pg';
 import { getSharedClient, resetSharedClient } from '../../src/repository/Db';
 import { findDocumentByMeadowlarkIdSql, findAliasIdsForDocumentByMeadowlarkIdSql } from '../../src/repository/SqlHelper';
 import { upsertDocument } from '../../src/repository/Upsert';
-import { deleteAll, retrieveReferencesByDocumentIdSql, verifyAliasId } from './TestHelper';
+import { deleteAll, retrieveReferencesByMeadowlarkIdSql, verifyAliasId } from './TestHelper';
 
 const newUpsertRequest = (): UpsertRequest => ({
   meadowlarkId: '' as MeadowlarkId,
@@ -239,7 +239,7 @@ describe('given an upsert of a new document that references an existing document
     ...newDocumentInfo(),
     documentIdentity: { natural: 'upsert5' },
   };
-  const referencedDocumentId = meadowlarkIdForDocumentIdentity(
+  const referencedMeadowlarkId = meadowlarkIdForDocumentIdentity(
     referencedResourceInfo,
     referencedDocumentInfo.documentIdentity,
   );
@@ -272,7 +272,7 @@ describe('given an upsert of a new document that references an existing document
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: referencedDocumentId,
+        meadowlarkId: referencedMeadowlarkId,
         resourceInfo: referencedResourceInfo,
         documentInfo: referencedDocumentInfo,
       },
@@ -320,7 +320,7 @@ describe('given an upsert of a new document with one existing and one non-existe
     ...newDocumentInfo(),
     documentIdentity: { natural: 'upsert7' },
   };
-  const referencedDocumentId = meadowlarkIdForDocumentIdentity(
+  const referencedMeadowlarkId = meadowlarkIdForDocumentIdentity(
     referencedResourceInfo,
     referencedDocumentInfo.documentIdentity,
   );
@@ -360,7 +360,7 @@ describe('given an upsert of a new document with one existing and one non-existe
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: referencedDocumentId,
+        meadowlarkId: referencedMeadowlarkId,
         resourceInfo: referencedResourceInfo,
         documentInfo: referencedDocumentInfo,
       },
@@ -433,7 +433,7 @@ describe('given an upsert of a subclass document when a different subclass has t
     documentIdentity: { schoolId: '123' },
     superclassInfo,
   };
-  const existingSubclassId = meadowlarkIdForDocumentIdentity(
+  const existingSubclassMeadowlarkId = meadowlarkIdForDocumentIdentity(
     existingSubclassResourceInfo,
     existingSubclassDocumentInfo.documentIdentity,
   );
@@ -447,7 +447,7 @@ describe('given an upsert of a subclass document when a different subclass has t
     documentIdentity: { localEducationAgencyId: '123' },
     superclassInfo,
   };
-  const sameSuperclassIdentityId = meadowlarkIdForDocumentIdentity(
+  const sameSuperclassIdentityMeadowlarkId = meadowlarkIdForDocumentIdentity(
     sameSuperclassIdentityResourceInfo,
     sameSuperclassIdentityDocumentInfo.documentIdentity,
   );
@@ -459,7 +459,7 @@ describe('given an upsert of a subclass document when a different subclass has t
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: existingSubclassId,
+        meadowlarkId: existingSubclassMeadowlarkId,
         resourceInfo: existingSubclassResourceInfo,
         documentInfo: existingSubclassDocumentInfo,
       },
@@ -470,7 +470,7 @@ describe('given an upsert of a subclass document when a different subclass has t
     upsertResult = await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: sameSuperclassIdentityId,
+        meadowlarkId: sameSuperclassIdentityMeadowlarkId,
         resourceInfo: sameSuperclassIdentityResourceInfo,
         documentInfo: sameSuperclassIdentityDocumentInfo,
         validateDocumentReferencesExist: true,
@@ -493,7 +493,7 @@ describe('given an upsert of a subclass document when a different subclass has t
   });
 
   it('should not have inserted the document with the same superclass identity in the db', async () => {
-    const result: any = await client.query(findDocumentByMeadowlarkIdSql(sameSuperclassIdentityId));
+    const result: any = await client.query(findDocumentByMeadowlarkIdSql(sameSuperclassIdentityMeadowlarkId));
     expect(result.rowCount).toEqual(0);
   });
 });
@@ -566,7 +566,7 @@ describe('given an update of a document that references a non-existent document 
 
   it('should have updated the document with an invalid reference in the db', async () => {
     const docResult: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
-    const refsResult: any = await client.query(retrieveReferencesByDocumentIdSql(documentWithReferencesId));
+    const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesId));
 
     const outboundRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
     expect(docResult.rows[0].document_identity.natural).toBe('upsert4');
@@ -590,7 +590,7 @@ describe('given an update of a document that references an existing document wit
     ...newDocumentInfo(),
     documentIdentity: { natural: 'upsert5' },
   };
-  const referencedDocumentId = meadowlarkIdForDocumentIdentity(
+  const referencedMeadowlarkId = meadowlarkIdForDocumentIdentity(
     referencedResourceInfo,
     referencedDocumentInfo.documentIdentity,
   );
@@ -622,7 +622,7 @@ describe('given an update of a document that references an existing document wit
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: referencedDocumentId,
+        meadowlarkId: referencedMeadowlarkId,
         resourceInfo: referencedResourceInfo,
         documentInfo: referencedDocumentInfo,
       },
@@ -667,7 +667,7 @@ describe('given an update of a document that references an existing document wit
 
   it('should have updated the document with a valid reference in the db', async () => {
     const docResult: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
-    const refsResult: any = await client.query(retrieveReferencesByDocumentIdSql(documentWithReferencesId));
+    const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesId));
 
     const outboundRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
 
@@ -692,7 +692,7 @@ describe('given an update of a document with one existing and one non-existent r
     ...newDocumentInfo(),
     documentIdentity: { natural: 'upsert7' },
   };
-  const referencedDocumentId = meadowlarkIdForDocumentIdentity(
+  const referencedMeadowlarkId = meadowlarkIdForDocumentIdentity(
     referencedResourceInfo,
     referencedDocumentInfo.documentIdentity,
   );
@@ -731,7 +731,7 @@ describe('given an update of a document with one existing and one non-existent r
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: referencedDocumentId,
+        meadowlarkId: referencedMeadowlarkId,
         resourceInfo: referencedResourceInfo,
         documentInfo: referencedDocumentInfo,
       },
@@ -791,7 +791,7 @@ describe('given an update of a document with one existing and one non-existent r
 
   it('should not have updated the document with an invalid reference in the db', async () => {
     await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
-    const refsResult: any = await client.query(retrieveReferencesByDocumentIdSql(documentWithReferencesId));
+    const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesId));
 
     const outboundRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
 
@@ -821,7 +821,7 @@ describe('given an update of a subclass document referenced by an existing docum
     documentIdentity: { schoolId: '123' },
     superclassInfo,
   };
-  const referencedDocumentId = meadowlarkIdForDocumentIdentity(
+  const referencedMeadowlarkId = meadowlarkIdForDocumentIdentity(
     referencedResourceInfo,
     referencedDocumentInfo.documentIdentity,
   );
@@ -853,7 +853,7 @@ describe('given an update of a subclass document referenced by an existing docum
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: referencedDocumentId,
+        meadowlarkId: referencedMeadowlarkId,
         resourceInfo: referencedResourceInfo,
         documentInfo: referencedDocumentInfo,
       },
@@ -897,7 +897,7 @@ describe('given an update of a subclass document referenced by an existing docum
   });
 
   it('should have updated the document with a valid reference to superclass in the db', async () => {
-    const result: any = await client.query(verifyAliasId(referencedDocumentId));
+    const result: any = await client.query(verifyAliasId(referencedMeadowlarkId));
     const outboundRefs = result.rows.map((row) => row.alias_id);
     expect(outboundRefs).toMatchInlineSnapshot(`
       [

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Upsert.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Upsert.test.ts
@@ -23,7 +23,7 @@ import {
 } from '@edfi/meadowlark-core';
 import type { PoolClient } from 'pg';
 import { getSharedClient, resetSharedClient } from '../../src/repository/Db';
-import { findDocumentByIdSql, findAliasIdsForDocumentSql } from '../../src/repository/SqlHelper';
+import { findDocumentByMeadowlarkIdSql, findAliasIdsForDocumentByMeadowlarkIdSql } from '../../src/repository/SqlHelper';
 import { upsertDocument } from '../../src/repository/Upsert';
 import { deleteAll, retrieveReferencesByDocumentIdSql, verifyAliasId } from './TestHelper';
 
@@ -74,7 +74,7 @@ describe('given the upsert of a new document', () => {
   });
 
   it('should exist in the db', async () => {
-    const result = await client.query(findAliasIdsForDocumentSql(meadowlarkId));
+    const result = await client.query(findAliasIdsForDocumentByMeadowlarkIdSql(meadowlarkId));
 
     expect(result.rowCount).toBe(1);
   });
@@ -163,7 +163,7 @@ describe('given an upsert of an existing document that changes the edfiDoc', () 
   });
 
   it('should have the change in the db', async () => {
-    const result: any = await client.query(findDocumentByIdSql(meadowlarkId));
+    const result: any = await client.query(findDocumentByMeadowlarkIdSql(meadowlarkId));
 
     expect(result.rows[0].edfi_doc.call).toBe('two');
   });
@@ -222,7 +222,7 @@ describe('given an upsert of a new document that references a non-existent docum
   });
 
   it('should have inserted the document with an invalid reference in the db', async () => {
-    const result: any = await client.query(findDocumentByIdSql(documentWithReferencesId));
+    const result: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
     expect(result.rows[0].document_identity.natural).toBe('upsert4');
   });
 });
@@ -303,7 +303,7 @@ describe('given an upsert of a new document that references an existing document
   });
 
   it('should have inserted the document with a valid reference in the db', async () => {
-    const result: any = await client.query(findDocumentByIdSql(documentWithReferencesId));
+    const result: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
     expect(result.rows[0].document_identity.natural).toBe('upsert6');
   });
 });
@@ -406,7 +406,7 @@ describe('given an upsert of a new document with one existing and one non-existe
   });
 
   it('should not have inserted the document with an invalid reference in the db', async () => {
-    const result: any = await client.query(findDocumentByIdSql(documentWithReferencesId));
+    const result: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
     expect(result.rowCount).toEqual(0);
   });
 });
@@ -493,7 +493,7 @@ describe('given an upsert of a subclass document when a different subclass has t
   });
 
   it('should not have inserted the document with the same superclass identity in the db', async () => {
-    const result: any = await client.query(findDocumentByIdSql(sameSuperclassIdentityId));
+    const result: any = await client.query(findDocumentByMeadowlarkIdSql(sameSuperclassIdentityId));
     expect(result.rowCount).toEqual(0);
   });
 });
@@ -565,7 +565,7 @@ describe('given an update of a document that references a non-existent document 
   });
 
   it('should have updated the document with an invalid reference in the db', async () => {
-    const docResult: any = await client.query(findDocumentByIdSql(documentWithReferencesId));
+    const docResult: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
     const refsResult: any = await client.query(retrieveReferencesByDocumentIdSql(documentWithReferencesId));
 
     const outboundRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
@@ -666,7 +666,7 @@ describe('given an update of a document that references an existing document wit
   });
 
   it('should have updated the document with a valid reference in the db', async () => {
-    const docResult: any = await client.query(findDocumentByIdSql(documentWithReferencesId));
+    const docResult: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
     const refsResult: any = await client.query(retrieveReferencesByDocumentIdSql(documentWithReferencesId));
 
     const outboundRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
@@ -790,7 +790,7 @@ describe('given an update of a document with one existing and one non-existent r
   });
 
   it('should not have updated the document with an invalid reference in the db', async () => {
-    await client.query(findDocumentByIdSql(documentWithReferencesId));
+    await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
     const refsResult: any = await client.query(retrieveReferencesByDocumentIdSql(documentWithReferencesId));
 
     const outboundRefs = refsResult.rows.map((ref) => ref.referenced_document_id);

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/locking/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/locking/Delete.test.ts
@@ -14,7 +14,7 @@ import {
   NoResourceInfo,
   ResourceInfo,
   newResourceInfo,
-  documentIdForDocumentReference,
+  getMeadowlarkIdForDocumentReference,
   MeadowlarkId,
   TraceId,
   DocumentUuid,
@@ -23,7 +23,7 @@ import { PoolClient } from 'pg';
 import { getSharedClient, resetSharedClient } from '../../../src/repository/Db';
 import { validateReferences } from '../../../src/repository/ReferenceValidation';
 import {
-  findReferencingDocumentIdsSql,
+  findReferencingMeadowlarkIdsSql,
   deleteAliasesForDocumentSql,
   findDocumentByMeadowlarkIdSql,
   documentInsertOrUpdateSql,
@@ -55,7 +55,7 @@ const schoolDocumentInfo: DocumentInfo = {
   ...newDocumentInfo(),
   documentIdentity: { schoolId: '123' },
 };
-const schoolDocumentId = meadowlarkIdForDocumentIdentity(schoolResourceInfo, schoolDocumentInfo.documentIdentity);
+const schoolMeadowlarkId = meadowlarkIdForDocumentIdentity(schoolResourceInfo, schoolDocumentInfo.documentIdentity);
 
 const referenceToSchool: DocumentReference = {
   projectName: schoolResourceInfo.projectName,
@@ -77,7 +77,7 @@ const academicWeekDocumentInfo: DocumentInfo = {
 
   documentReferences: [referenceToSchool],
 };
-const academicWeekDocumentId = meadowlarkIdForDocumentIdentity(
+const academicWeekMeadowlarkId = meadowlarkIdForDocumentIdentity(
   academicWeekResourceInfo,
   academicWeekDocumentInfo.documentIdentity,
 );
@@ -92,7 +92,7 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
     let resultDocumentUuid: DocumentUuid;
     // Insert a School document - it will be referenced by an AcademicWeek document while being deleted
     const upsertResult = await upsertDocument(
-      { ...newUpsertRequest(), meadowlarkId: schoolDocumentId, documentInfo: schoolDocumentInfo },
+      { ...newUpsertRequest(), meadowlarkId: schoolMeadowlarkId, documentInfo: schoolDocumentInfo },
       insertClient,
     );
     if (upsertResult.response === 'INSERT_SUCCESS') {
@@ -108,7 +108,7 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
     // try {
     await insertClient.query('BEGIN');
     const outboundRefs = academicWeekDocumentInfo.documentReferences.map((dr: DocumentReference) =>
-      documentIdForDocumentReference(dr),
+      getMeadowlarkIdForDocumentReference(dr),
     );
 
     // Check for reference validation failures on AcademicWeek document - This will also obtain a lock on the references
@@ -133,16 +133,16 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
       // Get the alias ids for the document we're trying to delete, because the update transaction is trying
       // to use our school, this is where the code will throw a locking error. This is technically the last line
       // of code in this try block that should execute
-      const aliasIdResult = await deleteClient.query(findAliasIdsForDocumentByMeadowlarkIdSql(schoolDocumentId));
+      const aliasIdResult = await deleteClient.query(findAliasIdsForDocumentByMeadowlarkIdSql(schoolMeadowlarkId));
 
       const validDocIds = aliasIdResult.rows.map((ref) => ref.alias_id);
-      const referenceResult = await deleteClient.query(findReferencingDocumentIdsSql(validDocIds));
-      const anyReferences = referenceResult.rows.filter((ref) => ref.document_id !== schoolDocumentId);
+      const referenceResult = await deleteClient.query(findReferencingMeadowlarkIdsSql(validDocIds));
+      const anyReferences = referenceResult.rows.filter((ref) => ref.document_id !== schoolMeadowlarkId);
 
       expect(anyReferences.length).toEqual(0);
 
       await deleteClient.query(deleteDocumentByDocumentUuIdSql(resultDocumentUuid));
-      await deleteClient.query(deleteAliasesForDocumentSql(schoolDocumentId));
+      await deleteClient.query(deleteAliasesForDocumentSql(schoolMeadowlarkId));
       await deleteClient.query('COMMIT');
     } catch (e1) {
       await deleteClient.query('ROLLBACK');
@@ -152,7 +152,7 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
     // Perform the insert of AcademicWeek document, adding a reference to to to-be-deleted document
     const documentUpsertSql = documentInsertOrUpdateSql(
       {
-        id: academicWeekDocumentId,
+        id: academicWeekMeadowlarkId,
         documentUuid,
         resourceInfo: academicWeekResourceInfo,
         documentInfo: academicWeekDocumentInfo,
@@ -166,8 +166,8 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
     const insertResult = await insertClient.query(documentUpsertSql);
     // eslint-disable-next-line no-restricted-syntax
     for (const ref of outboundRefs) {
-      await insertClient.query(insertOutboundReferencesSql(academicWeekDocumentId, ref as MeadowlarkId));
-      await insertClient.query(insertAliasSql(documentUuid, academicWeekDocumentId, ref as MeadowlarkId));
+      await insertClient.query(insertOutboundReferencesSql(academicWeekMeadowlarkId, ref as MeadowlarkId));
+      await insertClient.query(insertAliasSql(documentUuid, academicWeekMeadowlarkId, ref as MeadowlarkId));
     }
 
     // **** The insert of AcademicWeek document should have been successful
@@ -188,7 +188,7 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
   });
 
   it('should have still have the School document in the db - a success', async () => {
-    const docResult: any = await insertClient.query(findDocumentByMeadowlarkIdSql(schoolDocumentId));
+    const docResult: any = await insertClient.query(findDocumentByMeadowlarkIdSql(schoolMeadowlarkId));
     expect(docResult.rows[0].document_identity.schoolId).toBe('123');
   });
 });
@@ -205,7 +205,7 @@ describe('given an insert concurrent with a delete referencing the to-be-deleted
     const upsertResult = await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: schoolDocumentId,
+        meadowlarkId: schoolMeadowlarkId,
         documentInfo: schoolDocumentInfo,
       },
       insertClient,
@@ -223,27 +223,27 @@ describe('given an insert concurrent with a delete referencing the to-be-deleted
     // Retrieve the alias ids for the school that we're trying to delete, this call will also
     // lock the school record so when we try to lock the records during the insert of the academic week
     // below it will fail
-    const aliasIdResult = await deleteClient.query(findAliasIdsForDocumentByMeadowlarkIdSql(schoolDocumentId));
+    const aliasIdResult = await deleteClient.query(findAliasIdsForDocumentByMeadowlarkIdSql(schoolMeadowlarkId));
 
     // The school is in the database
     expect(aliasIdResult.rowCount).toEqual(1);
 
     // See if there are existing references to this document
     const validDocIds = aliasIdResult.rows.map((ref) => ref.alias_id);
-    const referenceResult = await deleteClient.query(findReferencingDocumentIdsSql(validDocIds));
-    const anyReferences = referenceResult.rows.filter((ref) => ref.document_id !== schoolDocumentId);
+    const referenceResult = await deleteClient.query(findReferencingMeadowlarkIdsSql(validDocIds));
+    const anyReferences = referenceResult.rows.filter((ref) => ref.document_id !== schoolMeadowlarkId);
 
     expect(anyReferences.length).toEqual(0);
 
     // Delete the document
     await deleteClient.query(deleteDocumentByDocumentUuIdSql(resultDocumentUuid));
-    await deleteClient.query(deleteAliasesForDocumentSql(schoolDocumentId));
+    await deleteClient.query(deleteAliasesForDocumentSql(schoolMeadowlarkId));
 
     // Start the insert
     await insertClient.query('BEGIN');
 
     const outboundRefs = academicWeekDocumentInfo.documentReferences.map((dr: DocumentReference) =>
-      documentIdForDocumentReference(dr),
+      getMeadowlarkIdForDocumentReference(dr),
     );
 
     try {
@@ -263,7 +263,7 @@ describe('given an insert concurrent with a delete referencing the to-be-deleted
       const documentUuid: DocumentUuid = '9ad5c9fa-82d1-494c-8d54-6aa1457f4365' as DocumentUuid;
       const documentUpsertSql = documentInsertOrUpdateSql(
         {
-          id: academicWeekDocumentId,
+          id: academicWeekMeadowlarkId,
           documentUuid,
           resourceInfo: academicWeekResourceInfo,
           documentInfo: academicWeekDocumentInfo,
@@ -278,8 +278,8 @@ describe('given an insert concurrent with a delete referencing the to-be-deleted
       expect(insertResult.rowCount).toEqual(0);
       // eslint-disable-next-line no-restricted-syntax
       for (const ref of outboundRefs) {
-        await insertClient.query(insertOutboundReferencesSql(academicWeekDocumentId, ref as MeadowlarkId));
-        await insertClient.query(insertAliasSql(documentUuid, academicWeekDocumentId, ref as MeadowlarkId));
+        await insertClient.query(insertOutboundReferencesSql(academicWeekMeadowlarkId, ref as MeadowlarkId));
+        await insertClient.query(insertAliasSql(documentUuid, academicWeekMeadowlarkId, ref as MeadowlarkId));
       }
       await insertClient.query('COMMIT');
     } catch (e1) {
@@ -299,8 +299,8 @@ describe('given an insert concurrent with a delete referencing the to-be-deleted
   });
 
   it('should have still have the School document in the db - a success', async () => {
-    const schoolDocResult: any = await insertClient.query(findDocumentByMeadowlarkIdSql(schoolDocumentId));
-    const awDocResult: any = await insertClient.query(findDocumentByMeadowlarkIdSql(academicWeekDocumentId));
+    const schoolDocResult: any = await insertClient.query(findDocumentByMeadowlarkIdSql(schoolMeadowlarkId));
+    const awDocResult: any = await insertClient.query(findDocumentByMeadowlarkIdSql(academicWeekMeadowlarkId));
     expect(schoolDocResult.rowCount).toEqual(0);
     expect(awDocResult.rowCount).toEqual(0);
   });

--- a/Meadowlark-js/packages/meadowlark-core/src/index.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/index.ts
@@ -33,13 +33,13 @@ export { newFrontendRequest, newFrontendRequestMiddleware } from './handler/Fron
 export type { FrontendResponse } from './handler/FrontendResponse';
 export { newFrontendResponse, newFrontendResponseSuccess } from './handler/FrontendResponse';
 export { meadowlarkIdForDocumentIdentity, generateDocumentUuid } from './model/DocumentIdentity';
-export { documentIdForDocumentReference } from './model/DocumentReference';
+export { getMeadowlarkIdForDocumentReference } from './model/DocumentReference';
 export type { DocumentInfo } from './model/DocumentInfo';
 export { newDocumentInfo, NoDocumentInfo } from './model/DocumentInfo';
 export type { ResourceInfo } from './model/ResourceInfo';
 export { newResourceInfo, NoResourceInfo } from './model/ResourceInfo';
 export type { SuperclassInfo } from './model/SuperclassInfo';
-export { newSuperclassInfo, documentIdForSuperclassInfo } from './model/SuperclassInfo';
+export { newSuperclassInfo, getMeadowlarkIdForSuperclassInfo } from './model/SuperclassInfo';
 export * as PluginLoader from './plugin/PluginLoader';
 export type { MiddlewareModel } from './middleware/MiddlewareModel';
 export { doNothingMiddleware } from './middleware/DoNothingMiddleware';

--- a/Meadowlark-js/packages/meadowlark-core/src/message/BlockingDocument.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/message/BlockingDocument.ts
@@ -3,6 +3,8 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+import { DocumentUuid, MeadowlarkId } from '../model/BrandedTypes';
+
 /**
  * Information on a document that is blocking the delete of another document for referential integrity reasons
  */
@@ -10,5 +12,6 @@ export type BlockingDocument = {
   projectName: string;
   resourceVersion: string;
   resourceName: string;
-  documentUuid: string;
+  documentUuid: DocumentUuid;
+  meadowlarkId: MeadowlarkId;
 };

--- a/Meadowlark-js/packages/meadowlark-core/src/middleware/ParsePathMiddleware.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/middleware/ParsePathMiddleware.ts
@@ -4,7 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 import { writeDebugStatusToLog, writeRequestToLog } from '../Logger';
-import { isDocumentIdWellFormed, isDocumentUuidWellFormed } from '../validation/DocumentIdValidator';
+import { isMeadowlarkIdWellFormed, isDocumentUuidWellFormed } from '../validation/DocumentIdValidator';
 import type { PathComponents } from '../model/PathComponents';
 import type { DocumentUuid } from '../model/BrandedTypes';
 import type { MiddlewareModel } from './MiddlewareModel';
@@ -49,10 +49,10 @@ export async function parsePath({ frontendRequest, frontendResponse }: Middlewar
   }
 
   // TEMP: Validation is added to maintain compatibility with postgres versions.
-  // When the documentUuid is updated for postgres, the isDocumentIdWellFormed could be removed.
+  // When the documentUuid is updated for postgres, the isMeadowlarkIdWellFormed could be removed.
   // Check for properly formed document id, if there is one
   const { documentUuid } = pathComponents;
-  if (documentUuid != null && !isDocumentUuidWellFormed(documentUuid) && !isDocumentIdWellFormed(documentUuid)) {
+  if (documentUuid != null && !isDocumentUuidWellFormed(documentUuid) && !isMeadowlarkIdWellFormed(documentUuid)) {
     writeDebugStatusToLog(moduleName, frontendRequest, 'parsePath', 404, `Malformed resource id ${documentUuid}`);
     return { frontendRequest, frontendResponse: { statusCode: 404 } };
   }

--- a/Meadowlark-js/packages/meadowlark-core/src/middleware/ParsePathMiddleware.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/middleware/ParsePathMiddleware.ts
@@ -48,11 +48,8 @@ export async function parsePath({ frontendRequest, frontendResponse }: Middlewar
     return { frontendRequest, frontendResponse: { statusCode: 404 } };
   }
 
-  // TEMP: Validation is added to maintain compatibility with postgres versions.
-  // When the documentUuid is updated for postgres, the isMeadowlarkIdWellFormed could be removed.
-  // Check for properly formed document id, if there is one
   const { documentUuid } = pathComponents;
-  if (documentUuid != null && !isDocumentUuidWellFormed(documentUuid) && !isMeadowlarkIdWellFormed(documentUuid)) {
+  if (documentUuid != null && !isDocumentUuidWellFormed(documentUuid)) {
     writeDebugStatusToLog(moduleName, frontendRequest, 'parsePath', 404, `Malformed resource id ${documentUuid}`);
     return { frontendRequest, frontendResponse: { statusCode: 404 } };
   }

--- a/Meadowlark-js/packages/meadowlark-core/src/middleware/ParsePathMiddleware.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/middleware/ParsePathMiddleware.ts
@@ -4,7 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 import { writeDebugStatusToLog, writeRequestToLog } from '../Logger';
-import { isMeadowlarkIdWellFormed, isDocumentUuidWellFormed } from '../validation/DocumentIdValidator';
+import { isDocumentUuidWellFormed } from '../validation/DocumentIdValidator';
 import type { PathComponents } from '../model/PathComponents';
 import type { DocumentUuid } from '../model/BrandedTypes';
 import type { MiddlewareModel } from './MiddlewareModel';

--- a/Meadowlark-js/packages/meadowlark-core/src/model/DocumentReference.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/model/DocumentReference.ts
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+import { MeadowlarkId } from './BrandedTypes';
 import { meadowlarkIdForDocumentIdentity } from './DocumentIdentity';
 import type { DocumentIdentity } from './DocumentIdentity';
 
@@ -33,7 +34,7 @@ export type DocumentReference = {
  * Returns the id of the given DocumentReference, using the project name, resource name, resource version
  * and identity of the API document.
  */
-export function documentIdForDocumentReference(documentReference: DocumentReference): string {
+export function getMeadowlarkIdForDocumentReference(documentReference: DocumentReference): MeadowlarkId {
   return meadowlarkIdForDocumentIdentity(
     {
       projectName: documentReference.projectName,

--- a/Meadowlark-js/packages/meadowlark-core/src/model/SuperclassInfo.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/model/SuperclassInfo.ts
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+import { MeadowlarkId } from './BrandedTypes';
 import { meadowlarkIdForDocumentIdentity, NoDocumentIdentity } from './DocumentIdentity';
 import type { DocumentIdentity } from './DocumentIdentity';
 import type { BaseResourceInfo } from './ResourceInfo';
@@ -56,7 +57,7 @@ export function newSuperclassInfo(): SuperclassInfo {
  * Returns the id of the given DocumentInfo superclass, using the project name, resource name
  * and identity of the superclass document.
  */
-export function documentIdForSuperclassInfo(superclassInfo: SuperclassInfo): string {
+export function getMeadowlarkIdForSuperclassInfo(superclassInfo: SuperclassInfo): MeadowlarkId {
   const resourceInfo: BaseResourceInfo = {
     projectName: superclassInfo.projectName,
     resourceName: superclassInfo.resourceName,

--- a/Meadowlark-js/packages/meadowlark-core/src/validation/DocumentIdValidator.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/validation/DocumentIdValidator.ts
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+import { MeadowlarkId } from '../model/BrandedTypes';
 import { resourceInfoHashFrom } from '../model/DocumentIdentity';
 import type { BaseResourceInfo } from '../model/ResourceInfo';
 
@@ -19,13 +20,13 @@ export function isDocumentUuidWellFormed(documentUuid: string): boolean {
  * Document Ids are 38 character Base64Url strings. No whitespace, plus or slash allowed
  * Example valid id: 02pe_9hl1wM_jO1vdx8w7iqmhPdEsFofglvS4g
  */
-export function isDocumentIdWellFormed(documentId: string): boolean {
-  return /^[^\s/+]{38}$/g.test(documentId);
+export function isMeadowlarkIdWellFormed(meadowlarkId: string): boolean {
+  return /^[^\s/+]{38}$/g.test(meadowlarkId);
 }
 
 /**
  * Returns true if resource info hash matches resource info portion of document id
  */
-export function isDocumentIdValidForResource(documentId: string, resourceInfo: BaseResourceInfo): boolean {
-  return documentId.startsWith(resourceInfoHashFrom(resourceInfo));
+export function isMeadowlarkIdValidForResource(meadowlarkId: MeadowlarkId, resourceInfo: BaseResourceInfo): boolean {
+  return meadowlarkId.startsWith(resourceInfoHashFrom(resourceInfo));
 }

--- a/Meadowlark-js/packages/meadowlark-core/test/handler/DeleteIt.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/handler/DeleteIt.test.ts
@@ -186,7 +186,7 @@ describe('given the document to be deleted is referenced by other documents ', (
       {
         "error": {
           "blockingUris": [
-            "/v3.3b/ed-fi/resourceNames/documentId",
+            "/v3.3b/ed-fi/resourceNames/documentUuid",
           ],
           "message": "The resource cannot be deleted because it is a dependency of other documents",
         },

--- a/Meadowlark-js/packages/meadowlark-core/test/handler/DeleteIt.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/handler/DeleteIt.test.ts
@@ -9,7 +9,7 @@ import { FrontendResponse } from '../../src/handler/FrontendResponse';
 import { FrontendRequest, newFrontendRequest, newFrontendRequestMiddleware } from '../../src/handler/FrontendRequest';
 import { NoDocumentStorePlugin } from '../../src/plugin/backend/NoDocumentStorePlugin';
 import { BlockingDocument } from '../../src/message/BlockingDocument';
-import { DocumentUuid } from '../../src/model/BrandedTypes';
+import { DocumentUuid, MeadowlarkId } from '../../src/model/BrandedTypes';
 
 const frontendRequest: FrontendRequest = {
   ...newFrontendRequest(),
@@ -153,7 +153,8 @@ describe('given the document to be deleted is referenced by other documents ', (
   let mockDocumentStore: any;
   const expectedBlockingDocument: BlockingDocument = {
     resourceName: 'resourceName',
-    documentUuid: 'documentUuid',
+    documentUuid: 'documentUuid' as DocumentUuid,
+    meadowlarkId: 'meadowlarkId' as MeadowlarkId,
     projectName: 'Ed-Fi',
     resourceVersion: '3.3.1-b',
   };

--- a/Meadowlark-js/packages/meadowlark-core/test/handler/DeleteIt.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/handler/DeleteIt.test.ts
@@ -153,7 +153,7 @@ describe('given the document to be deleted is referenced by other documents ', (
   let mockDocumentStore: any;
   const expectedBlockingDocument: BlockingDocument = {
     resourceName: 'resourceName',
-    documentUuid: 'documentId',
+    documentUuid: 'documentUuid',
     projectName: 'Ed-Fi',
     resourceVersion: '3.3.1-b',
   };

--- a/Meadowlark-js/packages/meadowlark-core/test/handler/Update.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/handler/Update.test.ts
@@ -63,7 +63,7 @@ describe('given the new document has an invalid reference ', () => {
   let mockDocumentStore: any;
   const expectedBlockingDocument: BlockingDocument = {
     resourceName: 'resourceName',
-    documentUuid: 'documentId',
+    documentUuid: 'documentUuid',
     projectName: 'Ed-Fi',
     resourceVersion: '3.3.1-b',
   };

--- a/Meadowlark-js/packages/meadowlark-core/test/handler/Update.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/handler/Update.test.ts
@@ -9,8 +9,7 @@ import { FrontendResponse } from '../../src/handler/FrontendResponse';
 import { FrontendRequest, newFrontendRequest, newFrontendRequestMiddleware } from '../../src/handler/FrontendRequest';
 import { NoDocumentStorePlugin } from '../../src/plugin/backend/NoDocumentStorePlugin';
 import { BlockingDocument } from '../../src/message/BlockingDocument';
-import { DocumentUuid } from '../../src/model/BrandedTypes';
-import { MeadowlarkId } from '../../dist/model/BrandedTypes';
+import { DocumentUuid, MeadowlarkId } from '../../src/model/BrandedTypes';
 
 const documentUuid = '2edb604f-eab0-412c-a242-508d6529214d' as DocumentUuid;
 const frontendRequest: FrontendRequest = {

--- a/Meadowlark-js/packages/meadowlark-core/test/handler/Update.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/handler/Update.test.ts
@@ -100,7 +100,7 @@ describe('given the new document has an invalid reference ', () => {
     expect(response.body).toMatchInlineSnapshot(`
     {
       "blockingUris": [
-        "/v3.3b/ed-fi/resourceNames/documentId",
+        "/v3.3b/ed-fi/resourceNames/documentUuid",
       ],
       "error": "this is the message",
     }

--- a/Meadowlark-js/packages/meadowlark-core/test/handler/Update.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/handler/Update.test.ts
@@ -10,6 +10,7 @@ import { FrontendRequest, newFrontendRequest, newFrontendRequestMiddleware } fro
 import { NoDocumentStorePlugin } from '../../src/plugin/backend/NoDocumentStorePlugin';
 import { BlockingDocument } from '../../src/message/BlockingDocument';
 import { DocumentUuid } from '../../src/model/BrandedTypes';
+import { MeadowlarkId } from '../../dist/model/BrandedTypes';
 
 const documentUuid = '2edb604f-eab0-412c-a242-508d6529214d' as DocumentUuid;
 const frontendRequest: FrontendRequest = {
@@ -63,7 +64,8 @@ describe('given the new document has an invalid reference ', () => {
   let mockDocumentStore: any;
   const expectedBlockingDocument: BlockingDocument = {
     resourceName: 'resourceName',
-    documentUuid: 'documentUuid',
+    documentUuid: 'documentUuid' as DocumentUuid,
+    meadowlarkId: 'meadowlarkId' as MeadowlarkId,
     projectName: 'Ed-Fi',
     resourceVersion: '3.3.1-b',
   };

--- a/Meadowlark-js/packages/meadowlark-core/test/handler/Upsert.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/handler/Upsert.test.ts
@@ -11,8 +11,7 @@ import { FrontendResponse } from '../../src/handler/FrontendResponse';
 import { NoDocumentStorePlugin } from '../../src/plugin/backend/NoDocumentStorePlugin';
 import { BlockingDocument } from '../../src/message/BlockingDocument';
 import { isDocumentUuidWellFormed } from '../../src/validation/DocumentIdValidator';
-import { DocumentUuid } from '../../src/model/BrandedTypes';
-import { MeadowlarkId } from '../../dist/model/BrandedTypes';
+import { DocumentUuid, MeadowlarkId } from '../../src/model/BrandedTypes';
 
 const documentUuid = '3218d452-a7b7-4f1c-aa91-26ccc48cf4b8' as DocumentUuid;
 const frontendRequest: FrontendRequest = {

--- a/Meadowlark-js/packages/meadowlark-core/test/handler/Upsert.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/handler/Upsert.test.ts
@@ -12,6 +12,7 @@ import { NoDocumentStorePlugin } from '../../src/plugin/backend/NoDocumentStoreP
 import { BlockingDocument } from '../../src/message/BlockingDocument';
 import { isDocumentUuidWellFormed } from '../../src/validation/DocumentIdValidator';
 import { DocumentUuid } from '../../src/model/BrandedTypes';
+import { MeadowlarkId } from '../../dist/model/BrandedTypes';
 
 const documentUuid = '3218d452-a7b7-4f1c-aa91-26ccc48cf4b8' as DocumentUuid;
 const frontendRequest: FrontendRequest = {
@@ -32,6 +33,7 @@ describe('given persistence is going to throw a reference error on insert', () =
   const expectedBlockingDocument: BlockingDocument = {
     resourceName: 'resourceName',
     documentUuid,
+    meadowlarkId: 'meadowlarkId' as MeadowlarkId,
     projectName: 'Ed-Fi',
     resourceVersion: '3.3.1-b',
   };
@@ -115,6 +117,7 @@ describe('given persistence is going to throw a conflict error on insert', () =>
   const expectedBlockingDocument: BlockingDocument = {
     resourceName: 'resourceName',
     documentUuid,
+    meadowlarkId: 'meadowlarkId' as MeadowlarkId,
     projectName: 'Ed-Fi',
     resourceVersion: '3.3.1-b',
   };
@@ -162,6 +165,7 @@ describe('given persistence is going to throw a reference error on update though
   const expectedBlockingDocument: BlockingDocument = {
     resourceName: 'resourceName',
     documentUuid,
+    meadowlarkId: 'meadowlarkId' as MeadowlarkId,
     projectName: 'Ed-Fi',
     resourceVersion: '3.3.1-b',
   };

--- a/Meadowlark-js/packages/meadowlark-core/test/validation/DocumentIdValidator.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/validation/DocumentIdValidator.test.ts
@@ -3,12 +3,13 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+import { MeadowlarkId } from '../../src/model/BrandedTypes';
 import { meadowlarkIdForDocumentIdentity } from '../../src/model/DocumentIdentity';
 import { BaseResourceInfo } from '../../src/model/ResourceInfo';
-import { isDocumentIdValidForResource, isDocumentIdWellFormed } from '../../src/validation/DocumentIdValidator';
+import { isMeadowlarkIdValidForResource, isMeadowlarkIdWellFormed } from '../../src/validation/DocumentIdValidator';
 
 describe('given a valid id', () => {
-  let id: string;
+  let id: MeadowlarkId;
   let validResourceInfo: BaseResourceInfo;
 
   beforeAll(async () => {
@@ -27,16 +28,16 @@ describe('given a valid id', () => {
   });
 
   it('should be well formed', () => {
-    expect(isDocumentIdWellFormed(id)).toEqual(true);
+    expect(isMeadowlarkIdWellFormed(id)).toEqual(true);
   });
 
   it('should be valid for the provided resource info', () => {
-    expect(isDocumentIdValidForResource(id, validResourceInfo)).toEqual(true);
+    expect(isMeadowlarkIdValidForResource(id, validResourceInfo)).toEqual(true);
   });
 });
 
 describe('given a valid id with a mismatched resource info', () => {
-  let id: string;
+  let id: MeadowlarkId;
   let mismatchedResourceInfo: BaseResourceInfo;
 
   beforeAll(async () => {
@@ -61,16 +62,16 @@ describe('given a valid id with a mismatched resource info', () => {
   });
 
   it('should be well formed', () => {
-    expect(isDocumentIdWellFormed(id)).toEqual(true);
+    expect(isMeadowlarkIdWellFormed(id)).toEqual(true);
   });
 
   it('should be invalid for the mismatched resource info', () => {
-    expect(isDocumentIdValidForResource(id, mismatchedResourceInfo)).toEqual(false);
+    expect(isMeadowlarkIdValidForResource(id, mismatchedResourceInfo)).toEqual(false);
   });
 });
 
 describe('given an invalid id', () => {
-  const invalidId = 'NotAValidId';
+  const invalidId: MeadowlarkId = 'NotAValidId' as MeadowlarkId;
   const mismatchedResourceInfo: BaseResourceInfo = {
     isDescriptor: false,
     projectName: 'MismatchedProjectName',
@@ -78,10 +79,10 @@ describe('given an invalid id', () => {
   };
 
   it('should not be well formed', () => {
-    expect(isDocumentIdWellFormed(invalidId)).toEqual(false);
+    expect(isMeadowlarkIdWellFormed(invalidId)).toEqual(false);
   });
 
   it('should be invalid for the mismatched resource info', () => {
-    expect(isDocumentIdValidForResource(invalidId, mismatchedResourceInfo)).toEqual(false);
+    expect(isMeadowlarkIdValidForResource(invalidId, mismatchedResourceInfo)).toEqual(false);
   });
 });

--- a/Meadowlark-js/tests/http/local.33b.http
+++ b/Meadowlark-js/tests/http/local.33b.http
@@ -167,6 +167,7 @@ authorization: bearer {{authToken1}}
 }
 
 ### Strict validation is disabled
+# @name students
 POST http://localhost:3000/local/v3.3b/ed-fi/students
 content-type: application/json
 authorization: bearer {{authToken4}}
@@ -181,12 +182,12 @@ authorization: bearer {{authToken4}}
 
 
 ### 403 deleting with wrong owner
-DELETE http://localhost:3000/local/v3.3b/ed-fi/students/WhT14ozRv-M80122ZFtMigb_5VtptJfuO4KRKA
+DELETE http://localhost:3000/local/v3.3b/ed-fi/students/{{students.response.headers.location}}
 authorization: bearer {{authToken1}}
 
 
 ### 204 deleting with correct owner
-DELETE http://localhost:3000/local/v3.3b/ed-fi/students/WhT14ozRv-M80122ZFtMigb_5VtptJfuO4KRKA
+DELETE http://localhost:3000/local/v3.3b/ed-fi/students/{{students.response.headers.location}}
 authorization: bearer {{authToken4}}
 
 ###

--- a/Meadowlark-js/tests/http/local.33b.http
+++ b/Meadowlark-js/tests/http/local.33b.http
@@ -685,7 +685,7 @@ authorization: bearer {{authToken1}}
 }
 
 ### Solved in RND-426
-PUT http://localhost:3000{{students.response.headers.location}}
+PUT http://localhost:3000{{twoDifferentSchoolYears.response.headers.location}}
 content-type: application/json
 authorization: bearer {{authToken1}}
 

--- a/Meadowlark-js/tests/http/local.33b.http
+++ b/Meadowlark-js/tests/http/local.33b.http
@@ -110,7 +110,7 @@ content-type: application/json
 
 ###
 @contentClassDescriptorLocation = {{contentClassDescriptor.response.headers.location}}
-GET http://localhost:3000{{contentClassDescriptorLocation}}
+GET http://localhost:3000/{{contentClassDescriptorLocation}}
 authorization: bearer {{authToken1}}
 
 

--- a/Meadowlark-js/tests/http/local.33b.http
+++ b/Meadowlark-js/tests/http/local.33b.http
@@ -110,7 +110,7 @@ content-type: application/json
 
 ###
 @contentClassDescriptorLocation = {{contentClassDescriptor.response.headers.location}}
-GET http://localhost:3000/{{contentClassDescriptorLocation}}
+GET http://localhost:3000{{contentClassDescriptorLocation}}
 authorization: bearer {{authToken1}}
 
 
@@ -182,12 +182,12 @@ authorization: bearer {{authToken4}}
 
 
 ### 403 deleting with wrong owner
-DELETE http://localhost:3000/local/v3.3b/ed-fi/students/{{students.response.headers.location}}
+DELETE http://localhost:3000{{students.response.headers.location}}
 authorization: bearer {{authToken1}}
 
 
 ### 204 deleting with correct owner
-DELETE http://localhost:3000/local/v3.3b/ed-fi/students/{{students.response.headers.location}}
+DELETE http://localhost:3000{{students.response.headers.location}}
 authorization: bearer {{authToken4}}
 
 ###
@@ -639,6 +639,7 @@ content-type: application/json
 authorization: bearer {{authToken1}}
 
 #### Contains two different school years
+# @name twoDifferentSchoolYears
 POST http://localhost:3000/local/v3.3b/ed-fi/studentSchoolAssociations
 content-type: application/json
 authorization: bearer {{authToken1}}
@@ -683,7 +684,7 @@ authorization: bearer {{authToken1}}
 }
 
 ### Solved in RND-426
-PUT http://localhost:3000/local/v3.3b/ed-fi/studentSchoolAssociations/uJ8Rk-JjLZuoSnnSQUUuG2-LY9kz5QrrD0_UyQ
+PUT http://localhost:3000{{students.response.headers.location}}
 content-type: application/json
 authorization: bearer {{authToken1}}
 
@@ -734,6 +735,7 @@ GET http://localhost:3000/local/v3.3b/ed-fi/GeneralStudentProgramAssociations
 authorization: bearer {{authToken1}}
 
 ### This test covers the scenario previously seen in RND-149
+# @name accountPosted
 POST http://localhost:3000/local/v3.3b/ed-fi/accounts
 content-type: application/json
 authorization: bearer {{authToken4}}
@@ -862,7 +864,7 @@ authorization: bearer {{authToken4}}
 }
 
 ### delete the record above
-DELETE http://localhost:3000/local/v3.3b/ed-fi/accounts/maSXphjSRux6PX3WbbQKovXlVJEmso06cecAZw
+DELETE http://localhost:3000{{accountPosted.response.headers.location}}
 authorization: bearer {{authToken1}}
 
 ###

--- a/Meadowlark-js/tests/http/local.33b.http
+++ b/Meadowlark-js/tests/http/local.33b.http
@@ -335,6 +335,7 @@ authorization: bearer {{authToken1}}
 }
 
 ### Create school 123 without validation
+# @name school_123
 POST http://localhost:3000/local/v3.3b/ed-fi/schools
 content-type: application/json
 authorization: bearer {{authToken4}}
@@ -868,16 +869,28 @@ DELETE http://localhost:3000{{accountPosted.response.headers.location}}
 authorization: bearer {{authToken1}}
 
 ###
-DELETE http://localhost:3000/local/v3.3b/ed-fi/SchoolCategoryDescriptors/gPVEJ4PgrhnDa-eMNdqix4aoE8oeVAt8E9opyQ
+# @name schoolCategoryDescriptors
+POST http://localhost:3000/local/v3.3b/ed-fi/SchoolCategoryDescriptors
+authorization: bearer {{authToken1}}
+content-type: application/json
+
+{
+    "codeValue": "All Levels Http Test",
+    "shortDescription": "All Levels Http Test",
+    "namespace": "uri://ed-fi.org/SchoolCategoryDescriptor"
+}
+
+###
+DELETE http://localhost:3000{{schoolCategoryDescriptors.response.headers.location}}
 authorization: bearer {{authToken1}}
 
 ###
-GET http://localhost:3000/local/v3.3b/ed-fi/SchoolCategoryDescriptors/gPVEJ4PgrhnDa-eMNdqix4aoE8oeVAt8E9opyQ
+GET http://localhost:3000{{schoolCategoryDescriptors.response.headers.location}}
 authorization: bearer {{authToken1}}
 
 
 ### Try to delete school 123. Should be denied (409) because there are references to it. Solved in RND-327.
-DELETE http://localhost:3000/local/v3.3b/ed-fi/Schools/LZRuhjvR1UiLz9Tat_4HOBmlPt_xB_pA20fKyQ
+DELETE http://localhost:3000{{school_123.response.headers.location}}
 authorization: bearer {{authToken1}}
 
 
@@ -940,8 +953,6 @@ content-type: application/json
       }
     ]
 }
-
-
 
 #
 ## PostSecondaryInstitutions


### PR DESCRIPTION
- Replace meadowlarkId by documentUuid.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Provide a brief description of your changes. Additional detail -->
<!--- should be in an associated Ed-Fi Tracker ticket (https://tracker.ed-fi.org) -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have signed all of the commits on this PR.
- [ ] I have agreed to the Ed-Fi Individual Contributors' License
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
