### PR TITLE
[RND-556] Fix faulty ownership security on POST requests

### DIFF
--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
@@ -124,8 +124,7 @@ export async function upsertDocument(
 
     // Perform the document upsert
     Logger.debug(`${moduleName}.upsertDocument: Upserting document meadowlarkId ${meadowlarkId}`, traceId);
-    const insertResult = await client.query(documentUpsertSql);
-    Logger.debug(`${moduleName}.upsertDocument: insert ${insertResult}`, traceId);
+    await client.query(documentUpsertSql);
     // Delete existing values from the aliases table
     await client.query(deleteAliasesForDocumentSql(meadowlarkId));
     // Perform insert of alias ids

--- a/Meadowlark-js/tests/e2e/scenarios/SecurityValidation.test.ts
+++ b/Meadowlark-js/tests/e2e/scenarios/SecurityValidation.test.ts
@@ -228,6 +228,19 @@ describe('given the existence of two vendors and one host', () => {
       });
     });
 
+    describe('when a different vendor tries to insert an existing resource', () => {
+      it('should return error', async () => {
+        await rootURLRequest()
+          .post(`/v3.3b/ed-fi/${resourceEndpoint}`)
+          .auth(vendor2DataAccessToken, { type: 'bearer' })
+          .send(resourceBodyPutUpdated)
+          .expect(403)
+          .then((response) => {
+            expect(response.body).toBe('');
+          });
+      });
+    });
+
     describe('when a different vendor updates the resource', () => {
       it('should return error', async () => {
         await rootURLRequest()

--- a/Meadowlark-js/tests/e2e/scenarios/SecurityValidation.test.ts
+++ b/Meadowlark-js/tests/e2e/scenarios/SecurityValidation.test.ts
@@ -231,7 +231,7 @@ describe('given the existence of two vendors and one host', () => {
     describe('when a different vendor tries to insert an existing resource', () => {
       it('should return error', async () => {
         await rootURLRequest()
-          .post(`/v3.3b/ed-fi/${resourceEndpoint}`)
+          .post(resourceLocation.slice(0, resourceLocation.lastIndexOf('/')))
           .auth(vendor2DataAccessToken, { type: 'bearer' })
           .send(resourceBodyPutUpdated)
           .expect(403)


### PR DESCRIPTION
Update ownership validation, to validate first by documentUuid, if that id is null, it tries to find the document by meadowlarkId.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Provide a brief description of your changes. Additional detail -->
<!--- should be in an associated Ed-Fi Tracker ticket (https://tracker.ed-fi.org) -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have signed all of the commits on this PR.
- [x] I have agreed to the Ed-Fi Individual Contributors' License
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
