### PR TITLE
[RND-562] Rename "documentId" to "meadowlarkId" for all PostgreSQL columns

### DIFF
--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/BackendFacade.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/BackendFacade.ts
@@ -41,11 +41,11 @@ import { getSharedClient, closeSharedConnection } from './repository/Db';
 
 // DocumentStore implementation
 export async function deleteDocumentById(request: DeleteRequest): Promise<DeleteResult> {
-  return Delete.deleteDocumentById(request, await getSharedClient());
+  return Delete.deleteDocumentByDocumentUuid(request, await getSharedClient());
 }
 
 export async function getDocumentById(request: GetRequest): Promise<GetResult> {
-  return Get.getDocumentById(request, await getSharedClient());
+  return Get.getDocumentByDocumentUuid(request, await getSharedClient());
 }
 
 export async function upsertDocument(request: UpsertRequest): Promise<UpsertResult> {
@@ -53,7 +53,7 @@ export async function upsertDocument(request: UpsertRequest): Promise<UpsertResu
 }
 
 export async function updateDocumentById(request: UpdateRequest): Promise<UpdateResult> {
-  return Update.updateDocumentById(request, await getSharedClient());
+  return Update.updateDocumentByDocumentUuid(request, await getSharedClient());
 }
 
 export async function securityMiddleware(middlewareModel: MiddlewareModel): Promise<MiddlewareModel> {

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/model/MeadowlarkDocument.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/model/MeadowlarkDocument.ts
@@ -63,7 +63,7 @@ export interface MeadowlarkDocument extends MeadowlarkDocumentId {
 
   /**
    * An array of ids this document will satisfy when reference validation performs existence checks.
-   * This array always includes the document id itself. If this document is a subclass, the array will also
+   * This array always includes the document meadowlark id itself. If this document is a subclass, the array will also
    * contain the id of this document in superclass form (superclass name and project, identity property
    * naming differences - like schoolId versus educationOrganizationId - accounted for). Such an id is an alias.
    *
@@ -78,7 +78,7 @@ export interface MeadowlarkDocument extends MeadowlarkDocumentId {
    *          a reference from ClassPeriod to a School with schoolId=123, as well as a reference from
    *          Assessment to EducationOrganization with educationOrganizationId=123.
    */
-  aliasIds: MeadowlarkId[];
+  aliasMeadowlarkIds: MeadowlarkId[];
 
   /**
    * True if this document has been reference and descriptor validated.
@@ -135,9 +135,9 @@ export function meadowlarkDocumentFrom(
   createdAt: number,
   lastModifiedAt: number,
 ): MeadowlarkDocument {
-  const aliasIds: MeadowlarkId[] = [meadowlarkId];
+  const aliasMeadowlarkIds: MeadowlarkId[] = [meadowlarkId];
   if (documentInfo.superclassInfo != null) {
-    aliasIds.push(getMeadowlarkIdForSuperclassInfo(documentInfo.superclassInfo));
+    aliasMeadowlarkIds.push(getMeadowlarkIdForSuperclassInfo(documentInfo.superclassInfo));
   }
 
   return {
@@ -149,7 +149,7 @@ export function meadowlarkDocumentFrom(
     documentUuid,
     _id: meadowlarkId,
     edfiDoc,
-    aliasIds,
+    aliasMeadowlarkIds,
     outboundRefs: referencedDocumentIdsFrom(documentInfo),
     validated: validate,
     createdBy,

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Db.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Db.ts
@@ -34,7 +34,7 @@ export async function getNewClient(): Promise<MongoClient> {
       .collection(DOCUMENT_COLLECTION_NAME);
     await documentCollection.createIndex({ documentUuid: 1 });
     await documentCollection.createIndex({ outboundRefs: 1 });
-    await documentCollection.createIndex({ aliasIds: 1 });
+    await documentCollection.createIndex({ aliasMeadowlarkIds: 1 });
 
     // Create authorizations collection if not exists
     const authorizationCollection: Collection<AuthorizationDocument> = newClient
@@ -102,7 +102,7 @@ export async function writeLockReferencedDocuments(
   session: ClientSession,
 ): Promise<void> {
   await mongoCollection.updateMany(
-    { aliasIds: { $in: referencedMeadowlarkIds } },
+    { aliasMeadowlarkIds: { $in: referencedMeadowlarkIds } },
     { $set: { lock: new ObjectId() } },
     { session },
   );
@@ -118,7 +118,10 @@ export const onlyReturnDocumentUuid = (session: ClientSession): FindOptions => (
 });
 
 // MongoDB FindOption to return only the aliasId
-export const onlyReturnAliasId = (session: ClientSession): FindOptions => ({ projection: { 'aliasIds.$': 1 }, session });
+export const onlyReturnAliasMeadowlarkId = (session: ClientSession): FindOptions => ({
+  projection: { 'aliasMeadowlarkIds.$': 1 },
+  session,
+});
 
 // MongoDB ReplaceOption that enables upsert (insert if not exists)
 export const asUpsert = (session: ClientSession): ReplaceOptions => ({ upsert: true, session });

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Get.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Get.ts
@@ -11,8 +11,11 @@ import { getDocumentCollection } from './Db';
 
 const moduleName: string = 'mongodb.repository.get';
 
-export async function getDocumentById({ documentUuid, traceId }: GetRequest, client: MongoClient): Promise<GetResult> {
-  Logger.debug(`${moduleName}.getDocumentById ${documentUuid}`, traceId);
+export async function getDocumentByDocumentUuid(
+  { documentUuid, traceId }: GetRequest,
+  client: MongoClient,
+): Promise<GetResult> {
+  Logger.debug(`${moduleName}.getDocumentByDocumentUuid ${documentUuid}`, traceId);
 
   const mongoCollection: Collection<MeadowlarkDocument> = getDocumentCollection(client);
 

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/OwnershipSecurity.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/OwnershipSecurity.ts
@@ -10,7 +10,7 @@ import { MeadowlarkDocument } from '../model/MeadowlarkDocument';
 import { SecurityResult } from '../security/SecurityResult';
 import { getDocumentCollection } from './Db';
 
-function extractIdIfUpsert(frontendRequest: FrontendRequest): MeadowlarkId | null {
+function extractMeadowlarkIdIfUpsert(frontendRequest: FrontendRequest): MeadowlarkId | null {
   if (frontendRequest.action !== 'upsert') return null;
 
   return meadowlarkIdForDocumentIdentity(
@@ -54,7 +54,7 @@ export async function rejectByOwnershipSecurity(
       Logger.debug(`${functionName} - document found for documentUuid ${documentUuid}`, frontendRequest.traceId);
     } else {
       // security by meadowlarkId if it's upsert - document body with no documentUuid
-      const meadowlarkId: MeadowlarkId | null = extractIdIfUpsert(frontendRequest);
+      const meadowlarkId: MeadowlarkId | null = extractMeadowlarkIdIfUpsert(frontendRequest);
 
       if (meadowlarkId == null) {
         Logger.error(`${functionName} - no documentUuid or meadowlarkId to secure against`, frontendRequest.traceId);

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Upsert.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Upsert.ts
@@ -46,17 +46,17 @@ export async function upsertDocumentTransaction(
 
   // If inserting a subclass, check whether the superclass identity is already claimed by a different subclass
   if (isInsert && documentInfo.superclassInfo != null) {
-    const superclassAliasId: MeadowlarkId = getMeadowlarkIdForSuperclassInfo(documentInfo.superclassInfo);
-    const superclassAliasIdInUse: WithId<MeadowlarkDocument> | null = await mongoCollection.findOne(
+    const superclassAliasMeadowlarkId: MeadowlarkId = getMeadowlarkIdForSuperclassInfo(documentInfo.superclassInfo);
+    const superclassAliasMeadowlarkIdInUse: WithId<MeadowlarkDocument> | null = await mongoCollection.findOne(
       {
-        aliasIds: superclassAliasId,
+        aliasMeadowlarkIds: superclassAliasMeadowlarkId,
       },
       { session },
     );
 
-    if (superclassAliasIdInUse) {
+    if (superclassAliasMeadowlarkIdInUse) {
       Logger.warn(
-        `${moduleName}.upsertDocumentTransaction insert failed due to another subclass with documentUuid ${superclassAliasIdInUse.documentUuid} and the same identity ${superclassAliasIdInUse._id}`,
+        `${moduleName}.upsertDocumentTransaction insert failed due to another subclass with documentUuid ${superclassAliasMeadowlarkIdInUse.documentUuid} and the same identity ${superclassAliasMeadowlarkIdInUse._id}`,
         traceId,
       );
 
@@ -65,11 +65,11 @@ export async function upsertDocumentTransaction(
         failureMessage: `Insert failed: the identity is in use by '${resourceInfo.resourceName}' which is also a(n) '${documentInfo.superclassInfo.resourceName}'`,
         blockingDocuments: [
           {
-            documentUuid: superclassAliasIdInUse.documentUuid,
-            meadowlarkId: superclassAliasIdInUse._id,
-            resourceName: superclassAliasIdInUse.resourceName,
-            projectName: superclassAliasIdInUse.projectName,
-            resourceVersion: superclassAliasIdInUse.resourceVersion,
+            documentUuid: superclassAliasMeadowlarkIdInUse.documentUuid,
+            meadowlarkId: superclassAliasMeadowlarkIdInUse._id,
+            resourceName: superclassAliasMeadowlarkIdInUse.resourceName,
+            projectName: superclassAliasMeadowlarkIdInUse.projectName,
+            resourceVersion: superclassAliasMeadowlarkIdInUse.resourceVersion,
           },
         ],
       };
@@ -88,7 +88,7 @@ export async function upsertDocumentTransaction(
     // Abort on validation failure
     if (failures.length > 0) {
       Logger.debug(
-        `${moduleName}.upsertDocumentTransaction Upserting document uuid ${documentUuid} failed due to invalid references`,
+        `${moduleName}.upsertDocumentTransaction Upserting DocumentUuid ${documentUuid} failed due to invalid references`,
         traceId,
       );
 

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Delete.test.ts
@@ -25,7 +25,7 @@ import {
 import { Collection, MongoClient } from 'mongodb';
 import { MeadowlarkDocument } from '../../src/model/MeadowlarkDocument';
 import { getDocumentCollection, getNewClient } from '../../src/repository/Db';
-import { deleteDocumentById } from '../../src/repository/Delete';
+import { deleteDocumentByDocumentUuid } from '../../src/repository/Delete';
 import { upsertDocument } from '../../src/repository/Upsert';
 import { setupConfigForIntegration } from './Config';
 
@@ -61,7 +61,7 @@ describe('given the delete of a non-existent document', () => {
 
     client = (await getNewClient()) as MongoClient;
 
-    deleteResult = await deleteDocumentById(
+    deleteResult = await deleteDocumentByDocumentUuid(
       { ...newDeleteRequest(), documentUuid: '123' as DocumentUuid, resourceInfo, validateNoReferencesToDocument: false },
       client,
     );
@@ -105,7 +105,7 @@ describe('given the delete of an existing document', () => {
     upsertResult = await upsertDocument(upsertRequest, client);
     if (upsertResult.response !== 'INSERT_SUCCESS') throw new Error();
 
-    deleteResult = await deleteDocumentById(
+    deleteResult = await deleteDocumentByDocumentUuid(
       { ...newDeleteRequest(), documentUuid: upsertResult.newDocumentUuid, resourceInfo },
       client,
     );
@@ -195,7 +195,7 @@ describe('given the delete of a document referenced by an existing document with
       client,
     );
 
-    deleteResult = await deleteDocumentById(
+    deleteResult = await deleteDocumentByDocumentUuid(
       {
         ...newDeleteRequest(),
         documentUuid: upsertResult.newDocumentUuid,
@@ -289,7 +289,7 @@ describe('given an delete of a document with an outbound reference only, with va
     );
     if (upsertResult2.response !== 'INSERT_SUCCESS') throw new Error();
 
-    deleteResult = await deleteDocumentById(
+    deleteResult = await deleteDocumentByDocumentUuid(
       {
         ...newDeleteRequest(),
         documentUuid: upsertResult2.newDocumentUuid,
@@ -382,7 +382,7 @@ describe('given the delete of a document referenced by an existing document with
       client,
     );
 
-    deleteResult = await deleteDocumentById(
+    deleteResult = await deleteDocumentByDocumentUuid(
       {
         ...newDeleteRequest(),
         documentUuid: upsertResult.newDocumentUuid,
@@ -485,7 +485,7 @@ describe('given the delete of a subclass document referenced by an existing docu
     );
     if (upsertResult.response !== 'INSERT_SUCCESS') throw new Error();
 
-    deleteResult = await deleteDocumentById(
+    deleteResult = await deleteDocumentByDocumentUuid(
       {
         ...newDeleteRequest(),
         documentUuid: upsertResult.newDocumentUuid,

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/OwnershipSecurity.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/OwnershipSecurity.test.ts
@@ -61,7 +61,7 @@ describe('given the getById where resource info is a Descriptor', () => {
   });
 });
 
-describe('given the upsert where no document id is specified', () => {
+describe('given the upsert where no meadowlark id is specified', () => {
   let client;
   let result;
 
@@ -88,7 +88,7 @@ describe('given the upsert where no document id is specified', () => {
     await client.close();
   });
 
-  it('should not apply security when no document id is specified', async () => {
+  it('should not apply security when no meadowlark id is specified', async () => {
     expect(result).toBe('NOT_APPLICABLE');
   });
 });

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Read.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Read.test.ts
@@ -22,10 +22,10 @@ import {
 import { Collection, MongoClient } from 'mongodb';
 import { MeadowlarkDocument } from '../../src/model/MeadowlarkDocument';
 import { getDocumentCollection, getNewClient } from '../../src/repository/Db';
-import { getDocumentById } from '../../src/repository/Get';
+import { getDocumentByDocumentUuid } from '../../src/repository/Get';
 import { upsertDocument } from '../../src/repository/Upsert';
 import { setupConfigForIntegration } from './Config';
-import { updateDocumentById } from '../../src/repository/Update';
+import { updateDocumentByDocumentUuid } from '../../src/repository/Update';
 
 const newGetRequest = (): GetRequest => ({
   documentUuid: '' as DocumentUuid,
@@ -74,7 +74,7 @@ describe('given the get of a non-existent document', () => {
 
     client = (await getNewClient()) as MongoClient;
 
-    getResult = await getDocumentById({ ...newGetRequest(), documentUuid: '123' as DocumentUuid }, client);
+    getResult = await getDocumentByDocumentUuid({ ...newGetRequest(), documentUuid: '123' as DocumentUuid }, client);
   });
 
   afterAll(async () => {
@@ -122,7 +122,7 @@ describe('given the get of an existing document', () => {
     const upsertResult = await upsertDocument(upsertRequest, client);
     if (upsertResult.response !== 'INSERT_SUCCESS') throw new Error();
 
-    getResult = await getDocumentById(
+    getResult = await getDocumentByDocumentUuid(
       { ...newGetRequest(), documentUuid: upsertResult.newDocumentUuid, resourceInfo },
       client,
     );
@@ -184,9 +184,9 @@ describe('given the get of an updated document', () => {
       documentInfo,
       edfiDoc: { natural: 'keyUpdated' },
     };
-    const updateResult = await updateDocumentById(updateRequest, client);
+    const updateResult = await updateDocumentByDocumentUuid(updateRequest, client);
     if (updateResult.response !== 'UPDATE_SUCCESS') throw new Error();
-    getResult = await getDocumentById(
+    getResult = await getDocumentByDocumentUuid(
       { ...newGetRequest(), documentUuid: upsertResult.newDocumentUuid, resourceInfo },
       client,
     );

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/SecurityMiddleware.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/SecurityMiddleware.test.ts
@@ -26,7 +26,7 @@ import { securityMiddleware } from '../../src/security/SecurityMiddleware';
 import { upsertDocument } from '../../src/repository/Upsert';
 import { setupConfigForIntegration } from './Config';
 
-describe('given the upsert where no document id is specified', () => {
+describe('given the upsert where no meadowlark id is specified', () => {
   let client;
   let result;
 
@@ -53,7 +53,7 @@ describe('given the upsert where no document id is specified', () => {
     await client.close();
   });
 
-  it('should not respond when no document id is specified', async () => {
+  it('should not respond when no meadowlark id is specified', async () => {
     expect(result.frontendResponse).toBeNull();
   });
 });

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Update.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/Update.test.ts
@@ -26,7 +26,7 @@ import {
 import { ClientSession, Collection, MongoClient } from 'mongodb';
 import { MeadowlarkDocument } from '../../src/model/MeadowlarkDocument';
 import { getDocumentCollection, getNewClient } from '../../src/repository/Db';
-import { updateDocumentById } from '../../src/repository/Update';
+import { updateDocumentByDocumentUuid } from '../../src/repository/Update';
 import { upsertDocument } from '../../src/repository/Upsert';
 import { setupConfigForIntegration } from './Config';
 import { onlyReturnAliasIds } from '../../src/repository/ReferenceValidation';
@@ -71,7 +71,7 @@ describe('given the update of a non-existent document', () => {
 
     client = (await getNewClient()) as MongoClient;
 
-    updateResult = await updateDocumentById(
+    updateResult = await updateDocumentByDocumentUuid(
       {
         ...newUpdateRequest(),
         meadowlarkId,
@@ -140,7 +140,7 @@ describe('given the update of an existing document', () => {
       documentInfo,
       edfiDoc: { natural: 'key' },
     };
-    updateResult = await updateDocumentById({ ...updateRequest, edfiDoc: { changeToDoc: true } }, client);
+    updateResult = await updateDocumentByDocumentUuid({ ...updateRequest, edfiDoc: { changeToDoc: true } }, client);
   });
 
   afterAll(async () => {
@@ -207,7 +207,7 @@ describe('given an update of a document that references a non-existent document 
 
     // Update the document with an invalid reference
     documentWithReferencesInfo.documentReferences = [invalidReference];
-    updateResult = await updateDocumentById(
+    updateResult = await updateDocumentByDocumentUuid(
       {
         ...newUpdateRequest(),
         documentUuid: upsertResult.newDocumentUuid,
@@ -310,7 +310,7 @@ describe('given an update of a document that references an existing document wit
 
     // The updated document with a valid reference
     documentWithReferencesInfo.documentReferences = [validReference];
-    updateResult = await updateDocumentById(
+    updateResult = await updateDocumentByDocumentUuid(
       {
         ...newUpdateRequest(),
         meadowlarkId: documentWithReferencesMeadowlarkId,
@@ -420,7 +420,7 @@ describe('given an update of a document with one existing and one non-existent r
 
     // The updated document with both valid and invalid references
     documentWithReferencesInfo.documentReferences = [validReference, invalidReference];
-    updateResult = await updateDocumentById(
+    updateResult = await updateDocumentByDocumentUuid(
       {
         ...newUpdateRequest(),
         documentUuid: upsertResult.newDocumentUuid,
@@ -541,7 +541,7 @@ describe('given an update of a subclass document referenced by an existing docum
 
     // The updated document with reference as superclass
     documentWithReferenceDocumentInfo.documentReferences = [referenceAsSuperclass];
-    updateResult = await updateDocumentById(
+    updateResult = await updateDocumentByDocumentUuid(
       {
         ...newUpdateRequest(),
         documentUuid: upsertResult.newDocumentUuid,
@@ -620,7 +620,7 @@ describe('given the update of an existing document changing meadowlarkId with al
       edfiDoc: { natural: 'key' },
     };
     // change document identity
-    updateResult = await updateDocumentById({ ...updateRequest, edfiDoc: { changeToDoc: true } }, client);
+    updateResult = await updateDocumentByDocumentUuid({ ...updateRequest, edfiDoc: { changeToDoc: true } }, client);
   });
 
   afterAll(async () => {
@@ -685,7 +685,7 @@ describe('given the update of an existing document changing meadowlarkId with al
       edfiDoc: { natural: 'key' },
     };
     // change document identity
-    updateResult = await updateDocumentById({ ...updateRequest, edfiDoc: { changeToDoc: true } }, client);
+    updateResult = await updateDocumentByDocumentUuid({ ...updateRequest, edfiDoc: { changeToDoc: true } }, client);
   });
 
   afterAll(async () => {
@@ -710,6 +710,6 @@ describe('given the update of an existing document changing meadowlarkId with al
       onlyReturnAliasIds(session),
     );
 
-    expect(documents.aliasIds.length).toEqual(1);
+    expect(documents.aliasMeadowlarkIds.length).toEqual(1);
   });
 });

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/locking/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/integration/locking/Delete.test.ts
@@ -139,7 +139,7 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
     const deleteSession: ClientSession = client.startSession();
     deleteSession.startTransaction();
 
-    // Get the aliasIds for the School document, used to check for references to it as School or as EducationOrganization
+    // Get the aliasMeadowlarkIds for the School document, used to check for references to it as School or as EducationOrganization
     const deleteCandidate: any = await mongoCollection.findOne(
       { _id: schoolMeadowlarkId },
       onlyReturnAliasIds(deleteSession),
@@ -147,7 +147,7 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
 
     // Check for any references to the School document
     const anyReferences = await mongoCollection.findOne(
-      onlyDocumentsReferencing(deleteCandidate.aliasIds),
+      onlyDocumentsReferencing(deleteCandidate.aliasMeadowlarkIds),
       onlyReturnId(deleteSession),
     );
 

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/model/MeadowlarkDocument.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/model/MeadowlarkDocument.test.ts
@@ -51,7 +51,7 @@ describe('given non-superclass document info with no references', () => {
     expect(meadowlarkDocument).toMatchInlineSnapshot(`
       {
         "_id": "Qw5FvPdKxAXWnGgh_UOwCVjZeWJb5MV0Gd-nQg",
-        "aliasIds": [
+        "aliasMeadowlarkIds": [
           "Qw5FvPdKxAXWnGgh_UOwCVjZeWJb5MV0Gd-nQg",
         ],
         "createdAt": 1673827200000,
@@ -169,7 +169,7 @@ describe('given superclass document info', () => {
   });
 
   it('should have two alias ids', async () => {
-    expect(meadowlarkDocument.aliasIds).toMatchInlineSnapshot(`
+    expect(meadowlarkDocument.aliasMeadowlarkIds).toMatchInlineSnapshot(`
       [
         "Qw5FvPdKxAXWnGgh_UOwCVjZeWJb5MV0Gd-nQg",
         "dfR7WrhrnYMh8lF_mnIhAN2Ur2Ji2MmlGBcSUg",

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/repository/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/repository/Delete.test.ts
@@ -1,6 +1,6 @@
 import { DeleteRequest, newSecurity, TraceId, NoResourceInfo, DocumentUuid } from '@edfi/meadowlark-core';
 import * as utilities from '@edfi/meadowlark-utilities';
-import { deleteDocumentById } from '../../src/repository/Delete';
+import { deleteDocumentByDocumentUuid } from '../../src/repository/Delete';
 import * as DB from '../../src/repository/Db';
 
 describe('given a transaction on a resource', () => {
@@ -42,7 +42,7 @@ describe('given a transaction on a resource', () => {
     describe('given that a number of retries greater than zero has been configured', () => {
       beforeAll(async () => {
         jest.spyOn(utilities.Config, 'get').mockReturnValue(retryNumberOfTimes);
-        result = await deleteDocumentById(newDeleteRequest(), mongoClientMock as any);
+        result = await deleteDocumentByDocumentUuid(newDeleteRequest(), mongoClientMock as any);
       });
 
       it('returns error', async () => {
@@ -61,7 +61,7 @@ describe('given a transaction on a resource', () => {
     describe('given that a number of retries equal to zero has been configured', () => {
       beforeAll(async () => {
         jest.spyOn(utilities.Config, 'get').mockReturnValue(0);
-        result = await deleteDocumentById(newDeleteRequest(), mongoClientMock as any);
+        result = await deleteDocumentByDocumentUuid(newDeleteRequest(), mongoClientMock as any);
       });
 
       it('should not retry', () => {
@@ -75,7 +75,7 @@ describe('given a transaction on a resource', () => {
 
     describe('given that a number of retries was not configured', () => {
       beforeAll(async () => {
-        result = await deleteDocumentById(newDeleteRequest(), mongoClientMock as any);
+        result = await deleteDocumentByDocumentUuid(newDeleteRequest(), mongoClientMock as any);
       });
 
       it('should not retry', () => {

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/test/repository/Update.test.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/test/repository/Update.test.ts
@@ -8,7 +8,7 @@ import {
   TraceId,
 } from '@edfi/meadowlark-core';
 import * as utilities from '@edfi/meadowlark-utilities';
-import { updateDocumentById } from '../../src/repository/Update';
+import { updateDocumentByDocumentUuid } from '../../src/repository/Update';
 import * as DB from '../../src/repository/Db';
 
 describe('given a transaction on a resource', () => {
@@ -56,7 +56,7 @@ describe('given a transaction on a resource', () => {
       beforeAll(async () => {
         jest.spyOn(DB, 'writeLockReferencedDocuments').mockImplementationOnce(async () => Promise.resolve());
         jest.spyOn(utilities.Config, 'get').mockReturnValue(retryNumberOfTimes);
-        result = await updateDocumentById(newUpdateRequest(), mongoClientMock as any);
+        result = await updateDocumentByDocumentUuid(newUpdateRequest(), mongoClientMock as any);
       });
 
       it('returns error', async () => {
@@ -76,7 +76,7 @@ describe('given a transaction on a resource', () => {
       beforeAll(async () => {
         jest.spyOn(DB, 'writeLockReferencedDocuments').mockImplementationOnce(async () => Promise.resolve());
         jest.spyOn(utilities.Config, 'get').mockReturnValue(0);
-        result = await updateDocumentById(newUpdateRequest(), mongoClientMock as any);
+        result = await updateDocumentByDocumentUuid(newUpdateRequest(), mongoClientMock as any);
       });
 
       it('should not retry', () => {
@@ -91,7 +91,7 @@ describe('given a transaction on a resource', () => {
     describe('given that a number of retries was not configured', () => {
       beforeAll(async () => {
         jest.spyOn(DB, 'writeLockReferencedDocuments').mockImplementationOnce(async () => Promise.resolve());
-        result = await updateDocumentById(newUpdateRequest(), mongoClientMock as any);
+        result = await updateDocumentByDocumentUuid(newUpdateRequest(), mongoClientMock as any);
       });
 
       it('should not retry', () => {

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Get.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Get.ts
@@ -15,12 +15,12 @@ export async function getDocumentByDocumentUuid(
   client: PoolClient,
 ): Promise<GetResult> {
   try {
-    Logger.debug(`${moduleName}.getDocumentById ${documentUuid}`, traceId);
+    Logger.debug(`${moduleName}.getDocumentByDocumentUuid ${documentUuid}`, traceId);
     const queryResult: QueryResult = await client.query(findDocumentByDocumentUuidSql(documentUuid));
 
     // Postgres will return an empty row set if no results are returned, if we have no rows, there is a problem
     if (queryResult.rows == null) {
-      const errorMessage = `Could not retrieve document ${documentUuid}
+      const errorMessage = `Could not retrieve DocumentUuid ${documentUuid}
       a null result set was returned, indicating system failure`;
       Logger.error(errorMessage, traceId);
       return {
@@ -34,11 +34,11 @@ export async function getDocumentByDocumentUuid(
 
     const response: GetResult = {
       response: 'GET_SUCCESS',
-      document: { id: queryResult.rows[0].document_id, ...queryResult.rows[0].edfi_doc },
+      document: { id: queryResult.rows[0].meadowlark_id, ...queryResult.rows[0].edfi_doc },
     };
     return response;
   } catch (e) {
-    Logger.error(`${moduleName}.getDocumentById Error retrieving document ${documentUuid}`, traceId, e);
+    Logger.error(`${moduleName}.getDocumentByDocumentUuid Error retrieving DocumentUuid ${documentUuid}`, traceId, e);
     return { response: 'UNKNOWN_FAILURE', document: [] };
   }
 }

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/OwnershipSecurity.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/OwnershipSecurity.ts
@@ -7,7 +7,7 @@ import { meadowlarkIdForDocumentIdentity, FrontendRequest, writeRequestToLog, Me
 import { Logger } from '@edfi/meadowlark-utilities';
 import type { PoolClient, QueryResult } from 'pg';
 import { SecurityResult } from '../security/SecurityResult';
-import { findOwnershipForDocumentByDocumentUuidSql, findOwnershipForDocumentSql } from './SqlHelper';
+import { findOwnershipForDocumentByDocumentUuidSql, findOwnershipForDocumentByMeadowlarkIdSql } from './SqlHelper';
 
 function extractIdIfUpsert(frontendRequest: FrontendRequest): MeadowlarkId | undefined {
   if (frontendRequest.action !== 'upsert') return undefined;
@@ -50,7 +50,7 @@ export async function rejectByOwnershipSecurity(
   }
 
   if (documentUuid == null && meadowlarkId === '') {
-    Logger.error(`${functionName} no id to secure against`, frontendRequest.traceId);
+    Logger.error(`${functionName} no MeadowlarkId or DocumentUuid to secure against`, frontendRequest.traceId);
     return 'NOT_APPLICABLE';
   }
 
@@ -58,7 +58,7 @@ export async function rejectByOwnershipSecurity(
     const result: QueryResult =
       documentUuid != null
         ? await client.query(findOwnershipForDocumentByDocumentUuidSql(documentUuid))
-        : await client.query(findOwnershipForDocumentSql(meadowlarkId));
+        : await client.query(findOwnershipForDocumentByMeadowlarkIdSql(meadowlarkId));
 
     if (result.rows == null) {
       Logger.error(`${functionName} Unknown Error determining access`, frontendRequest.traceId);

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
@@ -8,61 +8,65 @@ import format from 'pg-format';
 // SQL for Selects
 
 /**
- * Returns the SQL query that does a reverse lookup to find the ids of documents that reference the given ids.
+ * Returns the SQL query that does a reverse lookup to find the meadowlarkIds of documents that reference the given
+ * meadowlarkIds.
  *
- * @param referencedMeadowlarkIds the ids of the documents that are being referenced
- * @returns a SQL query to find the ids of the documents referencing the given ids
+ * @param referencedMeadowlarkIds the meadowlarkIds of the documents that are being referenced
+ * @returns a SQL query to find the meadowlarkIds of the documents referencing the given meadowlarkIds
  */
 export function findReferencingMeadowlarkIdsSql(referencedMeadowlarkIds: MeadowlarkId[]): string {
   return format(
-    `SELECT parent_document_id FROM meadowlark.references WHERE referenced_document_id IN (%L)`,
+    `SELECT parent_meadowlark_id FROM meadowlark.references WHERE referenced_meadowlark_id IN (%L)`,
     referencedMeadowlarkIds,
   );
 }
 
 /**
- * Returns the SQL query to find the alias ids for a given document. Alias ids include the document id
- * itself along with any superclass variations that the document satisifies. For example, a School is a subclass
- * of EducationOrganization, so each School document has an additional alias id as an EducationOrganization.
+ * Returns the SQL query to find the alias meadowlarkIds for a given document. Alias meadowlarkIds include the document
+ * meadowlarkId itself along with any superclass variations that the document satisifies. For example, a School is a subclass
+ * of EducationOrganization, so each School document has an additional alias meadowlarkId as an EducationOrganization.
  *
  * This has a secondary function of read-for-write locking this row for proper updating and deleting.
  *
- * @param meadowlarkId the id of the document to find aliases for
- * @returns a SQL query to find the alias ids of the given document
+ * @param meadowlarkId the meadowlarkId of the document to find aliases for
+ * @returns a SQL query to find the alias meadowlarkIds of the given document
  */
-export function findAliasIdsForDocumentByMeadowlarkIdSql(meadowlarkId: MeadowlarkId): string {
-  return format(`SELECT alias_id FROM meadowlark.aliases WHERE document_id = %L FOR SHARE NOWAIT`, meadowlarkId);
+export function findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql(meadowlarkId: MeadowlarkId): string {
+  return format(
+    `SELECT alias_meadowlark_id FROM meadowlark.aliases WHERE meadowlark_id = %L FOR SHARE NOWAIT`,
+    meadowlarkId,
+  );
 }
 
 /**
- * Returns the SQL query to find the alias ids for a given document. Alias ids include the document id
- * itself along with any superclass variations that the document satisifies. For example, a School is a subclass
- * of EducationOrganization, so each School document has an additional alias id as an EducationOrganization.
+ * Returns the SQL query to find the alias meadowlarkIds for a given document. Alias meadowlarkIds include the document
+ * meadowlarkId itself along with any superclass variations that the document satisifies. For example, a School is a subclass
+ * of EducationOrganization, so each School document has an additional alias meadowlarkId as an EducationOrganization.
  *
  * This has a secondary function of read-for-write locking this row for proper updating and deleting.
  *
- * @param meadowlarkId the id of the document to find aliases for
- * @returns a SQL query to find the alias ids of the given document
+ * @param meadowlarkId the meadowlarkId of the document to find aliases for
+ * @returns a SQL query to find the alias meadowlarkIds of the given document
  */
-export function findAliasIdsForDocumentByDocumentUuidSql(documentUuid: DocumentUuid): string {
+export function findAliasMeadowlarkIdsForDocumentByDocumentUuidSql(documentUuid: DocumentUuid): string {
   return format(
-    `SELECT alias_id, document_id FROM meadowlark.aliases WHERE document_uuid = %L FOR SHARE NOWAIT`,
+    `SELECT alias_meadowlark_id, meadowlark_id FROM meadowlark.aliases WHERE document_uuid = %L FOR SHARE NOWAIT`,
     documentUuid,
   );
 }
 
 /**
- * Returns the SQL query to find the existence of an alias id. Alias ids include the document id
+ * Returns the SQL query to find the existence of an alias meadowlarkId. Alias meadowlarkIds include the document meadowlarkId
  * itself along with any superclass variations that the document satisifies. For example, a School is a subclass
- * of EducationOrganization, so each School document has an additional alias id as an EducationOrganization.
+ * of EducationOrganization, so each School document has an additional alias meadowlarkId as an EducationOrganization.
  *
  * This function does NOT read-for-write lock.
  *
- * @param meadowlarkId the id of the document to find aliases for
- * @returns a SQL query to find the alias ids of the given document
+ * @param meadowlarkId the meadowlarkId of the document to find aliases for
+ * @returns a SQL query to find the alias meadowlarkIds of the given document
  */
-export function findAliasIdSql(meadowlarkId: MeadowlarkId): string {
-  return format(`SELECT alias_id FROM meadowlark.aliases WHERE alias_id = %L`, meadowlarkId);
+export function findAliasMeadowlarkIdSql(meadowlarkId: MeadowlarkId): string {
+  return format(`SELECT alias_meadowlark_id FROM meadowlark.aliases WHERE alias_meadowlark_id = %L`, meadowlarkId);
 }
 
 /**
@@ -73,9 +77,9 @@ export function findAliasIdSql(meadowlarkId: MeadowlarkId): string {
 export function findDocumentByMeadowlarkIdSql(meadowlarkId: MeadowlarkId): string {
   return format(
     `
-    SELECT document_uuid, document_id, document_identity, edfi_doc
+    SELECT document_uuid, meadowlark_id, document_identity, edfi_doc
        FROM meadowlark.documents
-       WHERE document_id = %L;`,
+       WHERE meadowlark_id = %L;`,
     [meadowlarkId],
   );
 }
@@ -88,7 +92,7 @@ export function findDocumentByMeadowlarkIdSql(meadowlarkId: MeadowlarkId): strin
 export function findDocumentByDocumentUuidSql(documentUuid: DocumentUuid): string {
   return format(
     `
-    SELECT document_uuid, document_id, document_identity, edfi_doc
+    SELECT document_uuid, meadowlark_id, document_identity, edfi_doc
        FROM meadowlark.documents
        WHERE document_uuid = %L;`,
     [documentUuid],
@@ -109,33 +113,36 @@ export function findOwnershipForDocumentByDocumentUuidSql(documentUuid: Document
  * @param meadowlarkId The identifier of the document
  * @returns SQL query string to retrieve ownership
  */
-export function findOwnershipForDocumentSql(meadowlarkId: MeadowlarkId): string {
-  return format('SELECT created_by FROM meadowlark.documents WHERE document_id = %L;', [meadowlarkId]);
+export function findOwnershipForDocumentByMeadowlarkIdSql(meadowlarkId: MeadowlarkId): string {
+  return format('SELECT created_by FROM meadowlark.documents WHERE meadowlark_id = %L;', [meadowlarkId]);
 }
 
 /**
- * Returns the SQL statement for retrieving alias ids from the aliases table for the given
+ * Returns the SQL statement for retrieving alias meadowlarkIds from the aliases table for the given
  * documents. This allows for checking for the existence of documents from the aliases table for deletes
  * and general reference validation.
  *
- * @param meadowlarkIds the id of the document we're checking references for
- * @returns SQL query string to retrieve existing alias ids
+ * @param meadowlarkIds the meadowlarkId of the document we're checking references for
+ * @returns SQL query string to retrieve existing alias meadowlarkIds
  */
 export function validateReferenceExistenceSql(meadowlarkIds: MeadowlarkId[]): string {
-  return format(`SELECT alias_id FROM meadowlark.aliases WHERE alias_id IN (%L) FOR NO KEY UPDATE NOWAIT`, meadowlarkIds);
+  return format(
+    `SELECT alias_meadowlark_id FROM meadowlark.aliases WHERE alias_meadowlark_id IN (%L) FOR NO KEY UPDATE NOWAIT`,
+    meadowlarkIds,
+  );
 }
 
 /**
- * Returns the SQL statement for retrieving alias ids from the aliases table for the given
+ * Returns the SQL statement for retrieving alias meadowlarkIds from the aliases table for the given
  * documents. This allows for checking for the existence of documents from the aliases table for deletes
  * and general reference validation.
  *
- * @param meadowlarkIds the id of the document we're checking references for
- * @returns SQL query string to retrieve existing alias ids
+ * @param meadowlarkIds the meadowlarkId of the document we're checking references for
+ * @returns SQL query string to retrieve existing alias meadowlarkIds
  */
 export function validateReferenceExistenceByDocumentUuidSql(documentUuids: DocumentUuid[]): string {
   return format(
-    `SELECT alias_id FROM meadowlark.aliases WHERE document_uuid IN (%L) FOR NO KEY UPDATE NOWAIT`,
+    `SELECT alias_meadowlark_id FROM meadowlark.aliases WHERE document_uuid IN (%L) FOR NO KEY UPDATE NOWAIT`,
     documentUuids,
   );
 }
@@ -145,11 +152,11 @@ export function validateReferenceExistenceByDocumentUuidSql(documentUuids: Docum
  * This is for error reporting when an attempt is made to delete the document.
  *
  * @param referringMeadowlarkIds The referring documents
- * @returns SQL query string to retrieve the document_id and resource_name of the referring documents
+ * @returns SQL query string to retrieve the meadowlark_id and resource_name of the referring documents
  */
 export function findReferringDocumentInfoForErrorReportingSql(referringMeadowlarkIds: MeadowlarkId[]): string {
   return format(
-    `SELECT project_name, resource_name, resource_version, document_id, document_uuid FROM meadowlark.documents WHERE document_id IN (%L) LIMIT 5`,
+    `SELECT project_name, resource_name, resource_version, meadowlark_id, document_uuid FROM meadowlark.documents WHERE meadowlark_id IN (%L) LIMIT 5`,
     referringMeadowlarkIds,
   );
 }
@@ -158,14 +165,14 @@ export function findReferringDocumentInfoForErrorReportingSql(referringMeadowlar
 
 /**
  * Returns the SQL statement to add an alias entry to the alias table
- * @param meadowlarkId the document with the given alias id
- * @param aliasId the alias id for the given document, this may be the same as the meadowlarkId
+ * @param meadowlarkId the document with the given alias meadowlarkId
+ * @param aliasId the alias meadowlarkId for the given document, this may be the same as the meadowlarkId
  * @returns SQL query string to insert into the aliases table
  */
 export function insertAliasSql(documentUuid: DocumentUuid, meadowlarkId: MeadowlarkId, aliasId: MeadowlarkId): string {
   return format(
     `INSERT INTO meadowlark.aliases
-     (document_uuid, document_id, alias_id)
+     (document_uuid, meadowlark_id, alias_meadowlark_id)
      VALUES (%L)`,
     [documentUuid, meadowlarkId, aliasId],
   );
@@ -178,7 +185,7 @@ export function insertAliasSql(documentUuid: DocumentUuid, meadowlarkId: Meadowl
  * @returns SQL query string to insert reference into references table
  */
 export function insertOutboundReferencesSql(meadowlarkId: MeadowlarkId, referencedMeadowlarkId: MeadowlarkId): string {
-  return format('INSERT INTO meadowlark.references (parent_document_id, referenced_document_id) VALUES (%L);', [
+  return format('INSERT INTO meadowlark.references (parent_meadowlark_id, referenced_meadowlark_id) VALUES (%L);', [
     meadowlarkId,
     referencedMeadowlarkId,
   ]);
@@ -191,11 +198,11 @@ export function insertOutboundReferencesSql(meadowlarkId: MeadowlarkId, referenc
  * @returns SQL query string for inserting or updating provided document info
  */
 export function documentInsertOrUpdateSql(
-  { id, documentUuid, resourceInfo, documentInfo, edfiDoc, validateDocumentReferencesExist, security },
+  { meadowlarkId, documentUuid, resourceInfo, documentInfo, edfiDoc, validateDocumentReferencesExist, security },
   isInsert: boolean,
 ): string {
   const documentValues = [
-    id,
+    meadowlarkId,
     documentUuid,
     JSON.stringify(documentInfo.documentIdentity),
     resourceInfo.projectName,
@@ -213,7 +220,7 @@ export function documentInsertOrUpdateSql(
     documentSql = format(
       `
       INSERT INTO meadowlark.documents
-        (document_id, document_uuid, document_identity, project_name, resource_name, resource_version, is_descriptor,
+        (meadowlark_id, document_uuid, document_identity, project_name, resource_name, resource_version, is_descriptor,
         validated, created_by, edfi_doc)
         VALUES (%L)
         RETURNING document_uuid;`,
@@ -224,7 +231,7 @@ export function documentInsertOrUpdateSql(
       `
       UPDATE meadowlark.documents
         SET
-        document_id = %L,
+        meadowlark_id = %L,
         document_identity = %L,
         project_name = %L,
         resource_name = %L,
@@ -267,23 +274,23 @@ export function deleteDocumentByDocumentUuIdSql(documentUuid: DocumentUuid): str
  * Returns the SQL query for deleting the outbound references of a document from the database.
  * Used as part of deleting the document itself.
  *
- * @param meadowlarkId the id of the document whose outbound references we want to delete
+ * @param meadowlarkId the meadowlarkId of the document whose outbound references we want to delete
  * @returns SQL query string to delete references
  */
-export function deleteOutboundReferencesOfDocumentSql(meadowlarkId: MeadowlarkId): string {
-  const sql = format('DELETE FROM meadowlark.references WHERE parent_document_id = (%L);', [meadowlarkId]);
+export function deleteOutboundReferencesOfDocumentByMeadowlarkIdSql(meadowlarkId: MeadowlarkId): string {
+  const sql = format('DELETE FROM meadowlark.references WHERE parent_meadowlark_id = (%L);', [meadowlarkId]);
   return sql;
 }
 
 /**
- * Returns the SQL query for deleting aliases for a given document id. Used as part of deleting the document itself.
- * @param meadowlarkId the id of the document we're deleting aliases for
+ * Returns the SQL query for deleting aliases for a given document meadowlarkId. Used as part of deleting the document itself.
+ * @param meadowlarkId the meadowlarkId of the document we're deleting aliases for
  * @returns SQL query string for deleting aliases
  */
-export function deleteAliasesForDocumentSql(meadowlarkId: MeadowlarkId): string {
+export function deleteAliasesForDocumentByMeadowlarkIdSql(meadowlarkId: MeadowlarkId): string {
   return format(
     `DELETE from meadowlark.aliases
-  WHERE document_id = %L`,
+  WHERE meadowlark_id = %L`,
     [meadowlarkId],
   );
 }
@@ -310,7 +317,7 @@ export const createSchemaSql = 'CREATE SCHEMA IF NOT EXISTS meadowlark';
 export const createDocumentTableSql = `
   CREATE TABLE IF NOT EXISTS meadowlark.documents(
   id bigserial PRIMARY KEY,
-  document_id VARCHAR(56) NOT NULL,
+  meadowlark_id VARCHAR(56) NOT NULL,
   document_uuid uuid,
   document_identity JSONB NOT NULL,
   project_name VARCHAR NOT NULL,
@@ -321,9 +328,9 @@ export const createDocumentTableSql = `
   created_by VARCHAR(100) NULL,
   edfi_doc JSONB NOT NULL);`;
 
-// All queries are on document_id, which must be unique
+// All queries are on meadowlark_id, which must be unique
 export const createDocumentTableUniqueIndexSql =
-  'CREATE UNIQUE INDEX IF NOT EXISTS ux_meadowlark_documents ON meadowlark.documents(document_id)';
+  'CREATE UNIQUE INDEX IF NOT EXISTS ux_meadowlark_documents ON meadowlark.documents(meadowlark_id)';
 
 // All queries are on document_uuid, which must be unique
 export const createDocumentUuidTableUniqueIndexSql =
@@ -335,16 +342,16 @@ export const createDocumentUuidTableUniqueIndexSql =
 export const createReferencesTableSql = `
   CREATE TABLE IF NOT EXISTS meadowlark.references(
   id bigserial PRIMARY KEY,
-  parent_document_id VARCHAR NOT NULL,
-  referenced_document_id VARCHAR NOT NULL);`;
+  parent_meadowlark_id VARCHAR NOT NULL,
+  referenced_meadowlark_id VARCHAR NOT NULL);`;
 
 // For reference checking before parent delete
 export const createReferencesTableCheckingIndexSql =
-  'CREATE INDEX IF NOT EXISTS ix_meadowlark_references_checking ON meadowlark.references(referenced_document_id)';
+  'CREATE INDEX IF NOT EXISTS ix_meadowlark_references_checking ON meadowlark.references(referenced_meadowlark_id)';
 
 // For reference removal in transaction with parent update/delete
 export const createReferencesTableDeletingIndexSql =
-  'CREATE INDEX IF NOT EXISTS ix_meadowlark_references_deleting ON meadowlark.references(parent_document_id)';
+  'CREATE INDEX IF NOT EXISTS ix_meadowlark_references_deleting ON meadowlark.references(parent_meadowlark_id)';
 
 /**
  * SQL query string to create the aliases table
@@ -352,18 +359,18 @@ export const createReferencesTableDeletingIndexSql =
 export const createAliasesTableSql = `
   CREATE TABLE IF NOT EXISTS meadowlark.aliases(
     id bigserial PRIMARY KEY,
-    document_id VARCHAR,
+    meadowlark_id VARCHAR,
     document_uuid uuid,
-    alias_id VARCHAR);`;
+    alias_meadowlark_id VARCHAR);`;
 
-// For finding alias ids given a document id
+// For finding alias meadowlarkIds given a document meadowlarkId
 export const createAliasesTableDocumentIndexSql =
-  'CREATE INDEX IF NOT EXISTS ix_meadowlark_aliases_document_id ON meadowlark.aliases(document_id)';
+  'CREATE INDEX IF NOT EXISTS ix_meadowlark_aliases_meadowlark_id ON meadowlark.aliases(meadowlark_id)';
 
-// For finding alias ids given a document_uuid
+// For finding alias meadowlarkIds given a document_uuid
 export const createAliasesTableDocumentUuidIndexSql =
   'CREATE INDEX IF NOT EXISTS ix_meadowlark_aliases_document_uuid ON meadowlark.aliases(document_uuid)';
 
-// For finding document ids given an alias id
+// For finding document meadowlarkIds given an alias meadowlarkId
 export const createAliasesTableAliasIndexSql =
-  'CREATE INDEX IF NOT EXISTS ix_meadowlark_aliases_alias_id ON meadowlark.aliases(alias_id)';
+  'CREATE INDEX IF NOT EXISTS ix_meadowlark_aliases_alias_meadowlark_id ON meadowlark.aliases(alias_meadowlark_id)';

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
@@ -30,7 +30,7 @@ import { getSharedClient, resetSharedClient } from '../../src/repository/Db';
 import { deleteDocumentByDocumentUuid } from '../../src/repository/Delete';
 import { upsertDocument } from '../../src/repository/Upsert';
 import {
-  findAliasIdsForDocumentByMeadowlarkIdSql,
+  findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql,
   findDocumentByDocumentUuidSql,
   findDocumentByMeadowlarkIdSql,
   findReferencingMeadowlarkIdsSql,
@@ -53,7 +53,7 @@ const newDeleteRequest = (): DeleteRequest => ({
   security: { ...newSecurity() },
   traceId: 'traceId' as TraceId,
 });
-
+jest.setTimeout(120000);
 describe('given the delete of a non-existent document', () => {
   let client: PoolClient;
   let deleteResult: DeleteResult;
@@ -66,6 +66,7 @@ describe('given the delete of a non-existent document', () => {
   const documentUuid = generateDocumentUuid();
 
   beforeAll(async () => {
+    jest.setTimeout(120000);
     client = await getSharedClient();
 
     deleteResult = await deleteDocumentByDocumentUuid(
@@ -168,7 +169,7 @@ describe('given an delete of a document referenced by an existing document with 
     documentIdentity: { natural: 'delete6' },
     documentReferences: [validReference],
   };
-  const documentWithReferencesId = meadowlarkIdForDocumentIdentity(
+  const documentWithReferencesMeadowlarkId = meadowlarkIdForDocumentIdentity(
     documentWithReferencesResourceInfo,
     documentWithReferencesInfo.documentIdentity,
   );
@@ -186,7 +187,7 @@ describe('given an delete of a document referenced by an existing document with 
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         documentInfo: documentWithReferencesInfo,
         validateDocumentReferencesExist: true,
       },
@@ -255,7 +256,7 @@ describe('given an delete of a document with an outbound reference only, with va
     documentIdentity: { natural: 'delete16' },
     documentReferences: [validReference],
   };
-  const documentWithReferencesId = meadowlarkIdForDocumentIdentity(
+  const documentWithReferencesMeadowlarkId = meadowlarkIdForDocumentIdentity(
     documentWithReferencesResourceInfo,
     documentWithReferencesInfo.documentIdentity,
   );
@@ -273,7 +274,7 @@ describe('given an delete of a document with an outbound reference only, with va
     const documentWithReferenceUpsertResult: UpsertResult = await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         documentInfo: documentWithReferencesInfo,
         validateDocumentReferencesExist: true,
       },
@@ -305,13 +306,15 @@ describe('given an delete of a document with an outbound reference only, with va
   });
 
   it('should have deleted the document in the db', async () => {
-    const result: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
+    const result: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesMeadowlarkId));
 
     expect(result.rowCount).toEqual(0);
   });
 
   it('should have deleted the document alias in the db', async () => {
-    const result: any = await client.query(findAliasIdsForDocumentByMeadowlarkIdSql(documentWithReferencesId));
+    const result: any = await client.query(
+      findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql(documentWithReferencesMeadowlarkId),
+    );
 
     expect(result.rowCount).toEqual(0);
   });
@@ -355,7 +358,7 @@ describe('given an delete of a document referenced by an existing document with 
     documentIdentity: { natural: 'delete6' },
     documentReferences: [validReference],
   };
-  const documentWithReferencesId = meadowlarkIdForDocumentIdentity(
+  const documentWithReferencesMeadowlarkId = meadowlarkIdForDocumentIdentity(
     documentWithReferencesResourceInfo,
     documentWithReferencesInfo.documentIdentity,
   );
@@ -373,7 +376,7 @@ describe('given an delete of a document referenced by an existing document with 
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         documentInfo: documentWithReferencesInfo,
         validateDocumentReferencesExist: true,
       },
@@ -458,7 +461,7 @@ describe('given the delete of a subclass document referenced by an existing docu
     documentIdentity: { week: 'delete6' },
     documentReferences: [referenceAsSuperclass],
   };
-  const documentWithReferencesId = meadowlarkIdForDocumentIdentity(
+  const documentWithReferencesMeadowlarkId = meadowlarkIdForDocumentIdentity(
     documentWithReferenceResourceInfo,
     documentWithReferenceDocumentInfo.documentIdentity,
   );
@@ -474,7 +477,7 @@ describe('given the delete of a subclass document referenced by an existing docu
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         documentInfo: documentWithReferenceDocumentInfo,
         validateDocumentReferencesExist: true,
       },

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
@@ -53,7 +53,7 @@ const newDeleteRequest = (): DeleteRequest => ({
   security: { ...newSecurity() },
   traceId: 'traceId' as TraceId,
 });
-jest.setTimeout(120000);
+
 describe('given the delete of a non-existent document', () => {
   let client: PoolClient;
   let deleteResult: DeleteResult;
@@ -66,7 +66,6 @@ describe('given the delete of a non-existent document', () => {
   const documentUuid = generateDocumentUuid();
 
   beforeAll(async () => {
-    jest.setTimeout(120000);
     client = await getSharedClient();
 
     deleteResult = await deleteDocumentByDocumentUuid(

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/OwnershipSecurity.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/OwnershipSecurity.test.ts
@@ -26,7 +26,7 @@ import { rejectByOwnershipSecurity } from '../../src/repository/OwnershipSecurit
 import { upsertDocument } from '../../src/repository/Upsert';
 import { SecurityResult } from '../../src/security/SecurityResult';
 
-describe('given the upsert where no document id is specified', () => {
+describe('given the upsert where no meadowlark id is specified', () => {
   let client: PoolClient;
   let result: SecurityResult;
 
@@ -52,7 +52,7 @@ describe('given the upsert where no document id is specified', () => {
     await resetSharedClient();
   });
 
-  it('should not apply security when no document id is specified', async () => {
+  it('should not apply security when no meadowlark id is specified', async () => {
     expect(result).toBe('NOT_APPLICABLE');
   });
 });

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/SecurityMiddleware.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/SecurityMiddleware.test.ts
@@ -26,7 +26,7 @@ import { securityMiddleware } from '../../src/security/SecurityMiddleware';
 import { upsertDocument } from '../../src/repository/Upsert';
 import { deleteAll } from './TestHelper';
 
-describe('given the upsert where no document id is specified', () => {
+describe('given the upsert where no meadowlark id is specified', () => {
   let client: PoolClient;
   let result: MiddlewareModel;
 
@@ -52,7 +52,7 @@ describe('given the upsert where no document id is specified', () => {
     await resetSharedClient();
   });
 
-  it('should not respond when no document id is specified', async () => {
+  it('should not respond when no meadowlark id is specified', async () => {
     expect(result.frontendResponse).toBeNull();
   });
 });

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/TestHelper.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/TestHelper.ts
@@ -12,11 +12,11 @@ export async function deleteAll(client: PoolClient): Promise<void> {
   await client.query('TRUNCATE TABLE meadowlark.aliases');
 }
 
-export const verifyAliasId = (aliasId: string): string =>
+export const verifyAliasMeadowlarkId = (aliasMeadowlarkId: MeadowlarkId): string =>
   format(
-    `SELECT alias_id from meadowlark.aliases
-  WHERE document_id = %L AND alias_id != %1$L`,
-    [aliasId],
+    `SELECT alias_meadowlark_id from meadowlark.aliases
+  WHERE meadowlark_id = %L AND alias_meadowlark_id != %1$L`,
+    [aliasMeadowlarkId],
   );
 
 /**
@@ -25,5 +25,5 @@ export const verifyAliasId = (aliasId: string): string =>
  * @returns SQL query string to retrieve references
  */
 export function retrieveReferencesByMeadowlarkIdSql(meadowlarkId: MeadowlarkId): string {
-  return format('SELECT referenced_document_id FROM meadowlark.references WHERE parent_document_id=%L', [meadowlarkId]);
+  return format('SELECT referenced_meadowlark_id FROM meadowlark.references WHERE parent_meadowlark_id=%L', [meadowlarkId]);
 }

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
@@ -28,10 +28,10 @@ import type { PoolClient } from 'pg';
 import { resetSharedClient, getSharedClient } from '../../src/repository/Db';
 import { updateDocumentByDocumentUuid } from '../../src/repository/Update';
 import { upsertDocument } from '../../src/repository/Upsert';
-import { deleteAll, retrieveReferencesByMeadowlarkIdSql, verifyAliasId } from './TestHelper';
+import { deleteAll, retrieveReferencesByMeadowlarkIdSql, verifyAliasMeadowlarkId } from './TestHelper';
 import { getDocumentByDocumentUuid } from '../../src/repository/Get';
 import {
-  findAliasIdsForDocumentByMeadowlarkIdSql,
+  findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql,
   findDocumentByDocumentUuidSql,
   findDocumentByMeadowlarkIdSql,
 } from '../../src/repository/SqlHelper';
@@ -251,7 +251,7 @@ describe('given an update of a document that references a non-existent document 
     const docResult: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
     const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesId));
 
-    const outboundRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
+    const outboundRefs = refsResult.rows.map((ref) => ref.referenced_meadowlark_id);
 
     expect(docResult.rows[0].document_identity.natural).toBe('update4');
 
@@ -356,7 +356,7 @@ describe('given an update of a document that references an existing document wit
     const docResult: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
     const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesId));
 
-    const outboundRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
+    const outboundRefs = refsResult.rows.map((ref) => ref.referenced_meadowlark_id);
     expect(docResult.rows[0].document_identity.natural).toBe('update6');
     expect(outboundRefs).toMatchInlineSnapshot(`
       [
@@ -480,7 +480,7 @@ describe('given an update of a document with one existing and one non-existent r
   it('should not have updated the document with an invalid reference in the db', async () => {
     const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesId));
 
-    const outboundRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
+    const outboundRefs = refsResult.rows.map((ref) => ref.referenced_meadowlark_id);
     expect(outboundRefs).toHaveLength(0);
   });
 });
@@ -583,8 +583,8 @@ describe('given an update of a subclass document referenced by an existing docum
   });
 
   it('should have updated the document with a valid reference to superclass in the db', async () => {
-    const result: any = await client.query(verifyAliasId(referencedMeadowlarkId));
-    const outboundRefs = result.rows.map((row) => row.alias_id);
+    const result: any = await client.query(verifyAliasMeadowlarkId(referencedMeadowlarkId));
+    const outboundRefs = result.rows.map((row) => row.alias_meadowlark_id);
     expect(outboundRefs).toMatchInlineSnapshot(`
       [
         "BS3Ub80H5FHOD2j0qzdjhJXZsGSfcZtPWaiepA",
@@ -750,13 +750,13 @@ describe('given the update of an existing document changing meadowlarkId with al
   });
 
   it('should have deleted the document alias related to the old meadowlarkId in the db', async () => {
-    const result: any = await client.query(findAliasIdsForDocumentByMeadowlarkIdSql(meadowlarkId));
+    const result: any = await client.query(findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql(meadowlarkId));
 
     expect(result.rowCount).toEqual(0);
   });
 
   it('should have created the document reference  related to the new meadowlarkId in the db', async () => {
-    const result: any = await client.query(findAliasIdsForDocumentByMeadowlarkIdSql(meadowlarkIdUpdated));
+    const result: any = await client.query(findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql(meadowlarkIdUpdated));
 
     expect(result.rowCount).toEqual(1);
   });

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Upsert.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Upsert.test.ts
@@ -23,9 +23,12 @@ import {
 } from '@edfi/meadowlark-core';
 import type { PoolClient } from 'pg';
 import { getSharedClient, resetSharedClient } from '../../src/repository/Db';
-import { findDocumentByMeadowlarkIdSql, findAliasIdsForDocumentByMeadowlarkIdSql } from '../../src/repository/SqlHelper';
+import {
+  findDocumentByMeadowlarkIdSql,
+  findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql,
+} from '../../src/repository/SqlHelper';
 import { upsertDocument } from '../../src/repository/Upsert';
-import { deleteAll, retrieveReferencesByMeadowlarkIdSql, verifyAliasId } from './TestHelper';
+import { deleteAll, retrieveReferencesByMeadowlarkIdSql, verifyAliasMeadowlarkId } from './TestHelper';
 
 const newUpsertRequest = (): UpsertRequest => ({
   meadowlarkId: '' as MeadowlarkId,
@@ -74,7 +77,7 @@ describe('given the upsert of a new document', () => {
   });
 
   it('should exist in the db', async () => {
-    const result = await client.query(findAliasIdsForDocumentByMeadowlarkIdSql(meadowlarkId));
+    const result = await client.query(findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql(meadowlarkId));
 
     expect(result.rowCount).toBe(1);
   });
@@ -182,7 +185,7 @@ describe('given an upsert of a new document that references a non-existent docum
     documentIdentity: { natural: 'upsert4' },
   };
 
-  const documentWithReferencesId = meadowlarkIdForDocumentIdentity(
+  const documentWithReferencesMeadowlarkId = meadowlarkIdForDocumentIdentity(
     documentWithReferencesResourceInfo,
     documentWithReferencesInfo.documentIdentity,
   );
@@ -202,7 +205,7 @@ describe('given an upsert of a new document that references a non-existent docum
     upsertResult = await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         resourceInfo: documentWithReferencesResourceInfo,
         documentInfo: documentWithReferencesInfo,
         validateDocumentReferencesExist: false,
@@ -222,7 +225,7 @@ describe('given an upsert of a new document that references a non-existent docum
   });
 
   it('should have inserted the document with an invalid reference in the db', async () => {
-    const result: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
+    const result: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesMeadowlarkId));
     expect(result.rows[0].document_identity.natural).toBe('upsert4');
   });
 });
@@ -260,7 +263,7 @@ describe('given an upsert of a new document that references an existing document
     documentIdentity: { natural: 'upsert6' },
     documentReferences: [validReference],
   };
-  const documentWithReferencesId = meadowlarkIdForDocumentIdentity(
+  const documentWithReferencesMeadowlarkId = meadowlarkIdForDocumentIdentity(
     documentWithReferencesResourceInfo,
     documentWithReferencesInfo.documentIdentity,
   );
@@ -283,7 +286,7 @@ describe('given an upsert of a new document that references an existing document
     upsertResult = await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         resourceInfo: documentWithReferencesResourceInfo,
         documentInfo: documentWithReferencesInfo,
         validateDocumentReferencesExist: true,
@@ -303,7 +306,7 @@ describe('given an upsert of a new document that references an existing document
   });
 
   it('should have inserted the document with a valid reference in the db', async () => {
-    const result: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
+    const result: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesMeadowlarkId));
     expect(result.rows[0].document_identity.natural).toBe('upsert6');
   });
 });
@@ -348,7 +351,7 @@ describe('given an upsert of a new document with one existing and one non-existe
     documentIdentity: { natural: 'upsert8' },
     documentReferences: [validReference, invalidReference],
   };
-  const documentWithReferencesId = meadowlarkIdForDocumentIdentity(
+  const documentWithReferencesMeadowlarkId = meadowlarkIdForDocumentIdentity(
     documentWithReferencesResourceInfo,
     documentWithReferencesInfo.documentIdentity,
   );
@@ -371,7 +374,7 @@ describe('given an upsert of a new document with one existing and one non-existe
     upsertResult = await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         resourceInfo: documentWithReferencesResourceInfo,
         documentInfo: documentWithReferencesInfo,
         validateDocumentReferencesExist: true,
@@ -406,7 +409,7 @@ describe('given an upsert of a new document with one existing and one non-existe
   });
 
   it('should not have inserted the document with an invalid reference in the db', async () => {
-    const result: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
+    const result: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesMeadowlarkId));
     expect(result.rowCount).toEqual(0);
   });
 });
@@ -513,7 +516,7 @@ describe('given an update of a document that references a non-existent document 
     documentIdentity: { natural: 'upsert4' },
   };
 
-  const documentWithReferencesId = meadowlarkIdForDocumentIdentity(
+  const documentWithReferencesMeadowlarkId = meadowlarkIdForDocumentIdentity(
     documentWithReferencesResourceInfo,
     documentWithReferencesInfo.documentIdentity,
   );
@@ -532,7 +535,7 @@ describe('given an update of a document that references a non-existent document 
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         resourceInfo: documentWithReferencesResourceInfo,
         documentInfo: documentWithReferencesInfo,
         validateDocumentReferencesExist: false,
@@ -545,7 +548,7 @@ describe('given an update of a document that references a non-existent document 
     upsertResult = await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         resourceInfo: documentWithReferencesResourceInfo,
         documentInfo: documentWithReferencesInfo,
         validateDocumentReferencesExist: false,
@@ -565,10 +568,10 @@ describe('given an update of a document that references a non-existent document 
   });
 
   it('should have updated the document with an invalid reference in the db', async () => {
-    const docResult: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
-    const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesId));
+    const docResult: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesMeadowlarkId));
+    const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesMeadowlarkId));
 
-    const outboundRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
+    const outboundRefs = refsResult.rows.map((ref) => ref.referenced_meadowlark_id);
     expect(docResult.rows[0].document_identity.natural).toBe('upsert4');
     expect(outboundRefs).toMatchInlineSnapshot(`
       [
@@ -610,7 +613,7 @@ describe('given an update of a document that references an existing document wit
     ...newDocumentInfo(),
     documentIdentity: { natural: 'upsert6' },
   };
-  const documentWithReferencesId = meadowlarkIdForDocumentIdentity(
+  const documentWithReferencesMeadowlarkId = meadowlarkIdForDocumentIdentity(
     documentWithReferencesResourceInfo,
     documentWithReferencesInfo.documentIdentity,
   );
@@ -633,7 +636,7 @@ describe('given an update of a document that references an existing document wit
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         resourceInfo: documentWithReferencesResourceInfo,
         documentInfo: documentWithReferencesInfo,
         validateDocumentReferencesExist: true,
@@ -646,7 +649,7 @@ describe('given an update of a document that references an existing document wit
     upsertResult = await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         resourceInfo: documentWithReferencesResourceInfo,
         documentInfo: documentWithReferencesInfo,
         validateDocumentReferencesExist: true,
@@ -666,10 +669,10 @@ describe('given an update of a document that references an existing document wit
   });
 
   it('should have updated the document with a valid reference in the db', async () => {
-    const docResult: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
-    const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesId));
+    const docResult: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesMeadowlarkId));
+    const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesMeadowlarkId));
 
-    const outboundRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
+    const outboundRefs = refsResult.rows.map((ref) => ref.referenced_meadowlark_id);
 
     expect(docResult.rows[0].document_identity.natural).toBe('upsert6');
     expect(outboundRefs).toMatchInlineSnapshot(`
@@ -719,7 +722,7 @@ describe('given an update of a document with one existing and one non-existent r
     ...newDocumentInfo(),
     documentIdentity: { natural: 'upsert8' },
   };
-  const documentWithReferencesId = meadowlarkIdForDocumentIdentity(
+  const documentWithReferencesMeadowlarkId = meadowlarkIdForDocumentIdentity(
     documentWithReferencesResourceInfo,
     documentWithReferencesInfo.documentIdentity,
   );
@@ -742,7 +745,7 @@ describe('given an update of a document with one existing and one non-existent r
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         resourceInfo: documentWithReferencesResourceInfo,
         documentInfo: documentWithReferencesInfo,
         validateDocumentReferencesExist: true,
@@ -755,7 +758,7 @@ describe('given an update of a document with one existing and one non-existent r
     upsertResult = await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         resourceInfo: documentWithReferencesResourceInfo,
         documentInfo: documentWithReferencesInfo,
         validateDocumentReferencesExist: true,
@@ -790,10 +793,10 @@ describe('given an update of a document with one existing and one non-existent r
   });
 
   it('should not have updated the document with an invalid reference in the db', async () => {
-    await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
-    const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesId));
+    await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesMeadowlarkId));
+    const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesMeadowlarkId));
 
-    const outboundRefs = refsResult.rows.map((ref) => ref.referenced_document_id);
+    const outboundRefs = refsResult.rows.map((ref) => ref.referenced_meadowlark_id);
 
     expect(outboundRefs).toHaveLength(0);
   });
@@ -841,7 +844,7 @@ describe('given an update of a subclass document referenced by an existing docum
     ...newDocumentInfo(),
     documentIdentity: { week: 'update6' },
   };
-  const documentWithReferencesId = meadowlarkIdForDocumentIdentity(
+  const documentWithReferencesMeadowlarkId = meadowlarkIdForDocumentIdentity(
     documentWithReferenceResourceInfo,
     documentWithReferenceDocumentInfo.documentIdentity,
   );
@@ -864,7 +867,7 @@ describe('given an update of a subclass document referenced by an existing docum
     await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         resourceInfo: documentWithReferenceResourceInfo,
         documentInfo: documentWithReferenceDocumentInfo,
         validateDocumentReferencesExist: true,
@@ -877,7 +880,7 @@ describe('given an update of a subclass document referenced by an existing docum
     upsertResult = await upsertDocument(
       {
         ...newUpsertRequest(),
-        meadowlarkId: documentWithReferencesId,
+        meadowlarkId: documentWithReferencesMeadowlarkId,
         resourceInfo: documentWithReferenceResourceInfo,
         documentInfo: documentWithReferenceDocumentInfo,
         validateDocumentReferencesExist: true,
@@ -897,8 +900,8 @@ describe('given an update of a subclass document referenced by an existing docum
   });
 
   it('should have updated the document with a valid reference to superclass in the db', async () => {
-    const result: any = await client.query(verifyAliasId(referencedMeadowlarkId));
-    const outboundRefs = result.rows.map((row) => row.alias_id);
+    const result: any = await client.query(verifyAliasMeadowlarkId(referencedMeadowlarkId));
+    const outboundRefs = result.rows.map((row) => row.alias_meadowlark_id);
     expect(outboundRefs).toMatchInlineSnapshot(`
       [
         "BS3Ub80H5FHOD2j0qzdjhJXZsGSfcZtPWaiepA",

--- a/Meadowlark-js/package-lock.json
+++ b/Meadowlark-js/package-lock.json
@@ -17394,7 +17394,7 @@
         "fast-memoize": "^2.5.2",
         "fs-extra": "^10.1.0",
         "supertest": "^6.3.1",
-        "testcontainers": "^9.4.0"
+        "testcontainers": "^9.8.0"
       }
     }
   }

--- a/Meadowlark-js/packages/meadowlark-core/src/model/DocumentIdentity.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/model/DocumentIdentity.ts
@@ -67,7 +67,7 @@ function documentIdentityHashFrom(documentIdentity: DocumentIdentity): string {
 }
 
 /**
- * Returns a 224-bit document id for the given document identity, as a concatenation of two Base64Url hashes.
+ * Returns a 224-bit meadowlark id for the given document identity, as a concatenation of two Base64Url hashes.
  *
  * The first 96 bits (12 bytes) are a SHAKE256 Base64Url encoded hash of the resource info.
  * The remaining 128 bits (16 bytes) are a SHAKE256 Base64Url encoded hash of the document identity.

--- a/Meadowlark-js/packages/meadowlark-core/src/validation/DocumentIdValidator.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/validation/DocumentIdValidator.ts
@@ -8,7 +8,7 @@ import { resourceInfoHashFrom } from '../model/DocumentIdentity';
 import type { BaseResourceInfo } from '../model/ResourceInfo';
 
 /**
- * Document Ids are 38 character Base64Url strings. No whitespace, plus or slash allowed
+ * Meadowlark Ids are 38 character Base64Url strings. No whitespace, plus or slash allowed
  * Example valid id: 02pe_9hl1wM_jO1vdx8w7iqmhPdEsFofglvS4g
  */
 export function isDocumentUuidWellFormed(documentUuid: string): boolean {
@@ -17,7 +17,7 @@ export function isDocumentUuidWellFormed(documentUuid: string): boolean {
 }
 
 /**
- * Document Ids are 38 character Base64Url strings. No whitespace, plus or slash allowed
+ * Meadowlark Ids are 38 character Base64Url strings. No whitespace, plus or slash allowed
  * Example valid id: 02pe_9hl1wM_jO1vdx8w7iqmhPdEsFofglvS4g
  */
 export function isMeadowlarkIdWellFormed(meadowlarkId: string): boolean {
@@ -25,7 +25,7 @@ export function isMeadowlarkIdWellFormed(meadowlarkId: string): boolean {
 }
 
 /**
- * Returns true if resource info hash matches resource info portion of document id
+ * Returns true if resource info hash matches resource info portion of meadowlark id
  */
 export function isMeadowlarkIdValidForResource(meadowlarkId: MeadowlarkId, resourceInfo: BaseResourceInfo): boolean {
   return meadowlarkId.startsWith(resourceInfoHashFrom(resourceInfo));


### PR DESCRIPTION
Replace uses of name id to use meadowlarkId: document, alias, references and functions. Update test cases.

Mongodb:
- Rename functions to add documentUuid or meadowlarkId to clarify the parameters.
- Update variables to use meadowlarkId instead of just id.
- Rename field aliasIds to aliasMeadowlarkId.

Postgres:
- Rename functions to add documentUuid or meadowlarkId to clarify the parameters.
- Update database scripts and queries to replace document_id by meadowlark_id and other columns using meadowlarkId.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Provide a brief description of your changes. Additional detail -->
<!--- should be in an associated Ed-Fi Tracker ticket (https://tracker.ed-fi.org) -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have signed all of the commits on this PR.
- [x] I have agreed to the Ed-Fi Individual Contributors' License
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
