### PR TITLE
[RND-565] Update open search image version for test execution

### DIFF
--- a/Meadowlark-js/backends/meadowlark-opensearch-backend/test/setup/OpenSearchContainer.ts
+++ b/Meadowlark-js/backends/meadowlark-opensearch-backend/test/setup/OpenSearchContainer.ts
@@ -10,7 +10,7 @@ let startedContainer: StartedTestContainer;
 export async function setup() {
   const openSearchPort = parseInt(process.env.OPENSEARCH_PORT ?? '8201', 10);
   startedContainer = await new GenericContainer(
-    'opensearchproject/opensearch:2.5.0@sha256:f077efb452be64d3df56d74fe99fd63244704896edf6ead73a0f5decb95a40bf',
+    'opensearchproject/opensearch:2.7.0@sha256:55f1f67e7d3645aa838b63a589bce5645154ba275814e52d4638d371ca0f8cb5',
   )
     .withName('opensearch-test')
     .withExposedPorts({

--- a/Meadowlark-js/tests/e2e/setup/containers/OpenSearchContainer.ts
+++ b/Meadowlark-js/tests/e2e/setup/containers/OpenSearchContainer.ts
@@ -12,7 +12,7 @@ export async function setup(network: StartedNetwork) {
   try {
     const openSearchPort = parseInt(process.env.OPENSEARCH_PORT ?? '8200', 10);
     const container = new GenericContainer(
-      'opensearchproject/opensearch:2.5.0@sha256:f077efb452be64d3df56d74fe99fd63244704896edf6ead73a0f5decb95a40bf',
+      'opensearchproject/opensearch:2.7.0@sha256:55f1f67e7d3645aa838b63a589bce5645154ba275814e52d4638d371ca0f8cb5',
     )
       .withName('opensearch-test')
       .withNetwork(network)


### PR DESCRIPTION
A previous [PR](https://github.com/Ed-Fi-Exchange-OSS/Meadowlark/pull/250) updated the OpenSearch version for the Dockerfiles, and we missed to update the version on the test setup. This PR updates the versions to run the tests for OpenSearch
