### PR TITLE
[RND-659] On pre release action: Fix SBOM hash generation

### DIFF
--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -198,7 +198,7 @@ jobs:
         id: sbom-hash-code
         shell: bash
         run: |
-          echo sbom-hash-code=$(iconv -f UTF-16 -t ASCII ./sbom/_manifest/spdx_2.2/manifest.spdx.json.sha256) >> $GITHUB_OUTPUT
+          echo sbom-hash-code=$(sha256sum ./sbom/_manifest/spdx_2.2/manifest.spdx.json | awk '{split($0,a); print a[1]}') >> $GITHUB_OUTPUT
 
   sbom-attach:
     name: Attach SBOM file


### PR DESCRIPTION
Use sha256sum instead of iconv to generate hash, iconv is getting errors parsing out to ASCII from UTF-16. sha256sum is the method used in Admin API to generate the hash.