### PR TITLE
[BIA-563] PostgreSQL backend SqlHelper functions should directly return typed results rather than strings

### DIFF
--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Delete.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Delete.ts
@@ -6,7 +6,7 @@
 /* eslint-disable no-underscore-dangle */
 
 import { Logger, Config } from '@edfi/meadowlark-utilities';
-import { DeleteResult, DeleteRequest, BlockingDocument, DocumentUuid, TraceId } from '@edfi/meadowlark-core';
+import { DeleteResult, DeleteRequest, ReferringDocumentInfo, DocumentUuid, TraceId } from '@edfi/meadowlark-core';
 import { ClientSession, Collection, MongoClient, WithId } from 'mongodb';
 import retry from 'async-retry';
 import { MeadowlarkDocument } from '../model/MeadowlarkDocument';
@@ -55,7 +55,7 @@ async function checkForReferencesToDocument(
     .find(onlyDocumentsReferencing(deleteCandidate.aliasMeadowlarkIds), limitFive(session))
     .toArray();
 
-  const blockingDocuments: BlockingDocument[] = referringDocuments.map((document) => ({
+  const referringDocumentInfo: ReferringDocumentInfo[] = referringDocuments.map((document) => ({
     documentUuid: document.documentUuid,
     meadowlarkId: document._id,
     resourceName: document.resourceName,
@@ -63,7 +63,7 @@ async function checkForReferencesToDocument(
     resourceVersion: document.resourceVersion,
   }));
 
-  return { response: 'DELETE_FAILURE_REFERENCE', blockingDocuments };
+  return { response: 'DELETE_FAILURE_REFERENCE', referringDocumentInfo };
 }
 
 /**

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Upsert.ts
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/src/repository/Upsert.ts
@@ -10,7 +10,7 @@ import {
   UpsertResult,
   UpsertRequest,
   getMeadowlarkIdForSuperclassInfo,
-  BlockingDocument,
+  ReferringDocumentInfo,
   DocumentUuid,
   generateDocumentUuid,
   MeadowlarkId,
@@ -63,7 +63,7 @@ export async function upsertDocumentTransaction(
       return {
         response: 'INSERT_FAILURE_CONFLICT',
         failureMessage: `Insert failed: the identity is in use by '${resourceInfo.resourceName}' which is also a(n) '${documentInfo.superclassInfo.resourceName}'`,
-        blockingDocuments: [
+        referringDocumentInfo: [
           {
             documentUuid: superclassAliasMeadowlarkIdInUse.documentUuid,
             meadowlarkId: superclassAliasMeadowlarkIdInUse._id,
@@ -96,7 +96,7 @@ export async function upsertDocumentTransaction(
         .find(onlyDocumentsReferencing([meadowlarkId]), limitFive(session))
         .toArray();
 
-      const blockingDocuments: BlockingDocument[] = referringDocuments.map((document) => ({
+      const referringDocumentInfo: ReferringDocumentInfo[] = referringDocuments.map((document) => ({
         documentUuid: document.documentUuid,
         meadowlarkId: document._id,
         resourceName: document.resourceName,
@@ -107,7 +107,7 @@ export async function upsertDocumentTransaction(
       return {
         response: isInsert ? 'INSERT_FAILURE_REFERENCE' : 'UPDATE_FAILURE_REFERENCE',
         failureMessage: { error: { message: 'Reference validation failed', failures } },
-        blockingDocuments,
+        referringDocumentInfo,
       };
     }
   }

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/model/MeadowlarkAlias.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/model/MeadowlarkAlias.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+import { MeadowlarkId } from '@edfi/meadowlark-core';
+import { MeadowlarkDocumentId } from './MeadowlarkDocument';
+
+export interface MeadowlarkAlias extends MeadowlarkDocumentId {
+  /**
+   * Alias meadowlarkId.
+   */
+  alias_meadowlark_id: MeadowlarkId;
+}

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/model/MeadowlarkDocument.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/model/MeadowlarkDocument.ts
@@ -3,7 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-import { DocumentIdentity, MeadowlarkId, DocumentUuid } from '@edfi/meadowlark-core';
+import { DocumentIdentity, MeadowlarkId, NoDocumentIdentity, DocumentUuid } from '@edfi/meadowlark-core';
 
 export interface MeadowlarkDocumentId {
   /**
@@ -61,10 +61,31 @@ export interface MeadowlarkDocument extends MeadowlarkDocumentId {
   created_by: string;
 }
 
-export function getEmptyMeadowlarkDocument(): MeadowlarkDocument {
-  return {} as MeadowlarkDocument;
+/**
+ * Creates a new empty newMeadowlarkDocument object
+ */
+export function newMeadowlarkDocument(): MeadowlarkDocument {
+  return {
+    meadowlark_id: undefined as unknown as MeadowlarkId,
+    document_uuid: undefined as unknown as DocumentUuid,
+    document_identity: NoDocumentIdentity,
+    project_name: '',
+    resource_name: '',
+    resource_version: '',
+    edfi_doc: null,
+    validated: false,
+    is_descriptor: false,
+    created_by: '',
+  };
 }
 
+/**
+ * The null object for DocumentInfo
+ */
+export const NoMeadowlarkDocument = Object.freeze({
+  ...newMeadowlarkDocument(),
+});
+
 export function isMeadowlarkDocumentEmpty(meadowlarkDocument: MeadowlarkDocument): boolean {
-  return Object.keys(meadowlarkDocument).length === 0;
+  return meadowlarkDocument === NoMeadowlarkDocument;
 }

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/model/MeadowlarkDocument.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/model/MeadowlarkDocument.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+import { DocumentIdentity, MeadowlarkId, DocumentUuid } from '@edfi/meadowlark-core';
+
+export interface MeadowlarkDocumentId {
+  /**
+   * A string hash derived from the project name, resource name
+   * and identity of the API document. This field replaces the built-in MongoDB _id.
+   */
+  meadowlark_id: MeadowlarkId;
+  /**
+   * The UUID for the document.
+   */
+  document_uuid: DocumentUuid;
+}
+
+export interface MeadowlarkDocument extends MeadowlarkDocumentId {
+  /**
+   * The identity elements extracted from the API document.
+   */
+  document_identity: DocumentIdentity;
+
+  /**
+   * The MetaEd project name the API document resource is defined in e.g. "EdFi" for a data standard entity.
+   */
+  project_name: string;
+
+  /**
+   * The name of the resource. Typically, this is the same as the corresponding MetaEd entity name. However,
+   * there are exceptions, for example descriptors have a "Descriptor" suffix on their resource name.
+   */
+  resource_name: string;
+
+  /**
+   * The resource version as a string. This is the same as the MetaEd project version
+   * the entity is defined in e.g. "3.3.1-b" for a 3.3b data standard entity.
+   */
+  resource_version: string;
+
+  /**
+   * The Ed-Fi ODS/API document itself.
+   */
+  edfi_doc: any;
+
+  /**
+   * True if this document has been reference and descriptor validated.
+   */
+  validated: boolean;
+
+  /**
+   * True if this document is a descriptor.
+   */
+  is_descriptor: boolean;
+
+  /**
+   * Creator of this document
+   */
+  created_by: string;
+}
+
+export function getEmptyMeadowlarkDocument(): MeadowlarkDocument {
+  return {} as MeadowlarkDocument;
+}
+
+export function isMeadowlarkDocumentEmpty(meadowlarkDocument: MeadowlarkDocument): boolean {
+  return Object.keys(meadowlarkDocument).length === 0;
+}

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/model/MeadowlarkDocument.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/model/MeadowlarkDocument.ts
@@ -87,5 +87,6 @@ export const NoMeadowlarkDocument = Object.freeze({
 });
 
 export function isMeadowlarkDocumentEmpty(meadowlarkDocument: MeadowlarkDocument): boolean {
-  return meadowlarkDocument === NoMeadowlarkDocument;
+  const noMeadowlarkDocument = NoMeadowlarkDocument;
+  return meadowlarkDocument === noMeadowlarkDocument;
 }

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/model/MeadowlarkDocumentAndAliasId.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/model/MeadowlarkDocumentAndAliasId.ts
@@ -6,7 +6,7 @@
 import { MeadowlarkId } from '@edfi/meadowlark-core';
 import { MeadowlarkDocumentId } from './MeadowlarkDocument';
 
-export interface MeadowlarkAlias extends MeadowlarkDocumentId {
+export interface MeadowlarkDocumentAndAliasId extends MeadowlarkDocumentId {
   /**
    * Alias meadowlarkId.
    */

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Db.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Db.ts
@@ -13,7 +13,7 @@ import {
   createReferencesTableDeletingIndexSql,
   createReferencesTableSql,
   createSchemaSql,
-  createDatabaseSql,
+  createDatabase,
   createAliasesTableSql,
   createAliasesTableDocumentIndexSql,
   createAliasesTableAliasIndexSql,
@@ -92,7 +92,7 @@ export async function createConnectionPoolAndReturnClient(): Promise<PoolClient>
   const client: Client = new Client(getDbConfiguration());
   try {
     await client.connect();
-    await client.query(createDatabaseSql(meadowlarkDbName));
+    await createDatabase(client, meadowlarkDbName);
 
     Logger.info(`${moduleName}.createConnectionPoolAndReturnClient database ${meadowlarkDbName} created successfully`, null);
   } catch (e) {

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Db.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Db.ts
@@ -6,18 +6,7 @@
 import { Pool, Client } from 'pg';
 import type { PoolClient } from 'pg';
 import { Config, Logger } from '@edfi/meadowlark-utilities';
-import {
-  createDocumentTableSql,
-  createDocumentTableUniqueIndexSql,
-  createReferencesTableCheckingIndexSql,
-  createReferencesTableDeletingIndexSql,
-  createReferencesTableSql,
-  createSchemaSql,
-  createDatabase,
-  createAliasesTableSql,
-  createAliasesTableDocumentIndexSql,
-  createAliasesTableAliasIndexSql,
-} from './SqlHelper';
+import { createDatabase, checkExistsAndCreateTables } from './SqlHelper';
 
 let singletonDbPool: Pool | null = null;
 
@@ -30,27 +19,6 @@ const getDbConfiguration = () => ({
 });
 
 const moduleName = 'postgresql.repository.Db';
-
-/**
- * Checks that the meadowlark schema, document and references tables exist in the database, if not will create them
- * @param client The Postgres client for querying
- */
-export async function checkExistsAndCreateTables(client: PoolClient) {
-  try {
-    await client.query(createSchemaSql);
-    await client.query(createDocumentTableSql);
-    await client.query(createDocumentTableUniqueIndexSql);
-    await client.query(createReferencesTableSql);
-    await client.query(createReferencesTableCheckingIndexSql);
-    await client.query(createReferencesTableDeletingIndexSql);
-    await client.query(createAliasesTableSql);
-    await client.query(createAliasesTableDocumentIndexSql);
-    await client.query(createAliasesTableAliasIndexSql);
-  } catch (e) {
-    Logger.error(`${moduleName}.checkExistsAndCreateTables error connecting to PostgreSQL`, null, e);
-    throw e;
-  }
-}
 
 /**
  * Create a connection pool, check that the database and table structure is in place

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
@@ -72,23 +72,18 @@ export async function deleteDocumentByDocumentUuid(
 
         // Get the information of up to five referring documents for failure message purposes
         const referenceIds = references.map((ref) => ref);
-        const referringDocuments = await findReferringDocumentInfoForErrorReportingSql(client, referenceIds);
+        const blockingDocuments: BlockingDocument[] = await findReferringDocumentInfoForErrorReportingSql(
+          client,
+          referenceIds,
+        );
 
-        if (referringDocuments == null) {
+        if (blockingDocuments == null) {
           await client.query('ROLLBACK');
           const errorMessage = `${moduleName}.deleteDocumentByDocumentUuid Error retrieving documents referenced by ${meadowlarkId}, a null result set was returned`;
           deleteResult.failureMessage = errorMessage;
           Logger.error(errorMessage, traceId);
           return deleteResult;
         }
-
-        const blockingDocuments: BlockingDocument[] = referringDocuments.map((document) => ({
-          documentUuid: document.document_uuid,
-          meadowlarkId: document.meadowlark_id,
-          resourceName: document.resource_name,
-          projectName: document.project_name,
-          resourceVersion: document.resource_version,
-        }));
 
         deleteResult = {
           response: 'DELETE_FAILURE_REFERENCE',

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
@@ -56,14 +56,6 @@ export async function deleteDocumentByDocumentUuid(
       // Find any documents that reference this document, either it's own meadowlarkId or an alias
       const referenceResult: MeadowlarkId[] = await findReferencingMeadowlarkIds(client, documentAliasMeadowlarkIds);
 
-      if (referenceResult.length === 0) {
-        await rollbackTransaction(client);
-        const errorMessage = `${moduleName}.deleteDocumentByDocumentUuid: Error determining documents referenced by ${documentUuid}, a null result set was returned`;
-        deleteResult.failureMessage = errorMessage;
-        Logger.error(errorMessage, traceId);
-        return deleteResult;
-      }
-
       const references = referenceResult.filter((ref) => ref !== meadowlarkId);
 
       // If this document is referenced, it's a validation failure

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
@@ -7,10 +7,10 @@ import { Logger } from '@edfi/meadowlark-utilities';
 import type { DeleteResult, DeleteRequest, ReferringDocumentInfo, MeadowlarkId } from '@edfi/meadowlark-core';
 import type { PoolClient } from 'pg';
 import {
-  executeDeleteDocumentByDocumentUuId,
-  executeDeleteOutboundReferencesOfDocumentByMeadowlarkId,
+  deleteDocumentRowByDocumentUuid,
+  deleteOutboundReferencesOfDocumentByMeadowlarkId,
   findReferringDocumentInfoForErrorReporting,
-  executeDeleteAliasesForDocumentByMeadowlarkId,
+  deleteAliasesForDocumentByMeadowlarkId,
   findReferencingMeadowlarkIds,
   findAliasMeadowlarkIdsForDocumentByDocumentUuid,
   beginTransaction,
@@ -90,21 +90,21 @@ export async function deleteDocumentByDocumentUuid(
 
     // Perform the document delete
     Logger.debug(`${moduleName}.deleteDocumentByDocumentUuid: Deleting document documentUuid ${documentUuid}`, traceId);
-    deleteResult = await executeDeleteDocumentByDocumentUuId(client, documentUuid);
+    deleteResult = await deleteDocumentRowByDocumentUuid(client, documentUuid);
 
     // Delete references where this is the parent document
     Logger.debug(
       `${moduleName}.deleteDocumentByDocumentUuid Deleting references with documentUuid ${documentUuid} as parent meadowlarkId`,
       traceId,
     );
-    await executeDeleteOutboundReferencesOfDocumentByMeadowlarkId(client, meadowlarkId);
+    await deleteOutboundReferencesOfDocumentByMeadowlarkId(client, meadowlarkId);
 
     // Delete this document from the aliases table
     Logger.debug(
       `${moduleName}.deleteDocumentByDocumentUuid Deleting alias entries with meadowlarkId ${meadowlarkId}`,
       traceId,
     );
-    await executeDeleteAliasesForDocumentByMeadowlarkId(client, meadowlarkId);
+    await deleteAliasesForDocumentByMeadowlarkId(client, meadowlarkId);
 
     await commitTransaction(client);
   } catch (e) {

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
@@ -4,7 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 import { Logger } from '@edfi/meadowlark-utilities';
-import type { DeleteResult, DeleteRequest, BlockingDocument, MeadowlarkId } from '@edfi/meadowlark-core';
+import type { DeleteResult, DeleteRequest, ReferringDocumentInfo, MeadowlarkId } from '@edfi/meadowlark-core';
 import type { PoolClient, QueryResult } from 'pg';
 import {
   deleteDocumentByDocumentUuIdSql,
@@ -72,12 +72,12 @@ export async function deleteDocumentByDocumentUuid(
 
         // Get the information of up to five referring documents for failure message purposes
         const referenceIds = references.map((ref) => ref);
-        const blockingDocuments: BlockingDocument[] = await findReferringDocumentInfoForErrorReportingSql(
+        const referringDocumentInfo: ReferringDocumentInfo[] = await findReferringDocumentInfoForErrorReportingSql(
           client,
           referenceIds,
         );
 
-        if (blockingDocuments == null) {
+        if (referringDocumentInfo == null) {
           await client.query('ROLLBACK');
           const errorMessage = `${moduleName}.deleteDocumentByDocumentUuid Error retrieving documents referenced by ${meadowlarkId}, a null result set was returned`;
           deleteResult.failureMessage = errorMessage;
@@ -87,7 +87,7 @@ export async function deleteDocumentByDocumentUuid(
 
         deleteResult = {
           response: 'DELETE_FAILURE_REFERENCE',
-          blockingDocuments,
+          referringDocumentInfo,
         };
         await client.query('ROLLBACK');
         return deleteResult;

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Delete.ts
@@ -17,7 +17,7 @@ import {
   rollbackTransaction,
   commitTransaction,
 } from './SqlHelper';
-import { MeadowlarkAlias } from '../model/MeadowlarkAlias';
+import { MeadowlarkDocumentAndAliasId } from '../model/MeadowlarkDocumentAndAliasId';
 
 const moduleName = 'postgresql.repository.Delete';
 
@@ -33,7 +33,7 @@ export async function deleteDocumentByDocumentUuid(
   try {
     await beginTransaction(client);
     // Find the alias meadowlarkIds for the document to be deleted
-    const documentAliasIdsResult: MeadowlarkAlias[] = await findAliasMeadowlarkIdsForDocumentByDocumentUuid(
+    const documentAliasIdsResult: MeadowlarkDocumentAndAliasId[] = await findAliasMeadowlarkIdsForDocumentByDocumentUuid(
       client,
       documentUuid,
     );

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Get.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Get.ts
@@ -6,7 +6,7 @@
 import type { PoolClient } from 'pg';
 import { GetResult, GetRequest } from '@edfi/meadowlark-core';
 import { Logger } from '@edfi/meadowlark-utilities';
-import { findDocumentByDocumentUuidSql } from './SqlHelper';
+import { findDocumentByDocumentUuid } from './SqlHelper';
 import { MeadowlarkDocument, isMeadowlarkDocumentEmpty } from '../model/MeadowlarkDocument';
 
 const moduleName = 'postgresql.repository.Get';
@@ -17,19 +17,7 @@ export async function getDocumentByDocumentUuid(
 ): Promise<GetResult> {
   try {
     Logger.debug(`${moduleName}.getDocumentByDocumentUuid ${documentUuid}`, traceId);
-    const meadowlarkDocument: MeadowlarkDocument = await findDocumentByDocumentUuidSql(client, documentUuid);
-
-    // Postgres will return an empty row set if no results are returned, if we have no rows, there is a problem
-    if (meadowlarkDocument == null) {
-      const errorMessage = `Could not retrieve DocumentUuid ${documentUuid}
-      a null result set was returned, indicating system failure`;
-      Logger.error(errorMessage, traceId);
-      return {
-        response: 'UNKNOWN_FAILURE',
-        document: {},
-        failureMessage: errorMessage,
-      };
-    }
+    const meadowlarkDocument: MeadowlarkDocument = await findDocumentByDocumentUuid(client, documentUuid);
 
     if (isMeadowlarkDocumentEmpty(meadowlarkDocument)) return { response: 'GET_FAILURE_NOT_EXISTS', document: {} };
 

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/OwnershipSecurity.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/OwnershipSecurity.ts
@@ -7,7 +7,7 @@ import { meadowlarkIdForDocumentIdentity, FrontendRequest, writeRequestToLog, Me
 import { Logger } from '@edfi/meadowlark-utilities';
 import type { PoolClient } from 'pg';
 import { SecurityResult } from '../security/SecurityResult';
-import { findOwnershipForDocumentByDocumentUuidSql, findOwnershipForDocumentByMeadowlarkIdSql } from './SqlHelper';
+import { findOwnershipForDocumentByDocumentUuid, findOwnershipForDocumentByMeadowlarkId } from './SqlHelper';
 import { MeadowlarkDocument, isMeadowlarkDocumentEmpty } from '../model/MeadowlarkDocument';
 
 function extractIdIfUpsert(frontendRequest: FrontendRequest): MeadowlarkId | undefined {
@@ -58,8 +58,8 @@ export async function rejectByOwnershipSecurity(
   try {
     const meadowlarkDocument: MeadowlarkDocument =
       documentUuid != null
-        ? await findOwnershipForDocumentByDocumentUuidSql(client, documentUuid)
-        : await findOwnershipForDocumentByMeadowlarkIdSql(client, meadowlarkId);
+        ? await findOwnershipForDocumentByDocumentUuid(client, documentUuid)
+        : await findOwnershipForDocumentByMeadowlarkId(client, meadowlarkId);
 
     if (meadowlarkDocument == null) {
       Logger.error(`${functionName} Unknown Error determining access`, frontendRequest.traceId);

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/ReferenceValidation.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/ReferenceValidation.ts
@@ -12,7 +12,7 @@ import {
 } from '@edfi/meadowlark-core';
 import { Logger } from '@edfi/meadowlark-utilities';
 import { PoolClient } from 'pg';
-import { validateReferenceExistenceSql } from './SqlHelper';
+import { validateReferenceExistence } from './SqlHelper';
 
 const moduleName = 'postgresql.repository.ReferenceValidation';
 
@@ -34,7 +34,7 @@ async function findReferencedMeadowlarkIdsByMeadowlarkId(
     return [];
   }
 
-  const referenceExistenceResult = await validateReferenceExistenceSql(client, referenceMeadowlarkIds as MeadowlarkId[]);
+  const referenceExistenceResult = await validateReferenceExistence(client, referenceMeadowlarkIds as MeadowlarkId[]);
 
   if (referenceExistenceResult == null) {
     Logger.error(`${moduleName}.findReferencedMeadowlarkIdsByMeadowlarkId Database error parsing references`, traceId);

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/ReferenceValidation.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/ReferenceValidation.ts
@@ -34,16 +34,14 @@ async function findReferencedMeadowlarkIdsByMeadowlarkId(
     return [];
   }
 
-  const referenceExistenceResult = await client.query(
-    validateReferenceExistenceSql(referenceMeadowlarkIds as MeadowlarkId[]),
-  );
+  const referenceExistenceResult = await validateReferenceExistenceSql(client, referenceMeadowlarkIds as MeadowlarkId[]);
 
-  if (referenceExistenceResult.rows == null) {
+  if (referenceExistenceResult == null) {
     Logger.error(`${moduleName}.findReferencedMeadowlarkIdsByMeadowlarkId Database error parsing references`, traceId);
     throw new Error(`${moduleName}.findReferencedMeadowlarkIdsByMeadowlarkId Database error parsing references`);
   }
 
-  return referenceExistenceResult.rows.map((val) => val.alias_meadowlark_id);
+  return referenceExistenceResult.map((val) => val);
 }
 
 /**

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
@@ -2,7 +2,7 @@
 // Licensed to the Ed-Fi Alliance under one or more agreements.
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
-import { BlockingDocument, DocumentUuid, MeadowlarkId } from '@edfi/meadowlark-core';
+import { ReferringDocumentInfo, DocumentUuid, MeadowlarkId } from '@edfi/meadowlark-core';
 import { PoolClient, QueryResult } from 'pg';
 import format from 'pg-format';
 import { MeadowlarkDocument, getEmptyMeadowlarkDocument } from '../model/MeadowlarkDocument';
@@ -243,14 +243,14 @@ export async function validateReferenceExistenceByDocumentUuidSql(
 export async function findReferringDocumentInfoForErrorReportingSql(
   client: PoolClient,
   referringMeadowlarkIds: MeadowlarkId[],
-): Promise<BlockingDocument[]> {
+): Promise<ReferringDocumentInfo[]> {
   const querySelect = format(
     `SELECT project_name, resource_name, resource_version, meadowlark_id, document_uuid FROM meadowlark.documents WHERE meadowlark_id IN (%L) LIMIT 5`,
     referringMeadowlarkIds,
   );
   const queryResult: QueryResult<any> = await client.query(querySelect);
   if (queryResult == null) {
-    return null as unknown as BlockingDocument[];
+    return null as unknown as ReferringDocumentInfo[];
   }
   return (
     (queryResult?.rowCount ?? 0) > 0
@@ -262,7 +262,7 @@ export async function findReferringDocumentInfoForErrorReportingSql(
           resourceVersion: document.resource_version,
         }))
       : []
-  ) as BlockingDocument[];
+  ) as ReferringDocumentInfo[];
 }
 
 // SQL for inserts/updates/upserts

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
@@ -7,7 +7,7 @@ import { Logger } from '@edfi/meadowlark-utilities';
 import { Client, PoolClient, QueryResult } from 'pg';
 import format from 'pg-format';
 import { MeadowlarkDocument, NoMeadowlarkDocument } from '../model/MeadowlarkDocument';
-import { MeadowlarkAlias } from '../model/MeadowlarkAlias';
+import { MeadowlarkDocumentAndAliasId } from '../model/MeadowlarkDocumentAndAliasId';
 
 const moduleName = 'postgresql.repository.SqlHelper';
 /**
@@ -102,7 +102,7 @@ export async function findAliasMeadowlarkIdsForDocumentByMeadowlarkId(
 export async function findAliasMeadowlarkIdsForDocumentByDocumentUuid(
   client: PoolClient,
   documentUuid: DocumentUuid,
-): Promise<MeadowlarkAlias[]> {
+): Promise<MeadowlarkDocumentAndAliasId[]> {
   const querySelect = format(
     `SELECT alias_meadowlark_id, meadowlark_id FROM meadowlark.aliases WHERE document_uuid = %L FOR SHARE NOWAIT`,
     documentUuid,
@@ -115,7 +115,7 @@ export async function findAliasMeadowlarkIdsForDocumentByDocumentUuid(
           meadowlark_id: ref.meadowlark_id,
         }))
       : []
-  ) as MeadowlarkAlias[];
+  ) as MeadowlarkDocumentAndAliasId[];
 }
 /**
  * Returns a list of alias meadowlarkIds. Alias meadowlarkIds include the document meadowlarkId

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
@@ -281,15 +281,13 @@ export async function findReferringDocumentInfoForErrorReporting(
   ) as ReferringDocumentInfo[];
 }
 
-// SQL for inserts/updates/upserts
-
 /**
- * Returns the SQL statement to add an alias entry to the alias table
+ * Inserts an alias entry to the alias table
  * @param meadowlarkId the document with the given alias meadowlarkId
  * @param aliasId the alias meadowlarkId for the given document, this may be the same as the meadowlarkId
- * @returns SQL query string to insert into the aliases table
+ * @returns if the result returned rows
  */
-export async function executeInsertAlias(
+export async function insertAlias(
   client: PoolClient,
   documentUuid: DocumentUuid,
   meadowlarkId: MeadowlarkId,
@@ -307,12 +305,12 @@ export async function executeInsertAlias(
 }
 
 /**
- * Returns the SQL statement to insert an outbound reference for a document into the references table
+ * Inserts an outbound reference for a document into the references table
  * @param meadowlarkId The parent document of the reference
  * @param referencedMeadowlarkId The document that is referenced
- * @returns SQL query string to insert reference into references table
+ * @returns if the result returned rows
  */
-export async function executeInsertOutboundReferences(
+export async function insertOutboundReferences(
   client: PoolClient,
   meadowlarkId: MeadowlarkId,
   referencedMeadowlarkId: MeadowlarkId,
@@ -326,12 +324,12 @@ export async function executeInsertOutboundReferences(
 }
 
 /**
- * Returns the SQL statement for inserting or updating a document in the database
+ * Inserts or updates a document in the database
  * @param param0 Document info for insert/update
  * @param isInsert is insert or update SQL re
- * @returns SQL query string for inserting or updating provided document info
+ * @returns if the result returned rows
  */
-export async function executeDocumentInsertOrUpdate(
+export async function insertOrUpdateDocument(
   client: PoolClient,
   { meadowlarkId, documentUuid, resourceInfo, documentInfo, edfiDoc, validateDocumentReferencesExist, security },
   isInsert: boolean,
@@ -392,7 +390,7 @@ export async function executeDocumentInsertOrUpdate(
   return hasResults(queryResult);
 }
 
-// SQL for Deletes
+// Deletes
 /**
  * Checks a delete result to return a deleteResult
  * @param deleteQueryResult The result from database
@@ -418,11 +416,11 @@ async function checkDeleteResult(
   return { response: 'DELETE_SUCCESS' };
 }
 /**
- * Returns the SQL query for deleting a document from the database
+ * Deletes a document from the database
  * @param meadowlarkId the document to delete from the documents table
- * @returns SQL query string to delete the document
+ * @returns a DeleteResult
  */
-export async function executeDeleteDocumentByDocumentUuId(
+export async function deleteDocumentRowByDocumentUuid(
   client: PoolClient,
   documentUuid: DocumentUuid,
 ): Promise<DeleteResult> {
@@ -435,13 +433,13 @@ export async function executeDeleteDocumentByDocumentUuId(
 }
 
 /**
- * Returns the SQL query for deleting the outbound references of a document from the database.
+ * Deletes the outbound references of a document from the database.
  * Used as part of deleting the document itself.
  *
  * @param meadowlarkId the meadowlarkId of the document whose outbound references we want to delete
- * @returns SQL query string to delete references
+ * @returns if the result returned rows
  */
-export async function executeDeleteOutboundReferencesOfDocumentByMeadowlarkId(
+export async function deleteOutboundReferencesOfDocumentByMeadowlarkId(
   client: PoolClient,
   meadowlarkId: MeadowlarkId,
 ): Promise<Boolean> {
@@ -451,11 +449,11 @@ export async function executeDeleteOutboundReferencesOfDocumentByMeadowlarkId(
 }
 
 /**
- * Returns the SQL query for deleting aliases for a given document meadowlarkId. Used as part of deleting the document itself.
+ * Deletes aliases for a given document meadowlarkId. Used as part of deleting the document itself.
  * @param meadowlarkId the meadowlarkId of the document we're deleting aliases for
- * @returns SQL query string for deleting aliases
+ * @returns if the result returned rows
  */
-export async function executeDeleteAliasesForDocumentByMeadowlarkId(
+export async function deleteAliasesForDocumentByMeadowlarkId(
   client: PoolClient,
   meadowlarkId: MeadowlarkId,
 ): Promise<Boolean> {
@@ -473,7 +471,7 @@ export async function executeDeleteAliasesForDocumentByMeadowlarkId(
 /**
  * Creates the meadowlark database
  * @param meadowlarkDbName the name of the database to create
- * @returns SQL query string to create the database
+ * @returns if the result returned rows
  */
 export async function createDatabase(client: Client, meadowlarkDbName: string): Promise<boolean> {
   const createDatabaseScript = format('CREATE DATABASE %I', meadowlarkDbName);

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/SqlHelper.ts
@@ -29,7 +29,7 @@ export async function rollbackTransaction(client: PoolClient) {
  * @param client database connector client.
  */
 export async function commitTransaction(client: PoolClient) {
-  await client.query('TRANSACTION');
+  await client.query('COMMIT');
 }
 
 /**

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
@@ -27,7 +27,7 @@ import {
   commitTransaction,
 } from './SqlHelper';
 import { validateReferences } from './ReferenceValidation';
-import { MeadowlarkAlias } from '../model/MeadowlarkAlias';
+import { MeadowlarkDocumentAndAliasId } from '../model/MeadowlarkDocumentAndAliasId';
 
 const moduleName = 'postgresql.repository.Update';
 
@@ -52,7 +52,7 @@ export async function updateDocumentByDocumentUuid(updateRequest: UpdateRequest,
   try {
     await beginTransaction(client);
 
-    const recordExistsResult: MeadowlarkAlias[] = await findAliasMeadowlarkIdsForDocumentByDocumentUuid(
+    const recordExistsResult: MeadowlarkDocumentAndAliasId[] = await findAliasMeadowlarkIdsForDocumentByDocumentUuid(
       client,
       documentUuid,
     );

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
@@ -10,7 +10,7 @@ import {
   DocumentReference,
   getMeadowlarkIdForDocumentReference,
   getMeadowlarkIdForSuperclassInfo,
-  BlockingDocument,
+  ReferringDocumentInfo,
 } from '@edfi/meadowlark-core';
 import { Logger } from '@edfi/meadowlark-utilities';
 import type { PoolClient, QueryResult } from 'pg';
@@ -81,14 +81,14 @@ export async function updateDocumentByDocumentUuid(updateRequest: UpdateRequest,
           traceId,
         );
 
-        const blockingDocuments: BlockingDocument[] = await findReferringDocumentInfoForErrorReportingSql(client, [
+        const referringDocumentInfo: ReferringDocumentInfo[] = await findReferringDocumentInfoForErrorReportingSql(client, [
           existingMeadowlarkId,
         ]);
 
         updateResult = {
           response: 'UPDATE_FAILURE_REFERENCE',
           failureMessage: { error: { message: 'Reference validation failed', failures } },
-          blockingDocuments,
+          referringDocumentInfo,
         };
         await client.query('ROLLBACK');
         return updateResult;

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Update.ts
@@ -81,15 +81,9 @@ export async function updateDocumentByDocumentUuid(updateRequest: UpdateRequest,
           traceId,
         );
 
-        const referringDocuments = await findReferringDocumentInfoForErrorReportingSql(client, [existingMeadowlarkId]);
-
-        const blockingDocuments: BlockingDocument[] = referringDocuments.map((document) => ({
-          resourceName: document.resource_name,
-          meadowlarkId: document.meadowlark_id,
-          documentUuid: document.document_uuid,
-          projectName: document.project_name,
-          resourceVersion: document.resource_version,
-        }));
+        const blockingDocuments: BlockingDocument[] = await findReferringDocumentInfoForErrorReportingSql(client, [
+          existingMeadowlarkId,
+        ]);
 
         updateResult = {
           response: 'UPDATE_FAILURE_REFERENCE',

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
@@ -10,7 +10,7 @@ import {
   DocumentReference,
   getMeadowlarkIdForDocumentReference,
   getMeadowlarkIdForSuperclassInfo,
-  BlockingDocument,
+  ReferringDocumentInfo,
   generateDocumentUuid,
   DocumentUuid,
   MeadowlarkId,
@@ -67,7 +67,7 @@ export async function upsertDocument(
           documentInfo.superclassInfo,
         ) as MeadowlarkId;
 
-        const blockingDocuments: BlockingDocument[] = await findReferringDocumentInfoForErrorReportingSql(client, [
+        const referringDocumentInfo: ReferringDocumentInfo[] = await findReferringDocumentInfoForErrorReportingSql(client, [
           superclassAliasId,
         ]);
 
@@ -75,7 +75,7 @@ export async function upsertDocument(
         return {
           response: 'INSERT_FAILURE_CONFLICT',
           failureMessage: `Insert failed: the identity is in use by '${resourceInfo.resourceName}' which is also a(n) '${documentInfo.superclassInfo.resourceName}'`,
-          blockingDocuments,
+          referringDocumentInfo,
         };
       }
     }
@@ -100,7 +100,7 @@ export async function upsertDocument(
           traceId,
         );
 
-        const blockingDocuments: BlockingDocument[] = await findReferringDocumentInfoForErrorReportingSql(client, [
+        const referringDocumentInfo: ReferringDocumentInfo[] = await findReferringDocumentInfoForErrorReportingSql(client, [
           meadowlarkId,
         ]);
 
@@ -108,7 +108,7 @@ export async function upsertDocument(
         return {
           response: isInsert ? 'INSERT_FAILURE_REFERENCE' : 'UPDATE_FAILURE_REFERENCE',
           failureMessage: { error: { message: 'Reference validation failed', failures } },
-          blockingDocuments,
+          referringDocumentInfo,
         };
       }
     }

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
@@ -17,11 +17,11 @@ import {
 } from '@edfi/meadowlark-core';
 import { Logger } from '@edfi/meadowlark-utilities';
 import {
-  executeDeleteOutboundReferencesOfDocumentByMeadowlarkId,
-  executeDocumentInsertOrUpdate,
-  executeInsertOutboundReferences,
-  executeDeleteAliasesForDocumentByMeadowlarkId,
-  executeInsertAlias,
+  deleteOutboundReferencesOfDocumentByMeadowlarkId,
+  insertOrUpdateDocument,
+  insertOutboundReferences,
+  deleteAliasesForDocumentByMeadowlarkId,
+  insertAlias,
   findAliasMeadowlarkId,
   findReferringDocumentInfoForErrorReporting,
   findDocumentByMeadowlarkId,
@@ -113,23 +113,23 @@ export async function upsertDocument(
 
     // Perform the document upsert
     Logger.debug(`${moduleName}.upsertDocument: Upserting document meadowlarkId ${meadowlarkId}`, traceId);
-    await executeDocumentInsertOrUpdate(
+    await insertOrUpdateDocument(
       client,
       { meadowlarkId, documentUuid, resourceInfo, documentInfo, edfiDoc, validateDocumentReferencesExist, security },
       isInsert,
     );
     // Delete existing values from the aliases table
-    await executeDeleteAliasesForDocumentByMeadowlarkId(client, meadowlarkId);
+    await deleteAliasesForDocumentByMeadowlarkId(client, meadowlarkId);
     // Perform insert of alias ids
-    await executeInsertAlias(client, documentUuid, meadowlarkId, meadowlarkId);
+    await insertAlias(client, documentUuid, meadowlarkId, meadowlarkId);
     if (documentInfo.superclassInfo != null) {
       const superclassAliasId: MeadowlarkId = getMeadowlarkIdForSuperclassInfo(documentInfo.superclassInfo) as MeadowlarkId;
-      await executeInsertAlias(client, documentUuid, meadowlarkId, superclassAliasId);
+      await insertAlias(client, documentUuid, meadowlarkId, superclassAliasId);
     }
 
     // Delete existing references in references table
     Logger.debug(`${moduleName}.upsertDocument: Deleting references for document meadowlarkId ${meadowlarkId}`, traceId);
-    await executeDeleteOutboundReferencesOfDocumentByMeadowlarkId(client, meadowlarkId);
+    await deleteOutboundReferencesOfDocumentByMeadowlarkId(client, meadowlarkId);
 
     // Adding descriptors to outboundRefs for reference checking
     const descriptorOutboundRefs = documentInfo.descriptorReferences.map((dr: DocumentReference) =>
@@ -144,7 +144,7 @@ export async function upsertDocument(
         `post${moduleName}.upsertDocument: Inserting reference meadowlarkId ${ref} for document meadowlarkId ${meadowlarkId}`,
         ref,
       );
-      await executeInsertOutboundReferences(client, meadowlarkId, ref as MeadowlarkId);
+      await insertOutboundReferences(client, meadowlarkId, ref as MeadowlarkId);
     }
 
     await commitTransaction(client);

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/src/repository/Upsert.ts
@@ -67,15 +67,9 @@ export async function upsertDocument(
           documentInfo.superclassInfo,
         ) as MeadowlarkId;
 
-        const referringDocuments = await findReferringDocumentInfoForErrorReportingSql(client, [superclassAliasId]);
-
-        const blockingDocuments: BlockingDocument[] = referringDocuments.map((document) => ({
-          resourceName: document.resource_name,
-          documentUuid: document.document_uuid,
-          meadowlarkId: document.meadowlark_id,
-          projectName: document.project_name,
-          resourceVersion: document.resource_version,
-        }));
+        const blockingDocuments: BlockingDocument[] = await findReferringDocumentInfoForErrorReportingSql(client, [
+          superclassAliasId,
+        ]);
 
         await client.query('ROLLBACK');
         return {
@@ -106,15 +100,9 @@ export async function upsertDocument(
           traceId,
         );
 
-        const referringDocuments = await findReferringDocumentInfoForErrorReportingSql(client, [meadowlarkId]);
-
-        const blockingDocuments: BlockingDocument[] = referringDocuments.map((document) => ({
-          resourceName: document.resource_name,
-          documentUuid: document.document_uuid,
-          meadowlarkId: document.meadowlark_id,
-          projectName: document.project_name,
-          resourceVersion: document.resource_version,
-        }));
+        const blockingDocuments: BlockingDocument[] = await findReferringDocumentInfoForErrorReportingSql(client, [
+          meadowlarkId,
+        ]);
 
         await client.query('ROLLBACK');
         return {

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
@@ -30,10 +30,10 @@ import { getSharedClient, resetSharedClient } from '../../src/repository/Db';
 import { deleteDocumentByDocumentUuid } from '../../src/repository/Delete';
 import { upsertDocument } from '../../src/repository/Upsert';
 import {
-  findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql,
-  findDocumentByDocumentUuidSql,
-  findDocumentByMeadowlarkIdSql,
-  findReferencingMeadowlarkIdsSql,
+  findAliasMeadowlarkIdsForDocumentByMeadowlarkId,
+  findDocumentByDocumentUuid,
+  findDocumentByMeadowlarkId,
+  findReferencingMeadowlarkIds,
 } from '../../src/repository/SqlHelper';
 import { MeadowlarkDocument, isMeadowlarkDocumentEmpty } from '../../src/model/MeadowlarkDocument';
 
@@ -130,7 +130,7 @@ describe('given the delete of an existing document', () => {
   });
 
   it('should have deleted the document in the db', async () => {
-    const result: MeadowlarkDocument = await findDocumentByDocumentUuidSql(client, documentUuid);
+    const result: MeadowlarkDocument = await findDocumentByDocumentUuid(client, documentUuid);
     expect(isMeadowlarkDocumentEmpty(result)).toEqual(true);
   });
 });
@@ -217,7 +217,7 @@ describe('given an delete of a document referenced by an existing document with 
   });
 
   it('should still have the referenced document in the db', async () => {
-    const docResult: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, referencedDocumentId);
+    const docResult: MeadowlarkDocument = await findDocumentByMeadowlarkId(client, referencedDocumentId);
     expect(docResult.document_identity.natural).toBe('delete5');
   });
 });
@@ -306,13 +306,13 @@ describe('given an delete of a document with an outbound reference only, with va
   });
 
   it('should have deleted the document in the db', async () => {
-    const result: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, documentWithReferencesMeadowlarkId);
+    const result: MeadowlarkDocument = await findDocumentByMeadowlarkId(client, documentWithReferencesMeadowlarkId);
 
     expect(isMeadowlarkDocumentEmpty(result)).toEqual(true);
   });
 
   it('should have deleted the document alias in the db', async () => {
-    const result: MeadowlarkId[] = await findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql(
+    const result: MeadowlarkId[] = await findAliasMeadowlarkIdsForDocumentByMeadowlarkId(
       client,
       documentWithReferencesMeadowlarkId,
     );
@@ -320,7 +320,7 @@ describe('given an delete of a document with an outbound reference only, with va
     expect(result.length).toEqual(0);
   });
   it('should have deleted the document reference in the db', async () => {
-    const result: MeadowlarkId[] = await findReferencingMeadowlarkIdsSql(client, [referencedDocumentId]);
+    const result: MeadowlarkId[] = await findReferencingMeadowlarkIds(client, [referencedDocumentId]);
 
     expect(result.length).toEqual(0);
   });
@@ -409,7 +409,7 @@ describe('given an delete of a document referenced by an existing document with 
   });
 
   it('should not have the referenced document in the db', async () => {
-    const docResult: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, referencedDocumentId);
+    const docResult: MeadowlarkDocument = await findDocumentByMeadowlarkId(client, referencedDocumentId);
     expect(isMeadowlarkDocumentEmpty(docResult)).toEqual(true);
   });
 
@@ -513,7 +513,7 @@ describe('given the delete of a subclass document referenced by an existing docu
   });
 
   it('should still have the referenced document in the db', async () => {
-    const result: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, referencedDocumentId);
+    const result: MeadowlarkDocument = await findDocumentByMeadowlarkId(client, referencedDocumentId);
     expect(result.document_identity.schoolId).toBe('123');
   });
 });

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Delete.test.ts
@@ -35,6 +35,7 @@ import {
   findDocumentByMeadowlarkIdSql,
   findReferencingMeadowlarkIdsSql,
 } from '../../src/repository/SqlHelper';
+import { MeadowlarkDocument, isMeadowlarkDocumentEmpty } from '../../src/model/MeadowlarkDocument';
 
 const newUpsertRequest = (): UpsertRequest => ({
   meadowlarkId: '' as MeadowlarkId,
@@ -129,8 +130,8 @@ describe('given the delete of an existing document', () => {
   });
 
   it('should have deleted the document in the db', async () => {
-    const result: any = await client.query(findDocumentByDocumentUuidSql(documentUuid));
-    expect(result.rowCount).toEqual(0);
+    const result: MeadowlarkDocument = await findDocumentByDocumentUuidSql(client, documentUuid);
+    expect(isMeadowlarkDocumentEmpty(result)).toEqual(true);
   });
 });
 
@@ -216,8 +217,8 @@ describe('given an delete of a document referenced by an existing document with 
   });
 
   it('should still have the referenced document in the db', async () => {
-    const docResult: any = await client.query(findDocumentByMeadowlarkIdSql(referencedDocumentId));
-    expect(docResult.rows[0].document_identity.natural).toBe('delete5');
+    const docResult: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, referencedDocumentId);
+    expect(docResult.document_identity.natural).toBe('delete5');
   });
 });
 
@@ -305,22 +306,23 @@ describe('given an delete of a document with an outbound reference only, with va
   });
 
   it('should have deleted the document in the db', async () => {
-    const result: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesMeadowlarkId));
+    const result: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, documentWithReferencesMeadowlarkId);
 
-    expect(result.rowCount).toEqual(0);
+    expect(isMeadowlarkDocumentEmpty(result)).toEqual(true);
   });
 
   it('should have deleted the document alias in the db', async () => {
-    const result: any = await client.query(
-      findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql(documentWithReferencesMeadowlarkId),
+    const result: MeadowlarkId[] = await findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql(
+      client,
+      documentWithReferencesMeadowlarkId,
     );
 
-    expect(result.rowCount).toEqual(0);
+    expect(result.length).toEqual(0);
   });
   it('should have deleted the document reference in the db', async () => {
-    const result: any = await client.query(findReferencingMeadowlarkIdsSql([referencedDocumentId]));
+    const result: MeadowlarkId[] = await findReferencingMeadowlarkIdsSql(client, [referencedDocumentId]);
 
-    expect(result.rowCount).toEqual(0);
+    expect(result.length).toEqual(0);
   });
 });
 
@@ -407,8 +409,8 @@ describe('given an delete of a document referenced by an existing document with 
   });
 
   it('should not have the referenced document in the db', async () => {
-    const docResult: any = await client.query(findDocumentByMeadowlarkIdSql(referencedDocumentId));
-    expect(docResult.rowCount).toEqual(0);
+    const docResult: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, referencedDocumentId);
+    expect(isMeadowlarkDocumentEmpty(docResult)).toEqual(true);
   });
 
   it('should not be the parent document in the references table', async () => {
@@ -511,7 +513,7 @@ describe('given the delete of a subclass document referenced by an existing docu
   });
 
   it('should still have the referenced document in the db', async () => {
-    const result: any = await client.query(findDocumentByMeadowlarkIdSql(referencedDocumentId));
-    expect(result.rows[0].document_identity.schoolId).toBe('123');
+    const result: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, referencedDocumentId);
+    expect(result.document_identity.schoolId).toBe('123');
   });
 });

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Read.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Read.test.ts
@@ -25,6 +25,7 @@ import { deleteAll } from './TestHelper';
 import { getDocumentByDocumentUuid } from '../../src/repository/Get';
 import { findDocumentByMeadowlarkIdSql } from '../../src/repository/SqlHelper';
 import { upsertDocument } from '../../src/repository/Upsert';
+import { MeadowlarkDocument, isMeadowlarkDocumentEmpty } from '../../src/model/MeadowlarkDocument';
 
 const newGetRequest = (): GetRequest => ({
   documentUuid: 'deb6ea15-fa93-4389-89a8-1428fb617490' as DocumentUuid,
@@ -71,9 +72,9 @@ describe('given the get of a non-existent document', () => {
   });
 
   it('should not exist in the db', async () => {
-    const result = await client.query(findDocumentByMeadowlarkIdSql(meadowlarkId));
+    const result: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, meadowlarkId);
 
-    expect(result.rowCount).toBe(0);
+    expect(isMeadowlarkDocumentEmpty(result)).toBe(true);
   });
 
   it('should return get failure', async () => {

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Read.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Read.test.ts
@@ -23,7 +23,7 @@ import type { PoolClient } from 'pg';
 import { resetSharedClient, getSharedClient } from '../../src/repository/Db';
 import { deleteAll } from './TestHelper';
 import { getDocumentByDocumentUuid } from '../../src/repository/Get';
-import { findDocumentByMeadowlarkIdSql } from '../../src/repository/SqlHelper';
+import { findDocumentByMeadowlarkId } from '../../src/repository/SqlHelper';
 import { upsertDocument } from '../../src/repository/Upsert';
 import { MeadowlarkDocument, isMeadowlarkDocumentEmpty } from '../../src/model/MeadowlarkDocument';
 
@@ -72,7 +72,7 @@ describe('given the get of a non-existent document', () => {
   });
 
   it('should not exist in the db', async () => {
-    const result: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, meadowlarkId);
+    const result: MeadowlarkDocument = await findDocumentByMeadowlarkId(client, meadowlarkId);
 
     expect(isMeadowlarkDocumentEmpty(result)).toBe(true);
   });

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
@@ -31,9 +31,9 @@ import { upsertDocument } from '../../src/repository/Upsert';
 import { deleteAll, retrieveReferencesByMeadowlarkIdSql, verifyAliasMeadowlarkId } from './TestHelper';
 import { getDocumentByDocumentUuid } from '../../src/repository/Get';
 import {
-  findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql,
-  findDocumentByDocumentUuidSql,
-  findDocumentByMeadowlarkIdSql,
+  findAliasMeadowlarkIdsForDocumentByMeadowlarkId,
+  findDocumentByDocumentUuid,
+  findDocumentByMeadowlarkId,
 } from '../../src/repository/SqlHelper';
 import { MeadowlarkDocument } from '../../src/model/MeadowlarkDocument';
 
@@ -174,7 +174,7 @@ describe('given the update of an existing document', () => {
   });
 
   it('should have updated the document in the db', async () => {
-    const result: MeadowlarkDocument = await findDocumentByDocumentUuidSql(client, resultDocumentUuid);
+    const result: MeadowlarkDocument = await findDocumentByDocumentUuid(client, resultDocumentUuid);
 
     expect(result.document_identity.natural).toBe('update2');
 
@@ -249,7 +249,7 @@ describe('given an update of a document that references a non-existent document 
   });
 
   it('should have updated the document with an invalid reference in the db', async () => {
-    const docResult: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, documentWithReferencesId);
+    const docResult: MeadowlarkDocument = await findDocumentByMeadowlarkId(client, documentWithReferencesId);
     const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesId));
 
     const outboundRefs = refsResult.rows.map((ref) => ref.referenced_meadowlark_id);
@@ -354,7 +354,7 @@ describe('given an update of a document that references an existing document wit
   });
 
   it('should have updated the document with a valid reference in the db', async () => {
-    const docResult: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, documentWithReferencesId);
+    const docResult: MeadowlarkDocument = await findDocumentByMeadowlarkId(client, documentWithReferencesId);
     const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesId));
 
     const outboundRefs = refsResult.rows.map((ref) => ref.referenced_meadowlark_id);
@@ -751,13 +751,13 @@ describe('given the update of an existing document changing meadowlarkId with al
   });
 
   it('should have deleted the document alias related to the old meadowlarkId in the db', async () => {
-    const result: MeadowlarkId[] = await findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql(client, meadowlarkId);
+    const result: MeadowlarkId[] = await findAliasMeadowlarkIdsForDocumentByMeadowlarkId(client, meadowlarkId);
 
     expect(result.length).toEqual(0);
   });
 
   it('should have created the document reference  related to the new meadowlarkId in the db', async () => {
-    const result: MeadowlarkId[] = await findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql(client, meadowlarkIdUpdated);
+    const result: MeadowlarkId[] = await findAliasMeadowlarkIdsForDocumentByMeadowlarkId(client, meadowlarkIdUpdated);
 
     expect(result.length).toEqual(1);
   });

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Update.test.ts
@@ -35,6 +35,7 @@ import {
   findDocumentByDocumentUuidSql,
   findDocumentByMeadowlarkIdSql,
 } from '../../src/repository/SqlHelper';
+import { MeadowlarkDocument } from '../../src/model/MeadowlarkDocument';
 
 const documentUuid: DocumentUuid = 'feb82f3e-3685-4868-86cf-f4b91749a799' as DocumentUuid;
 let resultDocumentUuid: DocumentUuid;
@@ -173,11 +174,11 @@ describe('given the update of an existing document', () => {
   });
 
   it('should have updated the document in the db', async () => {
-    const result: any = await client.query(findDocumentByDocumentUuidSql(resultDocumentUuid));
+    const result: MeadowlarkDocument = await findDocumentByDocumentUuidSql(client, resultDocumentUuid);
 
-    expect(result.rows[0].document_identity.natural).toBe('update2');
+    expect(result.document_identity.natural).toBe('update2');
 
-    expect(result.rows[0].edfi_doc.changeToDoc).toBe(true);
+    expect(result.edfi_doc.changeToDoc).toBe(true);
   });
 });
 
@@ -248,12 +249,12 @@ describe('given an update of a document that references a non-existent document 
   });
 
   it('should have updated the document with an invalid reference in the db', async () => {
-    const docResult: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
+    const docResult: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, documentWithReferencesId);
     const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesId));
 
     const outboundRefs = refsResult.rows.map((ref) => ref.referenced_meadowlark_id);
 
-    expect(docResult.rows[0].document_identity.natural).toBe('update4');
+    expect(docResult.document_identity.natural).toBe('update4');
 
     expect(outboundRefs).toMatchInlineSnapshot(`
       [
@@ -353,11 +354,11 @@ describe('given an update of a document that references an existing document wit
   });
 
   it('should have updated the document with a valid reference in the db', async () => {
-    const docResult: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesId));
+    const docResult: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, documentWithReferencesId);
     const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesId));
 
     const outboundRefs = refsResult.rows.map((ref) => ref.referenced_meadowlark_id);
-    expect(docResult.rows[0].document_identity.natural).toBe('update6');
+    expect(docResult.document_identity.natural).toBe('update6');
     expect(outboundRefs).toMatchInlineSnapshot(`
       [
         "Qw5FvPdKxAXWnGghsMh3I61yLFfls4Q949Fk2w",
@@ -750,14 +751,14 @@ describe('given the update of an existing document changing meadowlarkId with al
   });
 
   it('should have deleted the document alias related to the old meadowlarkId in the db', async () => {
-    const result: any = await client.query(findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql(meadowlarkId));
+    const result: MeadowlarkId[] = await findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql(client, meadowlarkId);
 
-    expect(result.rowCount).toEqual(0);
+    expect(result.length).toEqual(0);
   });
 
   it('should have created the document reference  related to the new meadowlarkId in the db', async () => {
-    const result: any = await client.query(findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql(meadowlarkIdUpdated));
+    const result: MeadowlarkId[] = await findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql(client, meadowlarkIdUpdated);
 
-    expect(result.rowCount).toEqual(1);
+    expect(result.length).toEqual(1);
   });
 });

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Upsert.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Upsert.test.ts
@@ -23,10 +23,7 @@ import {
 } from '@edfi/meadowlark-core';
 import type { PoolClient } from 'pg';
 import { getSharedClient, resetSharedClient } from '../../src/repository/Db';
-import {
-  findDocumentByMeadowlarkIdSql,
-  findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql,
-} from '../../src/repository/SqlHelper';
+import { findDocumentByMeadowlarkId, findAliasMeadowlarkIdsForDocumentByMeadowlarkId } from '../../src/repository/SqlHelper';
 import { upsertDocument } from '../../src/repository/Upsert';
 import { deleteAll, retrieveReferencesByMeadowlarkIdSql, verifyAliasMeadowlarkId } from './TestHelper';
 import { isMeadowlarkDocumentEmpty, MeadowlarkDocument } from '../../src/model/MeadowlarkDocument';
@@ -78,7 +75,7 @@ describe('given the upsert of a new document', () => {
   });
 
   it('should exist in the db', async () => {
-    const result: MeadowlarkId[] = await findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql(client, meadowlarkId);
+    const result: MeadowlarkId[] = await findAliasMeadowlarkIdsForDocumentByMeadowlarkId(client, meadowlarkId);
 
     expect(result.length).toBe(1);
   });
@@ -167,7 +164,7 @@ describe('given an upsert of an existing document that changes the edfiDoc', () 
   });
 
   it('should have the change in the db', async () => {
-    const result: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, meadowlarkId);
+    const result: MeadowlarkDocument = await findDocumentByMeadowlarkId(client, meadowlarkId);
 
     expect(result.edfi_doc.call).toBe('two');
   });
@@ -226,7 +223,7 @@ describe('given an upsert of a new document that references a non-existent docum
   });
 
   it('should have inserted the document with an invalid reference in the db', async () => {
-    const result: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, documentWithReferencesMeadowlarkId);
+    const result: MeadowlarkDocument = await findDocumentByMeadowlarkId(client, documentWithReferencesMeadowlarkId);
     expect(result.document_identity.natural).toBe('upsert4');
   });
 });
@@ -307,7 +304,7 @@ describe('given an upsert of a new document that references an existing document
   });
 
   it('should have inserted the document with a valid reference in the db', async () => {
-    const result: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, documentWithReferencesMeadowlarkId);
+    const result: MeadowlarkDocument = await findDocumentByMeadowlarkId(client, documentWithReferencesMeadowlarkId);
     expect(result.document_identity.natural).toBe('upsert6');
   });
 });
@@ -410,7 +407,7 @@ describe('given an upsert of a new document with one existing and one non-existe
   });
 
   it('should not have inserted the document with an invalid reference in the db', async () => {
-    const result: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, documentWithReferencesMeadowlarkId);
+    const result: MeadowlarkDocument = await findDocumentByMeadowlarkId(client, documentWithReferencesMeadowlarkId);
     expect(isMeadowlarkDocumentEmpty(result)).toEqual(true);
   });
 });
@@ -497,7 +494,7 @@ describe('given an upsert of a subclass document when a different subclass has t
   });
 
   it('should not have inserted the document with the same superclass identity in the db', async () => {
-    const result: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, sameSuperclassIdentityMeadowlarkId);
+    const result: MeadowlarkDocument = await findDocumentByMeadowlarkId(client, sameSuperclassIdentityMeadowlarkId);
     expect(isMeadowlarkDocumentEmpty(result)).toEqual(true);
   });
 });
@@ -569,7 +566,7 @@ describe('given an update of a document that references a non-existent document 
   });
 
   it('should have updated the document with an invalid reference in the db', async () => {
-    const docResult: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, documentWithReferencesMeadowlarkId);
+    const docResult: MeadowlarkDocument = await findDocumentByMeadowlarkId(client, documentWithReferencesMeadowlarkId);
     const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesMeadowlarkId));
 
     const outboundRefs = refsResult.rows.map((ref) => ref.referenced_meadowlark_id);
@@ -670,7 +667,7 @@ describe('given an update of a document that references an existing document wit
   });
 
   it('should have updated the document with a valid reference in the db', async () => {
-    const docResult: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, documentWithReferencesMeadowlarkId);
+    const docResult: MeadowlarkDocument = await findDocumentByMeadowlarkId(client, documentWithReferencesMeadowlarkId);
     const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesMeadowlarkId));
 
     const outboundRefs = refsResult.rows.map((ref) => ref.referenced_meadowlark_id);
@@ -794,7 +791,7 @@ describe('given an update of a document with one existing and one non-existent r
   });
 
   it('should not have updated the document with an invalid reference in the db', async () => {
-    await findDocumentByMeadowlarkIdSql(client, documentWithReferencesMeadowlarkId);
+    await findDocumentByMeadowlarkId(client, documentWithReferencesMeadowlarkId);
     const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesMeadowlarkId));
 
     const outboundRefs = refsResult.rows.map((ref) => ref.referenced_meadowlark_id);

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Upsert.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/Upsert.test.ts
@@ -29,6 +29,7 @@ import {
 } from '../../src/repository/SqlHelper';
 import { upsertDocument } from '../../src/repository/Upsert';
 import { deleteAll, retrieveReferencesByMeadowlarkIdSql, verifyAliasMeadowlarkId } from './TestHelper';
+import { isMeadowlarkDocumentEmpty, MeadowlarkDocument } from '../../src/model/MeadowlarkDocument';
 
 const newUpsertRequest = (): UpsertRequest => ({
   meadowlarkId: '' as MeadowlarkId,
@@ -77,9 +78,9 @@ describe('given the upsert of a new document', () => {
   });
 
   it('should exist in the db', async () => {
-    const result = await client.query(findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql(meadowlarkId));
+    const result: MeadowlarkId[] = await findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql(client, meadowlarkId);
 
-    expect(result.rowCount).toBe(1);
+    expect(result.length).toBe(1);
   });
 
   it('should return insert success', async () => {
@@ -166,9 +167,9 @@ describe('given an upsert of an existing document that changes the edfiDoc', () 
   });
 
   it('should have the change in the db', async () => {
-    const result: any = await client.query(findDocumentByMeadowlarkIdSql(meadowlarkId));
+    const result: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, meadowlarkId);
 
-    expect(result.rows[0].edfi_doc.call).toBe('two');
+    expect(result.edfi_doc.call).toBe('two');
   });
 });
 
@@ -225,8 +226,8 @@ describe('given an upsert of a new document that references a non-existent docum
   });
 
   it('should have inserted the document with an invalid reference in the db', async () => {
-    const result: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesMeadowlarkId));
-    expect(result.rows[0].document_identity.natural).toBe('upsert4');
+    const result: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, documentWithReferencesMeadowlarkId);
+    expect(result.document_identity.natural).toBe('upsert4');
   });
 });
 
@@ -306,8 +307,8 @@ describe('given an upsert of a new document that references an existing document
   });
 
   it('should have inserted the document with a valid reference in the db', async () => {
-    const result: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesMeadowlarkId));
-    expect(result.rows[0].document_identity.natural).toBe('upsert6');
+    const result: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, documentWithReferencesMeadowlarkId);
+    expect(result.document_identity.natural).toBe('upsert6');
   });
 });
 
@@ -409,8 +410,8 @@ describe('given an upsert of a new document with one existing and one non-existe
   });
 
   it('should not have inserted the document with an invalid reference in the db', async () => {
-    const result: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesMeadowlarkId));
-    expect(result.rowCount).toEqual(0);
+    const result: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, documentWithReferencesMeadowlarkId);
+    expect(isMeadowlarkDocumentEmpty(result)).toEqual(true);
   });
 });
 
@@ -496,8 +497,8 @@ describe('given an upsert of a subclass document when a different subclass has t
   });
 
   it('should not have inserted the document with the same superclass identity in the db', async () => {
-    const result: any = await client.query(findDocumentByMeadowlarkIdSql(sameSuperclassIdentityMeadowlarkId));
-    expect(result.rowCount).toEqual(0);
+    const result: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, sameSuperclassIdentityMeadowlarkId);
+    expect(isMeadowlarkDocumentEmpty(result)).toEqual(true);
   });
 });
 
@@ -568,11 +569,11 @@ describe('given an update of a document that references a non-existent document 
   });
 
   it('should have updated the document with an invalid reference in the db', async () => {
-    const docResult: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesMeadowlarkId));
+    const docResult: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, documentWithReferencesMeadowlarkId);
     const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesMeadowlarkId));
 
     const outboundRefs = refsResult.rows.map((ref) => ref.referenced_meadowlark_id);
-    expect(docResult.rows[0].document_identity.natural).toBe('upsert4');
+    expect(docResult.document_identity.natural).toBe('upsert4');
     expect(outboundRefs).toMatchInlineSnapshot(`
       [
         "QtykK4uDYZK7VOChNxRsMDtOcAu6a0oe9ozl2Q",
@@ -669,12 +670,12 @@ describe('given an update of a document that references an existing document wit
   });
 
   it('should have updated the document with a valid reference in the db', async () => {
-    const docResult: any = await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesMeadowlarkId));
+    const docResult: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(client, documentWithReferencesMeadowlarkId);
     const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesMeadowlarkId));
 
     const outboundRefs = refsResult.rows.map((ref) => ref.referenced_meadowlark_id);
 
-    expect(docResult.rows[0].document_identity.natural).toBe('upsert6');
+    expect(docResult.document_identity.natural).toBe('upsert6');
     expect(outboundRefs).toMatchInlineSnapshot(`
       [
         "Qw5FvPdKxAXWnGghUWv5LKuA2cXaJPWJGJRDBQ",
@@ -793,7 +794,7 @@ describe('given an update of a document with one existing and one non-existent r
   });
 
   it('should not have updated the document with an invalid reference in the db', async () => {
-    await client.query(findDocumentByMeadowlarkIdSql(documentWithReferencesMeadowlarkId));
+    await findDocumentByMeadowlarkIdSql(client, documentWithReferencesMeadowlarkId);
     const refsResult: any = await client.query(retrieveReferencesByMeadowlarkIdSql(documentWithReferencesMeadowlarkId));
 
     const outboundRefs = refsResult.rows.map((ref) => ref.referenced_meadowlark_id);

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/locking/Delete.test.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/integration/locking/Delete.test.ts
@@ -23,11 +23,11 @@ import { PoolClient } from 'pg';
 import { getSharedClient, resetSharedClient } from '../../../src/repository/Db';
 import { validateReferences } from '../../../src/repository/ReferenceValidation';
 import {
-  findReferencingMeadowlarkIdsSql,
+  findReferencingMeadowlarkIds,
   deleteAliasesForDocumentByMeadowlarkIdSql,
-  findDocumentByMeadowlarkIdSql,
+  findDocumentByMeadowlarkId,
   documentInsertOrUpdateSql,
-  findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql,
+  findAliasMeadowlarkIdsForDocumentByMeadowlarkId,
   insertAliasSql,
   insertOutboundReferencesSql,
   deleteDocumentByDocumentUuIdSql,
@@ -134,13 +134,13 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
       // Get the alias ids for the document we're trying to delete, because the update transaction is trying
       // to use our school, this is where the code will throw a locking error. This is technically the last line
       // of code in this try block that should execute
-      const aliasIdResult: MeadowlarkId[] = await findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql(
+      const aliasIdResult: MeadowlarkId[] = await findAliasMeadowlarkIdsForDocumentByMeadowlarkId(
         deleteClient,
         schoolMeadowlarkId,
       );
 
       const validDocMeadowlarkIds = aliasIdResult.map((ref) => ref);
-      const referenceResult: MeadowlarkId[] = await findReferencingMeadowlarkIdsSql(deleteClient, validDocMeadowlarkIds);
+      const referenceResult: MeadowlarkId[] = await findReferencingMeadowlarkIds(deleteClient, validDocMeadowlarkIds);
       const anyReferences: MeadowlarkId[] = referenceResult.filter((ref) => ref !== schoolMeadowlarkId);
 
       expect(anyReferences.length).toEqual(0);
@@ -192,7 +192,7 @@ describe('given a delete concurrent with an insert referencing the to-be-deleted
   });
 
   it('should have still have the School document in the db - a success', async () => {
-    const docResult: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(insertClient, schoolMeadowlarkId);
+    const docResult: MeadowlarkDocument = await findDocumentByMeadowlarkId(insertClient, schoolMeadowlarkId);
     expect(docResult.document_identity.schoolId).toBe('123');
   });
 });
@@ -227,7 +227,7 @@ describe('given an insert concurrent with a delete referencing the to-be-deleted
     // Retrieve the alias ids for the school that we're trying to delete, this call will also
     // lock the school record so when we try to lock the records during the insert of the academic week
     // below it will fail
-    const aliasIdResult: MeadowlarkId[] = await findAliasMeadowlarkIdsForDocumentByMeadowlarkIdSql(
+    const aliasIdResult: MeadowlarkId[] = await findAliasMeadowlarkIdsForDocumentByMeadowlarkId(
       deleteClient,
       schoolMeadowlarkId,
     );
@@ -237,7 +237,7 @@ describe('given an insert concurrent with a delete referencing the to-be-deleted
 
     // See if there are existing references to this document
     const validDocMeadowlarkIds = aliasIdResult.map((ref) => ref);
-    const referenceResult: MeadowlarkId[] = await findReferencingMeadowlarkIdsSql(deleteClient, validDocMeadowlarkIds);
+    const referenceResult: MeadowlarkId[] = await findReferencingMeadowlarkIds(deleteClient, validDocMeadowlarkIds);
     const anyReferences: MeadowlarkId[] = referenceResult.filter((ref) => ref !== schoolMeadowlarkId);
 
     expect(anyReferences.length).toEqual(0);
@@ -306,8 +306,8 @@ describe('given an insert concurrent with a delete referencing the to-be-deleted
   });
 
   it('should have still have the School document in the db - a success', async () => {
-    const schoolDocResult: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(insertClient, schoolMeadowlarkId);
-    const awDocResult: MeadowlarkDocument = await findDocumentByMeadowlarkIdSql(insertClient, academicWeekMeadowlarkId);
+    const schoolDocResult: MeadowlarkDocument = await findDocumentByMeadowlarkId(insertClient, schoolMeadowlarkId);
+    const awDocResult: MeadowlarkDocument = await findDocumentByMeadowlarkId(insertClient, academicWeekMeadowlarkId);
     expect(isMeadowlarkDocumentEmpty(schoolDocResult)).toEqual(true);
     expect(isMeadowlarkDocumentEmpty(awDocResult)).toEqual(true);
   });

--- a/Meadowlark-js/packages/meadowlark-core/src/handler/Delete.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/handler/Delete.ts
@@ -57,7 +57,7 @@ export async function deleteIt(frontendRequest: FrontendRequest): Promise<Fronte
     }
 
     if (result.response === 'DELETE_FAILURE_REFERENCE') {
-      const blockingUris: string[] = blockingDocumentsToUris(frontendRequest, result.blockingDocuments);
+      const blockingUris: string[] = blockingDocumentsToUris(frontendRequest, result.referringDocumentInfo);
 
       if (isDebugEnabled()) {
         writeDebugStatusToLog(moduleName, frontendRequest, 'deleteIt', 409, blockingUris.join(','));

--- a/Meadowlark-js/packages/meadowlark-core/src/handler/Update.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/handler/Update.ts
@@ -62,7 +62,7 @@ export async function update(frontendRequest: FrontendRequest): Promise<Frontend
     }
 
     if (response === 'UPDATE_FAILURE_REFERENCE') {
-      const blockingUris: string[] = blockingDocumentsToUris(frontendRequest, result.blockingDocuments);
+      const blockingUris: string[] = blockingDocumentsToUris(frontendRequest, result.referringDocumentInfo);
       writeDebugStatusToLog(moduleName, frontendRequest, 'update', 409, 'reference error');
       return {
         body: R.is(String, result.failureMessage) ? { error: result.failureMessage, blockingUris } : result.failureMessage,
@@ -95,7 +95,7 @@ export async function update(frontendRequest: FrontendRequest): Promise<Frontend
     }
 
     if (response === 'UPDATE_FAILURE_CONFLICT') {
-      const blockingUris: string[] = blockingDocumentsToUris(frontendRequest, result.blockingDocuments);
+      const blockingUris: string[] = blockingDocumentsToUris(frontendRequest, result.referringDocumentInfo);
       writeDebugStatusToLog(moduleName, frontendRequest, 'update', 409, blockingUris.join(','));
       return {
         body: { error: { message: result.failureMessage ?? '', blockingUris } },

--- a/Meadowlark-js/packages/meadowlark-core/src/handler/Upsert.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/handler/Upsert.ts
@@ -62,7 +62,7 @@ export async function upsert(frontendRequest: FrontendRequest): Promise<Frontend
     }
 
     if (response === 'UPDATE_FAILURE_REFERENCE') {
-      const blockingUris: string[] = blockingDocumentsToUris(frontendRequest, result.blockingDocuments);
+      const blockingUris: string[] = blockingDocumentsToUris(frontendRequest, result.referringDocumentInfo);
       writeDebugStatusToLog(moduleName, frontendRequest, 'upsert', 409, blockingUris.join(','));
       return {
         // body: { error: { message: failureMessage, blockingUris } },
@@ -73,7 +73,7 @@ export async function upsert(frontendRequest: FrontendRequest): Promise<Frontend
     }
 
     if (response === 'INSERT_FAILURE_REFERENCE' || response === 'INSERT_FAILURE_CONFLICT') {
-      const blockingUris: string[] = blockingDocumentsToUris(frontendRequest, result.blockingDocuments);
+      const blockingUris: string[] = blockingDocumentsToUris(frontendRequest, result.referringDocumentInfo);
       writeDebugStatusToLog(moduleName, frontendRequest, 'upsert', 409, blockingUris.join(','));
       return {
         body: R.is(String, failureMessage) ? { error: failureMessage, blockingUris } : failureMessage,

--- a/Meadowlark-js/packages/meadowlark-core/src/handler/UriBuilder.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/handler/UriBuilder.ts
@@ -6,7 +6,7 @@
 import { pluralize, uncapitalize } from '@edfi/metaed-plugin-edfi-api-schema';
 import { PathComponents } from '../model/PathComponents';
 import { FrontendRequest } from './FrontendRequest';
-import { BlockingDocument } from '../message/BlockingDocument';
+import { ReferringDocumentInfo } from '../message/ReferringDocumentInfo';
 import { versionAbbreviationFor } from '../metaed/MetaEdProjectMetadata';
 
 /**
@@ -19,10 +19,13 @@ export function resourceUriFrom(pathComponents: PathComponents, documentUuid: st
 /**
  * For generating problem details when a document references the document to be deleted.
  */
-export function blockingDocumentsToUris(frontendRequest: FrontendRequest, blockingDocuments?: BlockingDocument[]): string[] {
+export function blockingDocumentsToUris(
+  frontendRequest: FrontendRequest,
+  referringDocumentInfo?: ReferringDocumentInfo[],
+): string[] {
   const result: string[] = [];
-  if (blockingDocuments) {
-    blockingDocuments.forEach((document) => {
+  if (referringDocumentInfo) {
+    referringDocumentInfo.forEach((document) => {
       let uri = resourceUriFrom(
         {
           version: versionAbbreviationFor(document.resourceVersion),

--- a/Meadowlark-js/packages/meadowlark-core/src/index.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/index.ts
@@ -32,7 +32,7 @@ export type { FrontendRequest, Headers } from './handler/FrontendRequest';
 export { newFrontendRequest, newFrontendRequestMiddleware } from './handler/FrontendRequest';
 export type { FrontendResponse } from './handler/FrontendResponse';
 export { newFrontendResponse, newFrontendResponseSuccess } from './handler/FrontendResponse';
-export { meadowlarkIdForDocumentIdentity, generateDocumentUuid } from './model/DocumentIdentity';
+export { meadowlarkIdForDocumentIdentity, generateDocumentUuid, NoDocumentIdentity } from './model/DocumentIdentity';
 export { getMeadowlarkIdForDocumentReference } from './model/DocumentReference';
 export type { DocumentInfo } from './model/DocumentInfo';
 export { newDocumentInfo, NoDocumentInfo } from './model/DocumentInfo';

--- a/Meadowlark-js/packages/meadowlark-core/src/index.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/index.ts
@@ -20,7 +20,7 @@ export type { DeleteRequest } from './message/DeleteRequest';
 export type { UpdateRequest } from './message/UpdateRequest';
 export type { UpsertRequest } from './message/UpsertRequest';
 export type { QueryRequest } from './message/QueryRequest';
-export type { BlockingDocument } from './message/BlockingDocument';
+export type { ReferringDocumentInfo } from './message/ReferringDocumentInfo';
 export type { PaginationParameters } from './message/PaginationParameters';
 export type { Security } from './security/Security';
 export { newSecurity } from './security/Security';

--- a/Meadowlark-js/packages/meadowlark-core/src/message/DeleteResult.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/message/DeleteResult.ts
@@ -3,11 +3,11 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-import { BlockingDocument } from './BlockingDocument';
+import { ReferringDocumentInfo } from './ReferringDocumentInfo';
 
 export type DeleteFailureReference = {
   response: 'DELETE_FAILURE_REFERENCE';
-  blockingDocuments: BlockingDocument[];
+  referringDocumentInfo: ReferringDocumentInfo[];
 };
 
 export type DeleteResult =

--- a/Meadowlark-js/packages/meadowlark-core/src/message/ReferringDocumentInfo.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/message/ReferringDocumentInfo.ts
@@ -6,9 +6,9 @@
 import { DocumentUuid, MeadowlarkId } from '../model/BrandedTypes';
 
 /**
- * Information on a document that is blocking the delete of another document for referential integrity reasons
+ * Information on a document that is referring another document for referential integrity reasons
  */
-export type BlockingDocument = {
+export type ReferringDocumentInfo = {
   projectName: string;
   resourceVersion: string;
   resourceName: string;

--- a/Meadowlark-js/packages/meadowlark-core/src/message/UpdateResult.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/message/UpdateResult.ts
@@ -3,12 +3,12 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-import { BlockingDocument } from './BlockingDocument';
+import { ReferringDocumentInfo } from './ReferringDocumentInfo';
 
 type UpdateFailureBlocked = {
   response: 'UPDATE_FAILURE_REFERENCE' | 'UPDATE_FAILURE_CONFLICT';
   failureMessage?: string | object;
-  blockingDocuments: BlockingDocument[];
+  referringDocumentInfo: ReferringDocumentInfo[];
 };
 
 export type UpdateResult =

--- a/Meadowlark-js/packages/meadowlark-core/src/message/UpsertResult.ts
+++ b/Meadowlark-js/packages/meadowlark-core/src/message/UpsertResult.ts
@@ -4,12 +4,12 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 import { DocumentUuid } from '../model/BrandedTypes';
-import { BlockingDocument } from './BlockingDocument';
+import { ReferringDocumentInfo } from './ReferringDocumentInfo';
 
 type UpsertFailureBlocked = {
   response: 'INSERT_FAILURE_REFERENCE' | 'INSERT_FAILURE_CONFLICT' | 'UPDATE_FAILURE_REFERENCE';
   failureMessage?: string | object;
-  blockingDocuments: BlockingDocument[];
+  referringDocumentInfo: ReferringDocumentInfo[];
 };
 
 export type UpsertResult =

--- a/Meadowlark-js/packages/meadowlark-core/test/handler/DeleteIt.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/handler/DeleteIt.test.ts
@@ -8,7 +8,7 @@ import * as PluginLoader from '../../src/plugin/PluginLoader';
 import { FrontendResponse } from '../../src/handler/FrontendResponse';
 import { FrontendRequest, newFrontendRequest, newFrontendRequestMiddleware } from '../../src/handler/FrontendRequest';
 import { NoDocumentStorePlugin } from '../../src/plugin/backend/NoDocumentStorePlugin';
-import { BlockingDocument } from '../../src/message/BlockingDocument';
+import { ReferringDocumentInfo } from '../../src/message/ReferringDocumentInfo';
 import { DocumentUuid, MeadowlarkId } from '../../src/model/BrandedTypes';
 
 const frontendRequest: FrontendRequest = {
@@ -151,7 +151,7 @@ describe('given id does not exist', () => {
 
 describe('given the document to be deleted is referenced by other documents ', () => {
   let mockDocumentStore: any;
-  const expectedBlockingDocument: BlockingDocument = {
+  const expectedBlockingDocument: ReferringDocumentInfo = {
     resourceName: 'resourceName',
     documentUuid: 'documentUuid' as DocumentUuid,
     meadowlarkId: 'meadowlarkId' as MeadowlarkId,
@@ -166,7 +166,7 @@ describe('given the document to be deleted is referenced by other documents ', (
       deleteDocumentById: async () =>
         Promise.resolve({
           response: 'DELETE_FAILURE_REFERENCE',
-          blockingDocuments: [expectedBlockingDocument],
+          referringDocumentInfo: [expectedBlockingDocument],
         }),
     });
 

--- a/Meadowlark-js/packages/meadowlark-core/test/handler/Update.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/handler/Update.test.ts
@@ -8,7 +8,7 @@ import * as PluginLoader from '../../src/plugin/PluginLoader';
 import { FrontendResponse } from '../../src/handler/FrontendResponse';
 import { FrontendRequest, newFrontendRequest, newFrontendRequestMiddleware } from '../../src/handler/FrontendRequest';
 import { NoDocumentStorePlugin } from '../../src/plugin/backend/NoDocumentStorePlugin';
-import { BlockingDocument } from '../../src/message/BlockingDocument';
+import { ReferringDocumentInfo } from '../../src/message/ReferringDocumentInfo';
 import { DocumentUuid, MeadowlarkId } from '../../src/model/BrandedTypes';
 
 const documentUuid = '2edb604f-eab0-412c-a242-508d6529214d' as DocumentUuid;
@@ -61,7 +61,7 @@ describe('given the requested document does not exist', () => {
 
 describe('given the new document has an invalid reference ', () => {
   let mockDocumentStore: any;
-  const expectedBlockingDocument: BlockingDocument = {
+  const expectedBlockingDocument: ReferringDocumentInfo = {
     resourceName: 'resourceName',
     documentUuid: 'documentUuid' as DocumentUuid,
     meadowlarkId: 'meadowlarkId' as MeadowlarkId,
@@ -78,7 +78,7 @@ describe('given the new document has an invalid reference ', () => {
         Promise.resolve({
           response: 'UPDATE_FAILURE_REFERENCE',
           failureMessage: expectedError,
-          blockingDocuments: [expectedBlockingDocument],
+          referringDocumentInfo: [expectedBlockingDocument],
         }),
     });
 

--- a/Meadowlark-js/packages/meadowlark-core/test/handler/Upsert.test.ts
+++ b/Meadowlark-js/packages/meadowlark-core/test/handler/Upsert.test.ts
@@ -9,7 +9,7 @@ import * as PluginLoader from '../../src/plugin/PluginLoader';
 import { FrontendRequest, newFrontendRequest, newFrontendRequestMiddleware } from '../../src/handler/FrontendRequest';
 import { FrontendResponse } from '../../src/handler/FrontendResponse';
 import { NoDocumentStorePlugin } from '../../src/plugin/backend/NoDocumentStorePlugin';
-import { BlockingDocument } from '../../src/message/BlockingDocument';
+import { ReferringDocumentInfo } from '../../src/message/ReferringDocumentInfo';
 import { isDocumentUuidWellFormed } from '../../src/validation/DocumentIdValidator';
 import { DocumentUuid, MeadowlarkId } from '../../src/model/BrandedTypes';
 
@@ -29,7 +29,7 @@ const frontendRequest: FrontendRequest = {
 
 describe('given persistence is going to throw a reference error on insert', () => {
   let response: FrontendResponse;
-  const expectedBlockingDocument: BlockingDocument = {
+  const expectedBlockingDocument: ReferringDocumentInfo = {
     resourceName: 'resourceName',
     documentUuid,
     meadowlarkId: 'meadowlarkId' as MeadowlarkId,
@@ -46,7 +46,7 @@ describe('given persistence is going to throw a reference error on insert', () =
         Promise.resolve({
           response: 'INSERT_FAILURE_REFERENCE',
           failureMessage: expectedError,
-          blockingDocuments: [expectedBlockingDocument],
+          referringDocumentInfo: [expectedBlockingDocument],
         }),
     });
 
@@ -113,7 +113,7 @@ describe('given upsert has write conflict failure', () => {
 
 describe('given persistence is going to throw a conflict error on insert', () => {
   let response: FrontendResponse;
-  const expectedBlockingDocument: BlockingDocument = {
+  const expectedBlockingDocument: ReferringDocumentInfo = {
     resourceName: 'resourceName',
     documentUuid,
     meadowlarkId: 'meadowlarkId' as MeadowlarkId,
@@ -130,7 +130,7 @@ describe('given persistence is going to throw a conflict error on insert', () =>
         Promise.resolve({
           response: 'INSERT_FAILURE_CONFLICT',
           failureMessage: expectedError,
-          blockingDocuments: [expectedBlockingDocument],
+          referringDocumentInfo: [expectedBlockingDocument],
         }),
     });
 
@@ -161,7 +161,7 @@ describe('given persistence is going to throw a conflict error on insert', () =>
 
 describe('given persistence is going to throw a reference error on update though did not on insert attempt', () => {
   let response: FrontendResponse;
-  const expectedBlockingDocument: BlockingDocument = {
+  const expectedBlockingDocument: ReferringDocumentInfo = {
     resourceName: 'resourceName',
     documentUuid,
     meadowlarkId: 'meadowlarkId' as MeadowlarkId,
@@ -177,7 +177,7 @@ describe('given persistence is going to throw a reference error on update though
         Promise.resolve({
           response: 'UPDATE_FAILURE_REFERENCE',
           failureMessage: 'Reference failure',
-          blockingDocuments: [expectedBlockingDocument],
+          referringDocumentInfo: [expectedBlockingDocument],
         }),
     });
 


### PR DESCRIPTION


Update sqlHelper to execute sql queries and return an object with the result. Update references to use the new result instead of execute the sql string. Update tests.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Provide a brief description of your changes. Additional detail -->
<!--- should be in an associated Ed-Fi Tracker ticket (https://tracker.ed-fi.org) -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have signed all of the commits on this PR.
- [x] I have agreed to the Ed-Fi Individual Contributors' License
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
