### PR TITLE
[RND-560] Postgres: Deleting resource is not deleting references and alias

### DIFF
--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
@@ -28,21 +28,23 @@ export async function deleteDocumentByDocumentUuid(
 
   try {
     await client.query('BEGIN');
-
+    // Find the alias ids for the document to be deleted
+    const documentAliasIdsResult: QueryResult = await client.query(findAliasIdsForDocumentByDocumentUuidSql(documentUuid));
+    meadowlarkId =
+      documentAliasIdsResult?.rowCount != null && documentAliasIdsResult.rowCount > 0
+        ? documentAliasIdsResult.rows[0].document_id
+        : ('' as MeadowlarkId);
     if (validateNoReferencesToDocument) {
-      // Find the alias ids for the document to be deleted
-      const documentAliasIdsResult: QueryResult = await client.query(findAliasIdsForDocumentByDocumentUuidSql(documentUuid));
-
       // All documents have alias ids. If no alias ids were found, the document doesn't exist
-      if (documentAliasIdsResult.rowCount == null || documentAliasIdsResult.rowCount === 0) {
+      if (meadowlarkId.length === 0) {
         await client.query('ROLLBACK');
         Logger.debug(`${moduleName}.deleteDocumentByDocumentUuid: DocumentUuid ${documentUuid} does not exist`, traceId);
         deleteResult = { response: 'DELETE_FAILURE_NOT_EXISTS' };
         return deleteResult;
       }
-      meadowlarkId = documentAliasIdsResult.rows[0].document_id;
+
       // Extract from the query result
-      const documentAliasIds: string[] = documentAliasIdsResult.rows.map((ref) => ref.alias_id);
+      const documentAliasIds: MeadowlarkId[] = documentAliasIdsResult.rows.map((ref) => ref.alias_id);
 
       // Find any documents that reference this document, either it's own id or an alias
       const referenceResult: QueryResult<any> = await client.query(findReferencingMeadowlarkIdsSql(documentAliasIds));

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
@@ -30,13 +30,15 @@ export async function deleteDocumentByDocumentUuid(
     await client.query('BEGIN');
     // Find the alias ids for the document to be deleted
     const documentAliasIdsResult: QueryResult = await client.query(findAliasIdsForDocumentByDocumentUuidSql(documentUuid));
+    // Each row contains documentUuid and corresponding meadowlarkId (document_id),
+    // we just need the first row to return the document_id
     meadowlarkId =
       documentAliasIdsResult?.rowCount != null && documentAliasIdsResult.rowCount > 0
         ? documentAliasIdsResult.rows[0].document_id
         : ('' as MeadowlarkId);
     if (validateNoReferencesToDocument) {
       // All documents have alias ids. If no alias ids were found, the document doesn't exist
-      if (meadowlarkId.length === 0) {
+      if (meadowlarkId === '') {
         await client.query('ROLLBACK');
         Logger.debug(`${moduleName}.deleteDocumentByDocumentUuid: DocumentUuid ${documentUuid} does not exist`, traceId);
         deleteResult = { response: 'DELETE_FAILURE_NOT_EXISTS' };

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
@@ -21,6 +21,15 @@ export function findReferencingMeadowlarkIdsSql(referencedMeadowlarkIds: Meadowl
 }
 
 /**
+ * Returns the SQL query to find the ids of documents that referenced by the given ids.
+ *
+ * @param parentDocumentId the ids of the documents that are being referenced
+ * @returns a SQL query to find the ids of the documents referencing the given ids by parent id
+ */
+export function findParentReferenceByMeadowlarkIdSql(parentDocumentId: MeadowlarkId): string {
+  return format(`SELECT parent_document_id FROM meadowlark.references WHERE parent_document_id = %L`, parentDocumentId);
+}
+/**
  * Returns the SQL query to find the alias ids for a given document. Alias ids include the document id
  * itself along with any superclass variations that the document satisifies. For example, a School is a subclass
  * of EducationOrganization, so each School document has an additional alias id as an EducationOrganization.

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
@@ -13,7 +13,7 @@ import format from 'pg-format';
  * @param referencedMeadowlarkIds the ids of the documents that are being referenced
  * @returns a SQL query to find the ids of the documents referencing the given ids
  */
-export function findReferencingMeadowlarkIdsSql(referencedMeadowlarkIds: string[]): string {
+export function findReferencingMeadowlarkIdsSql(referencedMeadowlarkIds: MeadowlarkId[]): string {
   return format(
     `SELECT parent_document_id FROM meadowlark.references WHERE referenced_document_id IN (%L)`,
     referencedMeadowlarkIds,

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
@@ -21,15 +21,6 @@ export function findReferencingMeadowlarkIdsSql(referencedMeadowlarkIds: Meadowl
 }
 
 /**
- * Returns the SQL query to find the ids of documents that referenced by the given ids.
- *
- * @param parentDocumentId the ids of the documents that are being referenced
- * @returns a SQL query to find the ids of the documents referencing the given ids by parent id
- */
-export function findParentReferenceByMeadowlarkIdSql(parentDocumentId: MeadowlarkId): string {
-  return format(`SELECT parent_document_id FROM meadowlark.references WHERE parent_document_id = %L`, parentDocumentId);
-}
-/**
  * Returns the SQL query to find the alias ids for a given document. Alias ids include the document id
  * itself along with any superclass variations that the document satisifies. For example, a School is a subclass
  * of EducationOrganization, so each School document has an additional alias id as an EducationOrganization.

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
@@ -29,7 +29,12 @@ import { deleteAll, retrieveReferencesByMeadowlarkIdSql } from './TestHelper';
 import { getSharedClient, resetSharedClient } from '../../src/repository/Db';
 import { deleteDocumentByDocumentUuid } from '../../src/repository/Delete';
 import { upsertDocument } from '../../src/repository/Upsert';
-import { findDocumentByDocumentUuidSql, findDocumentByMeadowlarkIdSql } from '../../src/repository/SqlHelper';
+import {
+  findAliasIdsForDocumentByMeadowlarkIdSql,
+  findDocumentByDocumentUuidSql,
+  findDocumentByMeadowlarkIdSql,
+  findReferencingMeadowlarkIdsSql,
+} from '../../src/repository/SqlHelper';
 
 const newUpsertRequest = (): UpsertRequest => ({
   meadowlarkId: '' as MeadowlarkId,
@@ -301,6 +306,17 @@ describe('given an delete of a document with an outbound reference only, with va
 
   it('should have deleted the document in the db', async () => {
     const result: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
+
+    expect(result.rowCount).toEqual(0);
+  });
+
+  it('should have deleted the document alias in the db', async () => {
+    const result: any = await client.query(findAliasIdsForDocumentByMeadowlarkIdSql(documentWithReferencesId));
+
+    expect(result.rowCount).toEqual(0);
+  });
+  it('should have deleted the document reference in the db', async () => {
+    const result: any = await client.query(findReferencingMeadowlarkIdsSql([referencedDocumentId]));
 
     expect(result.rowCount).toEqual(0);
   });

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
@@ -24,6 +24,7 @@ import {
   UpsertRequest,
   UpsertResult,
 } from '@edfi/meadowlark-core';
+import format from 'pg-format';
 import type { PoolClient } from 'pg';
 import { resetSharedClient, getSharedClient } from '../../src/repository/Db';
 import { updateDocumentByDocumentUuid } from '../../src/repository/Update';
@@ -34,7 +35,6 @@ import {
   findAliasIdsForDocumentByMeadowlarkIdSql,
   findDocumentByDocumentUuidSql,
   findDocumentByMeadowlarkIdSql,
-  findParentReferenceByMeadowlarkIdSql,
 } from '../../src/repository/SqlHelper';
 
 const documentUuid: DocumentUuid = 'feb82f3e-3685-4868-86cf-f4b91749a799' as DocumentUuid;
@@ -756,7 +756,11 @@ describe('given the update of an existing document changing meadowlarkId with al
     expect(result.rowCount).toEqual(0);
   });
   it('should have deleted the document reference  related to the old meadowlarkId in the db', async () => {
-    const result: any = await client.query(findParentReferenceByMeadowlarkIdSql(meadowlarkId));
+    const findParentReferenceByMeadowlarkIdSql = format(
+      `SELECT alias_id FROM meadowlark.aliases WHERE document_id = %L FOR SHARE NOWAIT`,
+      meadowlarkId,
+    );
+    const result: any = await client.query(findParentReferenceByMeadowlarkIdSql);
 
     expect(result.rowCount).toEqual(0);
   });

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
@@ -696,7 +696,6 @@ describe('given the update of an existing document changing meadowlarkId with al
   const meadowlarkIdUpdated = meadowlarkIdForDocumentIdentity(resourceInfo, documentInfoUpdated.documentIdentity);
 
   beforeAll(async () => {
-    jest.setTimeout(120000);
     client = (await getSharedClient()) as PoolClient;
     // The document that will be referenced
     await upsertDocument(

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
@@ -34,7 +34,7 @@ import {
   findAliasIdsForDocumentByMeadowlarkIdSql,
   findDocumentByDocumentUuidSql,
   findDocumentByMeadowlarkIdSql,
-  findReferencingMeadowlarkIdsSql,
+  findParentReferenceByMeadowlarkIdSql,
 } from '../../src/repository/SqlHelper';
 
 const documentUuid: DocumentUuid = 'feb82f3e-3685-4868-86cf-f4b91749a799' as DocumentUuid;
@@ -688,8 +688,15 @@ describe('given the update of an existing document changing meadowlarkId with al
     documentReferences: [validReference],
   };
   const meadowlarkId = meadowlarkIdForDocumentIdentity(resourceInfo, documentInfo.documentIdentity);
+  const documentInfoUpdated: DocumentInfo = {
+    ...newDocumentInfo(),
+    documentIdentity: { natural: 'update 2' },
+    documentReferences: [validReference],
+  };
+  const meadowlarkIdUpdated = meadowlarkIdForDocumentIdentity(resourceInfo, documentInfoUpdated.documentIdentity);
 
   beforeAll(async () => {
+    jest.setTimeout(120000);
     client = (await getSharedClient()) as PoolClient;
     // The document that will be referenced
     await upsertDocument(
@@ -710,12 +717,6 @@ describe('given the update of an existing document changing meadowlarkId with al
       edfiDoc: { natural: 'key upsert' },
       validateDocumentReferencesExist: true,
     };
-    const documentInfoUpdated: DocumentInfo = {
-      ...newDocumentInfo(),
-      documentIdentity: { natural: 'update 2' },
-      documentReferences: [validReference],
-    };
-    const meadowlarkIdUpdated = meadowlarkIdForDocumentIdentity(resourceInfo, documentInfoUpdated.documentIdentity);
 
     // insert the initial version
     upsertResult = await upsertDocument(upsertRequest, client);
@@ -756,7 +757,7 @@ describe('given the update of an existing document changing meadowlarkId with al
     expect(result.rowCount).toEqual(0);
   });
   it('should have deleted the document reference  related to the old meadowlarkId in the db', async () => {
-    const result: any = await client.query(findReferencingMeadowlarkIdsSql([meadowlarkId]));
+    const result: any = await client.query(findParentReferenceByMeadowlarkIdSql(meadowlarkId));
 
     expect(result.rowCount).toEqual(0);
   });


### PR DESCRIPTION
Update delete and update modules.
Update test to validate if aliases and references are deleted when a document is deleted. Update update module to use an old meadowlarkId to filter aliases and references, because, if it change, this query will return empty. Add validation to use enable or disable allow Identity Updates

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Provide a brief description of your changes. Additional detail -->
<!--- should be in an associated Ed-Fi Tracker ticket (https://tracker.ed-fi.org) -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have signed all of the commits on this PR.
- [x] I have agreed to the Ed-Fi Individual Contributors' License
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
