### PR TITLE
[RND-650] GitHub Actions is not saving docker logs after failure

### DIFF
--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/test/setup/PostgresqlContainer.ts
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/test/setup/PostgresqlContainer.ts
@@ -20,7 +20,6 @@ export async function setup() {
   try {
     const container = new PostgreSqlContainer(image)
       .withName('postgres-test')
-      .withReuse()
       .withDatabase(process.env.MEADOWLARK_DATABASE_NAME)
       .withUsername(process.env.POSTGRES_USER)
       .withPassword(process.env.POSTGRES_PASSWORD);

--- a/Meadowlark-js/tests/e2e/setup/LogConfig.ts
+++ b/Meadowlark-js/tests/e2e/setup/LogConfig.ts
@@ -4,7 +4,7 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 import fs from 'fs-extra';
-import { StartedTestContainer } from 'testcontainers';
+import { Stream } from 'stream';
 
 let apiWriteStream: fs.WriteStream;
 let mongoWriteStream: fs.WriteStream;
@@ -32,56 +32,51 @@ export function endLog() {
   }
 }
 
-export async function setMongoLog(container: StartedTestContainer) {
+export async function setMongoLog(stream: Stream) {
   try {
-    const mongoStream = await container.logs();
     mongoWriteStream = fs.createWriteStream(`${logFolder}/mongo.log`);
 
-    mongoStream.on('data', (line) => mongoWriteStream.write(line)).on('err', (line) => mongoWriteStream.write(line));
+    stream.on('data', (line) => mongoWriteStream.write(line)).on('err', (line) => mongoWriteStream.write(line));
   } catch (error) {
     throw new Error(`\nUnexpected error setting up mongo logs:\n${error}`);
   }
 }
 
-export async function setAPILog(container: StartedTestContainer) {
+export async function setAPILog(stream: Stream) {
   try {
-    const apiStream = await container.logs();
     apiWriteStream = fs.createWriteStream(`${logFolder}/meadowlark-api.log`);
 
-    apiStream.on('data', (line) => apiWriteStream.write(line)).on('err', (line) => apiWriteStream.write(line));
+    stream.on('data', (line) => apiWriteStream.write(line)).on('err', (line) => apiWriteStream.write(line));
   } catch (error) {
     throw new Error(`\nUnexpected error setting up api logs:\n${error}`);
   }
 }
 
-export async function setOpenSearchLog(container: StartedTestContainer) {
+export async function setOpenSearchLog(stream: Stream) {
   try {
-    const osStream = await container.logs();
     opSearchWriteStream = fs.createWriteStream(`${logFolder}/openSearch.log`);
 
-    osStream.on('data', (line) => opSearchWriteStream.write(line)).on('err', (line) => opSearchWriteStream.write(line));
+    stream.on('data', (line) => opSearchWriteStream.write(line)).on('err', (line) => opSearchWriteStream.write(line));
   } catch (error) {
     throw new Error(`\nUnexpected error setting up open search logs:\n${error}`);
   }
 }
 
-export async function setElasticSearchLog(container: StartedTestContainer) {
+export async function setElasticSearchLog(stream: Stream) {
   try {
-    const osStream = await container.logs();
     elasticSearchWriteStream = fs.createWriteStream(`${logFolder}/elasticSearch.log`);
 
-    osStream.on('data', (line) => elasticSearchWriteStream.write(line)).on('err', (line) => opSearchWriteStream.write(line));
+    stream.on('data', (line) => elasticSearchWriteStream.write(line)).on('err', (line) => opSearchWriteStream.write(line));
   } catch (error) {
     throw new Error(`\nUnexpected error setting up elastic search logs:\n${error}`);
   }
 }
 
-export async function setPostgresLog(container: StartedTestContainer) {
+export async function setPostgresLog(stream: Stream) {
   try {
-    const pgStream = await container.logs();
     pgWriteStream = fs.createWriteStream(`${logFolder}/postgres.log`);
 
-    pgStream.on('data', (line) => pgWriteStream.write(line)).on('err', (line) => pgWriteStream.write(line));
+    stream.on('data', (line) => pgWriteStream.write(line)).on('err', (line) => pgWriteStream.write(line));
   } catch (error) {
     throw new Error(`\nUnexpected error setting up postgres logs:\n${error}`);
   }

--- a/Meadowlark-js/tests/e2e/setup/SetupTestEnvironment.ts
+++ b/Meadowlark-js/tests/e2e/setup/SetupTestEnvironment.ts
@@ -30,7 +30,11 @@ module.exports = async () => {
   if (process.env.USE_EXISTING_ENVIRONMENT) {
     console.info('Using existing environment, Verify that variables are set');
   } else {
-    await environment.configure(initialize);
+    try {
+      await environment.configure(initialize);
+    } catch (error) {
+      throw new Error(`⚠️ Error initializing containers.⚠️\n${error}`);
+    }
   }
 
   process.env.ROOT_URL = `http://localhost:${process.env.FASTIFY_PORT ?? 3001}`;

--- a/Meadowlark-js/tests/e2e/setup/SetupTestEnvironment.ts
+++ b/Meadowlark-js/tests/e2e/setup/SetupTestEnvironment.ts
@@ -13,7 +13,11 @@ const environment = require('./SetupTestContainers');
 if (process.env.USE_EXISTING_ENVIRONMENT) {
   dotenv.config({ path: join(process.cwd(), './services/meadowlark-fastify/.env') });
 } else {
-  dotenv.config({ path: join(__dirname, './.env-e2e') });
+  const result = dotenv.config({ path: join(__dirname, './.env-e2e') });
+
+  if (result.error) {
+    throw new Error(`An error ocurred loading .env-e2e file:\n${result.error}`);
+  }
 }
 
 module.exports = async () => {

--- a/Meadowlark-js/tests/e2e/setup/containers/ApiContainer.ts
+++ b/Meadowlark-js/tests/e2e/setup/containers/ApiContainer.ts
@@ -23,7 +23,6 @@ export async function setup(network: StartedNetwork) {
         container: fastifyPort,
         host: fastifyPort,
       })
-      .withReuse()
       .withEnvironment({
         OAUTH_SIGNING_KEY: process.env.OAUTH_SIGNING_KEY ?? '',
         OAUTH_HARD_CODED_CREDENTIALS_ENABLED: 'true',

--- a/Meadowlark-js/tests/e2e/setup/containers/ApiContainer.ts
+++ b/Meadowlark-js/tests/e2e/setup/containers/ApiContainer.ts
@@ -19,6 +19,7 @@ export async function setup(network: StartedNetwork) {
     container = new GenericContainer(process.env.API_IMAGE_NAME ?? 'meadowlark')
       .withName('meadowlark-api-test')
       .withNetwork(network)
+      .withLogConsumer(async (stream) => setAPILog(stream))
       .withExposedPorts({
         container: fastifyPort,
         host: fastifyPort,
@@ -62,7 +63,6 @@ export async function setup(network: StartedNetwork) {
 
     throw new Error(`\nUnexpected error setting up API container:\n${error}`);
   }
-  await setAPILog(startedContainer);
 }
 
 export async function stop(): Promise<void> {

--- a/Meadowlark-js/tests/e2e/setup/containers/ElasticSearchContainer.ts
+++ b/Meadowlark-js/tests/e2e/setup/containers/ElasticSearchContainer.ts
@@ -16,6 +16,7 @@ export async function setup(network: StartedNetwork) {
     )
       .withName('elasticsearch-node-test')
       .withNetwork(network)
+      .withLogConsumer(async (stream) => setElasticSearchLog(stream))
       .withExposedPorts({
         container: elasticSearchPort,
         host: elasticSearchPort,
@@ -33,8 +34,6 @@ export async function setup(network: StartedNetwork) {
   } catch (error) {
     throw new Error(`\nUnexpected error setting up elastic search container:\n${error}`);
   }
-
-  await setElasticSearchLog(startedContainer);
 }
 
 export async function stop(): Promise<void> {

--- a/Meadowlark-js/tests/e2e/setup/containers/ElasticSearchContainer.ts
+++ b/Meadowlark-js/tests/e2e/setup/containers/ElasticSearchContainer.ts
@@ -16,7 +16,6 @@ export async function setup(network: StartedNetwork) {
     )
       .withName('elasticsearch-node-test')
       .withNetwork(network)
-      .withReuse()
       .withExposedPorts({
         container: elasticSearchPort,
         host: elasticSearchPort,

--- a/Meadowlark-js/tests/e2e/setup/containers/MongoContainer.ts
+++ b/Meadowlark-js/tests/e2e/setup/containers/MongoContainer.ts
@@ -17,6 +17,7 @@ export async function setup(network: StartedNetwork) {
       .withNetwork(network)
       .withNetworkAliases('mongo-t1')
       .withName('mongo-test')
+      .withLogConsumer(async (stream) => setMongoLog(stream))
       .withCommand([
         '/usr/bin/mongod',
         '--bind_ip_all',
@@ -32,8 +33,6 @@ export async function setup(network: StartedNetwork) {
   } catch (error) {
     throw new Error(`\nUnexpected error setting up mongo container:\n${error}`);
   }
-
-  await setMongoLog(startedContainer);
 }
 
 export async function stop(): Promise<void> {

--- a/Meadowlark-js/tests/e2e/setup/containers/MongoContainer.ts
+++ b/Meadowlark-js/tests/e2e/setup/containers/MongoContainer.ts
@@ -17,7 +17,6 @@ export async function setup(network: StartedNetwork) {
       .withNetwork(network)
       .withNetworkAliases('mongo-t1')
       .withName('mongo-test')
-      .withReuse()
       .withCommand([
         '/usr/bin/mongod',
         '--bind_ip_all',

--- a/Meadowlark-js/tests/e2e/setup/containers/OpenSearchContainer.ts
+++ b/Meadowlark-js/tests/e2e/setup/containers/OpenSearchContainer.ts
@@ -16,7 +16,6 @@ export async function setup(network: StartedNetwork) {
     )
       .withName('opensearch-test')
       .withNetwork(network)
-      .withReuse()
       .withExposedPorts({
         container: openSearchPort,
         host: openSearchPort,

--- a/Meadowlark-js/tests/e2e/setup/containers/OpenSearchContainer.ts
+++ b/Meadowlark-js/tests/e2e/setup/containers/OpenSearchContainer.ts
@@ -16,6 +16,7 @@ export async function setup(network: StartedNetwork) {
     )
       .withName('opensearch-test')
       .withNetwork(network)
+      .withLogConsumer(async (stream) => setOpenSearchLog(stream))
       .withExposedPorts({
         container: openSearchPort,
         host: openSearchPort,
@@ -32,8 +33,6 @@ export async function setup(network: StartedNetwork) {
   } catch (error) {
     throw new Error(`\nUnexpected error setting up open search container:\n${error}`);
   }
-
-  await setOpenSearchLog(startedContainer);
 }
 
 export async function stop(): Promise<void> {

--- a/Meadowlark-js/tests/e2e/setup/containers/PostgresqlContainer.ts
+++ b/Meadowlark-js/tests/e2e/setup/containers/PostgresqlContainer.ts
@@ -23,6 +23,7 @@ export async function setup(network: StartedNetwork) {
       .withName('postgres-test')
       .withNetwork(network)
       .withNetworkAliases('pg-test')
+      .withLogConsumer(async (stream) => setPostgresLog(stream))
       .withDatabase(process.env.MEADOWLARK_DATABASE_NAME)
       .withUsername(process.env.POSTGRES_USER)
       .withPassword(process.env.POSTGRES_PASSWORD)
@@ -32,8 +33,6 @@ export async function setup(network: StartedNetwork) {
 
     process.env.POSTGRES_HOST = startedContainer.getHost();
     process.env.POSTGRES_PORT = `${startedContainer.getFirstMappedPort()}`;
-
-    await setPostgresLog(startedContainer);
   } catch (error) {
     throw new Error(`\nUnexpected error setting up postgres container:\n${error}`);
   }

--- a/Meadowlark-js/tests/e2e/setup/containers/PostgresqlContainer.ts
+++ b/Meadowlark-js/tests/e2e/setup/containers/PostgresqlContainer.ts
@@ -23,7 +23,6 @@ export async function setup(network: StartedNetwork) {
       .withName('postgres-test')
       .withNetwork(network)
       .withNetworkAliases('pg-test')
-      .withReuse()
       .withDatabase(process.env.MEADOWLARK_DATABASE_NAME)
       .withUsername(process.env.POSTGRES_USER)
       .withPassword(process.env.POSTGRES_PASSWORD)


### PR DESCRIPTION
Refactor attachment of log stream to TestContainers since previous behavior didn't catch errors when starting containers.
Adding more details on scenarios where error was not clear.

## Description

- Refactor log tracking for TestContainers.
- Remove withReuse flag since that leaves a dirty environment locally.
- Add error messages when .env file not found and when unable to start containers.
