### PR TITLE
[RND-653] Refactor Config file to not require mongodb URI

### DIFF
--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -30,9 +30,7 @@ jobs:
     uses: ed-fi-alliance-oss/ed-fi-actions/.github/workflows/repository-scanner.yml@main
 
   upgrade:
-    # Upgrade packages on PR only to avoid a double update when pushed to main
     name: Upgrade packages
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -45,27 +43,29 @@ jobs:
         with:
           fetch-depth: 0w
 
-      - name: Get changes
-        id: changes
+      - name: Get version changes
+        id: versions
         run: |
-          suggested=v$(cat lerna.json | jq -r .version)
-          current=$(git describe --tags $(git rev-list --tags --max-count=1))
-          echo "Versions: Lerna: $suggested. Current: $current"
-          echo "changes=$([[ "$suggested" != "$current" ]] && echo true)" >>$GITHUB_OUTPUT
+          if [ ${{ github.event_name }} == 'pull_request' ]; then
+            suggested=v$(cat lerna.json | jq -r .version)
+            current=$(git describe --tags $(git rev-list --tags --max-count=1))
+            echo "Versions: Lerna: $suggested. Current: $current"
+            echo "update-required=$([[ "$suggested" == "$current" ]] && echo true)" >>$GITHUB_OUTPUT
+          fi
 
       - name: Update versions
-        if: ${{ ! steps.changes.outputs.changes }}
+        if: steps.versions.outputs.update-required
         run: npx lerna@6.6.2 version prerelease --exact --no-git-tag-version --yes
 
       - name: Set Version
-        if: ${{ ! steps.changes.outputs.changes }}
+        if: steps.versions.outputs.update-required
         id: set-version
         run: |
           version=v$(cat lerna.json | jq -r .version)
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - uses: planetscale/ghcommit-action@4131649dbf2fdf1eb34421702972a5af7b0a8731 #v0.1.18
-        if: ${{ ! steps.changes.outputs.changes }}
+        if: steps.versions.outputs.update-required
         with:
           commit_message: "${{steps.set-version.outputs.version}}"
           repo: ${{ github.repository }}
@@ -159,7 +159,7 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install dependencies
-        if: ${{ steps.modules-cache.outputs.cache-hit != 'true' }}
+        if: steps.modules-cache.outputs.cache-hit != 'true'
         run: npm install
 
       - name: Linter
@@ -189,7 +189,7 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install dependencies
-        if: ${{ steps.modules-cache.outputs.cache-hit != 'true' }}
+        if: steps.modules-cache.outputs.cache-hit != 'true'
         run: npm install
 
       - name: Build
@@ -223,7 +223,7 @@ jobs:
           cache-dependency-path: "**/package-lock.json"
 
       - name: Load MongoDB binary cache
-        if: ${{ matrix.tests.type != 'Unit' }}
+        if: matrix.tests.type != 'Unit'
         id: cache-mongodb-binaries
         uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
         with:
@@ -238,7 +238,7 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install dependencies
-        if: ${{ steps.modules-cache.outputs.cache-hit != 'true' }}
+        if: steps.modules-cache.outputs.cache-hit != 'true'
         run: npm install
 
       - name: Jest cache
@@ -249,7 +249,7 @@ jobs:
           key: ${{ runner.os }}-jest-${{ hashFiles('**/package-lock.json') }}
 
       - name: Configure postgres
-        if: ${{ matrix.tests.type != 'Unit' }}
+        if: matrix.tests.type != 'Unit'
         run: |
           sudo systemctl start postgresql.service
           sudo -u postgres psql -U postgres -c "alter user postgres with password '${{env.POSTGRES_PASSWORD}}';"
@@ -287,7 +287,7 @@ jobs:
 
   end-to-end:
     name: End to End tests for ${{ matrix.store.db }} as store and ${{matrix.query_handler.provider}} as query handler
-    needs: [lint]
+    needs: lint
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -326,7 +326,7 @@ jobs:
           echo OAUTH_SIGNING_KEY="$( openssl rand -base64 256 | tr -d '\n' )" >> .env-e2e
         working-directory: Meadowlark-js/tests/e2e/setup/
 
-      - name: End to End tests for ${{matrix.store.db}} as store, ${{matrix.store.plugin}} as authorization and ${{matrix.query_handler.provider}} as query handler
+      - name: End to End tests for ${{matrix.store.db}} as store, ${{matrix.query_handler.provider}} as query handler
         run: npm run test:e2e:build -- --ci
         env:
           AUTHORIZATION_STORE_PLUGIN: ${{ matrix.store.plugin }}
@@ -335,7 +335,7 @@ jobs:
           LISTENER1_PLUGIN: ${{ matrix.query_handler.plugin }}
 
       - name: Docker logs
-        if: ${{ failure() }}
+        if: failure()
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: docker-logs

--- a/Meadowlark-js/backends/meadowlark-elasticsearch-backend/package.json
+++ b/Meadowlark-js/backends/meadowlark-elasticsearch-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edfi/meadowlark-elasticsearch-backend",
   "main": "dist/index.js",
-  "version": "0.4.0-pre.2",
+  "version": "0.4.0-pre.3",
   "description": "Meadowlark backend plugin for elasticsearch",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -19,8 +19,8 @@
     "build:copy-non-ts": "copyfiles -u 1 -e \"**/*.ts\" \"src/**/*\" dist --verbose"
   },
   "dependencies": {
-    "@edfi/meadowlark-core": "0.4.0-pre.2",
-    "@edfi/meadowlark-utilities": "0.4.0-pre.2",
+    "@edfi/meadowlark-core": "0.4.0-pre.3",
+    "@edfi/meadowlark-utilities": "0.4.0-pre.3",
     "@elastic/elasticsearch": "^8.10.0",
     "@elastic/transport": "^8.3.4"
   },

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/package.json
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edfi/meadowlark-mongodb-backend",
   "main": "dist/index.js",
-  "version": "0.4.0-pre.2",
+  "version": "0.4.0-pre.3",
   "description": "Meadowlark backend plugin for MongoDB",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -19,9 +19,9 @@
     "build:copy-non-ts": "copyfiles -u 1 -e \"**/*.ts\" \"src/**/*\" dist --verbose"
   },
   "dependencies": {
-    "@edfi/meadowlark-authz-server": "0.4.0-pre.2",
-    "@edfi/meadowlark-core": "0.4.0-pre.2",
-    "@edfi/meadowlark-utilities": "0.4.0-pre.2",
+    "@edfi/meadowlark-authz-server": "0.4.0-pre.3",
+    "@edfi/meadowlark-core": "0.4.0-pre.3",
+    "@edfi/meadowlark-utilities": "0.4.0-pre.3",
     "async-retry": "^1.3.3",
     "mongodb": "^5.9.0",
     "ramda": "0.29.1"

--- a/Meadowlark-js/backends/meadowlark-opensearch-backend/package.json
+++ b/Meadowlark-js/backends/meadowlark-opensearch-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edfi/meadowlark-opensearch-backend",
   "main": "dist/index.js",
-  "version": "0.4.0-pre.2",
+  "version": "0.4.0-pre.3",
   "description": "Meadowlark backend plugin for OpenSearch",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -19,8 +19,8 @@
     "build:copy-non-ts": "copyfiles -u 1 -e \"**/*.ts\" \"src/**/*\" dist --verbose"
   },
   "dependencies": {
-    "@edfi/meadowlark-core": "0.4.0-pre.2",
-    "@edfi/meadowlark-utilities": "0.4.0-pre.2",
+    "@edfi/meadowlark-core": "0.4.0-pre.3",
+    "@edfi/meadowlark-utilities": "0.4.0-pre.3",
     "@opensearch-project/opensearch": "^2.4.0"
   },
   "devDependencies": {

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/docker/docker-compose.yml
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     restart: always
     environment:
     # If username and password not provided through and env file
-    # default to postres/abcdefgh1!
+    # default to postgres/abcdefgh1!
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-abcdefgh1!}
     ports:
@@ -17,3 +17,7 @@ services:
 volumes:
   meadowlark-pgsql:
     driver: local
+
+networks:
+  meadowlark-net:
+    external: true

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/package.json
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edfi/meadowlark-postgresql-backend",
   "main": "dist/index.js",
-  "version": "0.4.0-pre.2",
+  "version": "0.4.0-pre.3",
   "description": "Meadowlark backend plugin for PostgreSQL",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -19,9 +19,9 @@
     "build:copy-non-ts": "copyfiles -u 1 -e \"**/*.ts\" \"src/**/*\" dist --verbose"
   },
   "dependencies": {
-    "@edfi/meadowlark-authz-server": "0.4.0-pre.2",
-    "@edfi/meadowlark-core": "0.4.0-pre.2",
-    "@edfi/meadowlark-utilities": "0.4.0-pre.2",
+    "@edfi/meadowlark-authz-server": "0.4.0-pre.3",
+    "@edfi/meadowlark-core": "0.4.0-pre.3",
+    "@edfi/meadowlark-utilities": "0.4.0-pre.3",
     "pg": "^8.11.3",
     "pg-format": "^1.0.4",
     "ramda": "0.29.1"

--- a/Meadowlark-js/lerna.json
+++ b/Meadowlark-js/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.4.0-pre.2",
+  "version": "0.4.0-pre.3",
   "npmClient": "npm",
   "useWorkspaces": true
 }

--- a/Meadowlark-js/package-lock.json
+++ b/Meadowlark-js/package-lock.json
@@ -52,11 +52,11 @@
     },
     "backends/meadowlark-elasticsearch-backend": {
       "name": "@edfi/meadowlark-elasticsearch-backend",
-      "version": "0.4.0-pre.2",
+      "version": "0.4.0-pre.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@edfi/meadowlark-core": "0.4.0-pre.2",
-        "@edfi/meadowlark-utilities": "0.4.0-pre.2",
+        "@edfi/meadowlark-core": "0.4.0-pre.3",
+        "@edfi/meadowlark-utilities": "0.4.0-pre.3",
         "@elastic/elasticsearch": "^8.10.0",
         "@elastic/transport": "^8.3.4"
       },
@@ -70,12 +70,12 @@
     },
     "backends/meadowlark-mongodb-backend": {
       "name": "@edfi/meadowlark-mongodb-backend",
-      "version": "0.4.0-pre.2",
+      "version": "0.4.0-pre.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@edfi/meadowlark-authz-server": "0.4.0-pre.2",
-        "@edfi/meadowlark-core": "0.4.0-pre.2",
-        "@edfi/meadowlark-utilities": "0.4.0-pre.2",
+        "@edfi/meadowlark-authz-server": "0.4.0-pre.3",
+        "@edfi/meadowlark-core": "0.4.0-pre.3",
+        "@edfi/meadowlark-utilities": "0.4.0-pre.3",
         "async-retry": "^1.3.3",
         "mongodb": "^5.9.0",
         "ramda": "0.29.1"
@@ -88,11 +88,11 @@
     },
     "backends/meadowlark-opensearch-backend": {
       "name": "@edfi/meadowlark-opensearch-backend",
-      "version": "0.4.0-pre.2",
+      "version": "0.4.0-pre.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@edfi/meadowlark-core": "0.4.0-pre.2",
-        "@edfi/meadowlark-utilities": "0.4.0-pre.2",
+        "@edfi/meadowlark-core": "0.4.0-pre.3",
+        "@edfi/meadowlark-utilities": "0.4.0-pre.3",
         "@opensearch-project/opensearch": "^2.4.0"
       },
       "devDependencies": {
@@ -105,12 +105,12 @@
     },
     "backends/meadowlark-postgresql-backend": {
       "name": "@edfi/meadowlark-postgresql-backend",
-      "version": "0.4.0-pre.2",
+      "version": "0.4.0-pre.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@edfi/meadowlark-authz-server": "0.4.0-pre.2",
-        "@edfi/meadowlark-core": "0.4.0-pre.2",
-        "@edfi/meadowlark-utilities": "0.4.0-pre.2",
+        "@edfi/meadowlark-authz-server": "0.4.0-pre.3",
+        "@edfi/meadowlark-core": "0.4.0-pre.3",
+        "@edfi/meadowlark-utilities": "0.4.0-pre.3",
         "pg": "^8.11.3",
         "pg-format": "^1.0.4",
         "ramda": "0.29.1"
@@ -22540,11 +22540,11 @@
     },
     "packages/meadowlark-authz-server": {
       "name": "@edfi/meadowlark-authz-server",
-      "version": "0.4.0-pre.2",
+      "version": "0.4.0-pre.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@apideck/better-ajv-errors": "^0.3.6",
-        "@edfi/meadowlark-utilities": "0.4.0-pre.2",
+        "@edfi/meadowlark-utilities": "0.4.0-pre.3",
         "ajv": "^8.12.0",
         "dotenv": "^16.3.1",
         "fast-memoize": "^2.5.2",
@@ -22593,11 +22593,11 @@
     },
     "packages/meadowlark-core": {
       "name": "@edfi/meadowlark-core",
-      "version": "0.4.0-pre.2",
+      "version": "0.4.0-pre.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@apideck/better-ajv-errors": "^0.3.6",
-        "@edfi/meadowlark-utilities": "0.4.0-pre.2",
+        "@edfi/meadowlark-utilities": "0.4.0-pre.3",
         "@isaacs/ttlcache": "^1.4.1",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
@@ -22686,7 +22686,7 @@
     },
     "packages/meadowlark-utilities": {
       "name": "@edfi/meadowlark-utilities",
-      "version": "0.4.0-pre.2",
+      "version": "0.4.0-pre.3",
       "license": "Apache-2.0",
       "dependencies": {
         "pino": "^8.15.4",
@@ -22733,12 +22733,12 @@
     },
     "services/meadowlark-fastify": {
       "name": "@edfi/meadowlark-fastify",
-      "version": "0.4.0-pre.2",
+      "version": "0.4.0-pre.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@edfi/meadowlark-authz-server": "0.4.0-pre.2",
-        "@edfi/meadowlark-core": "0.4.0-pre.2",
-        "@edfi/meadowlark-utilities": "0.4.0-pre.2",
+        "@edfi/meadowlark-authz-server": "0.4.0-pre.3",
+        "@edfi/meadowlark-core": "0.4.0-pre.3",
+        "@edfi/meadowlark-utilities": "0.4.0-pre.3",
         "@fastify/rate-limit": "^6.0.1",
         "dotenv": "^16.3.1",
         "fastify": "^3.29.5"
@@ -22751,10 +22751,10 @@
     },
     "tests/e2e": {
       "name": "@edfi/meadowlark-e2e-tests",
-      "version": "0.4.0-pre.2",
+      "version": "0.4.0-pre.3",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@edfi/meadowlark-utilities": "0.4.0-pre.2",
+        "@edfi/meadowlark-utilities": "0.4.0-pre.3",
         "@testcontainers/mongodb": "^10.2.1",
         "@testcontainers/postgresql": "^10.2.1",
         "@types/chance": "^1.1.4",

--- a/Meadowlark-js/packages/meadowlark-authz-server/package.json
+++ b/Meadowlark-js/packages/meadowlark-authz-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edfi/meadowlark-authz-server",
   "main": "dist/index.js",
-  "version": "0.4.0-pre.2",
+  "version": "0.4.0-pre.3",
   "description": "Meadowlark authorization server",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "@apideck/better-ajv-errors": "^0.3.6",
-    "@edfi/meadowlark-utilities": "0.4.0-pre.2",
+    "@edfi/meadowlark-utilities": "0.4.0-pre.3",
     "ajv": "^8.12.0",
     "dotenv": "^16.3.1",
     "fast-memoize": "^2.5.2",

--- a/Meadowlark-js/packages/meadowlark-core/package.json
+++ b/Meadowlark-js/packages/meadowlark-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edfi/meadowlark-core",
   "main": "dist/index.js",
-  "version": "0.4.0-pre.2",
+  "version": "0.4.0-pre.3",
   "description": "Meadowlark core functionality",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "@apideck/better-ajv-errors": "^0.3.6",
-    "@edfi/meadowlark-utilities": "0.4.0-pre.2",
+    "@edfi/meadowlark-utilities": "0.4.0-pre.3",
     "@isaacs/ttlcache": "^1.4.1",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",

--- a/Meadowlark-js/packages/meadowlark-utilities/package.json
+++ b/Meadowlark-js/packages/meadowlark-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edfi/meadowlark-utilities",
   "main": "dist/index.js",
-  "version": "0.4.0-pre.2",
+  "version": "0.4.0-pre.3",
   "description": "Meadowlark shared utilities",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/Meadowlark-js/services/meadowlark-fastify/package.json
+++ b/Meadowlark-js/services/meadowlark-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edfi/meadowlark-fastify",
-  "version": "0.4.0-pre.2",
+  "version": "0.4.0-pre.3",
   "description": "Meadowlark service using Fastify",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -12,9 +12,9 @@
     "/package.json"
   ],
   "dependencies": {
-    "@edfi/meadowlark-authz-server": "0.4.0-pre.2",
-    "@edfi/meadowlark-core": "0.4.0-pre.2",
-    "@edfi/meadowlark-utilities": "0.4.0-pre.2",
+    "@edfi/meadowlark-authz-server": "0.4.0-pre.3",
+    "@edfi/meadowlark-core": "0.4.0-pre.3",
+    "@edfi/meadowlark-utilities": "0.4.0-pre.3",
     "@fastify/rate-limit": "^6.0.1",
     "dotenv": "^16.3.1",
     "fastify": "^3.29.5"

--- a/Meadowlark-js/tests/e2e/package.json
+++ b/Meadowlark-js/tests/e2e/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@edfi/meadowlark-e2e-tests",
   "main": "dist/index.js",
-  "version": "0.4.0-pre.2",
+  "version": "0.4.0-pre.3",
   "description": "Meadowlark Ed-Fi API end to end tests",
   "license": "Apache-2.0",
   "private": true,
   "files": [],
   "devDependencies": {
-    "@edfi/meadowlark-utilities": "0.4.0-pre.2",
+    "@edfi/meadowlark-utilities": "0.4.0-pre.3",
     "@testcontainers/mongodb": "^10.2.1",
     "@testcontainers/postgresql": "^10.2.1",
     "@types/chance": "^1.1.4",

--- a/Meadowlark-js/tests/e2e/readme.md
+++ b/Meadowlark-js/tests/e2e/readme.md
@@ -12,15 +12,53 @@ To run the tests:
 
 Postgresql support is currently disabled and should be included again once Postgresql support is matched on main code.
 
-## Developer Mode
+## Modes of running End to End tests
 
-This is a special mode to use when adding new e2e tests or in situations where it is not necessary to use a clean environment.
+### Local Mode
+
+This will run the end to end tests against your existing local environment. This will not load any new environment variables
+and use the ones defined for fastify.
+
+> [!NOTE]  
+> This mode is recommended when doing new development into Meadowlark and you want to test your changes.
+
+> [!WARNING]  
+> If the tests does not have a correct teardown step or if there was an error cleaning the database, you will have to
+> manually clean your databases and/or indexes to avoid unexpected behavior.
+
+### Isolated mode
+
+This will run the end to end tests with [TestContainers](https://node.testcontainers.org/). It will automatically setup the
+containers to run the tests against and will delete the containers afterwards.
+
+- To setup, create a .env-e2e file in the same location as the [example](./setup/.env-e2e.example) with the required values.
+- Run `test:e2e:build` to build the code and then run the tests in isolated mode.
+
+> [!NOTE]  
+> This mode is recommended when exploring or verifying an installation, or verifying that the tests are passing correctly in
+> the local environment.
+
+> [!WARNING]  
+> This mode will run against a compiled version of the code, so after making changes in the Meadowlark code (not the tests),
+> you must build the code again. This mode ignores all values in the different .env files other than the env-e2e file.
+
+### Developer Mode
+
+This is a special mode that will setup a group of containers in different ports (denoted with the names -test) and will not
+delete the containers after each run.
 
 - To setup, run: `npm run test:e2e:dev:setup`. This will configure the test containers
 - Set the environment variable `DEVELOPER_MODE=true`
-- Run `npm run test:e2e:jest` to run the tests. Save the Admin Key and Secret (as specified in [.env.example](./setup/.env.example)) to be able to run the tests
-without cleaning the environment
-- When done, run: `npm run test:e2e:dev:exit` or execute the `exit-dev-containers.ps1` script to clean the environment
+- Run `npm run test:e2e:jest:tc` to run the tests. Save the Admin Key and Secret (as specified in
+[.env.example](./setup/.env.example)) to be able to run the tests without cleaning the environment
+- When done, run: `npm run test:e2e:dev:exit` or execute the `exit-dev-containers.ps1` script to clean the environment.
+
+> [!NOTE]  
+> This mode is recommended when adding new end to ends tests.
+
+> [!WARNING]  
+> When running side to side with a "real" installation of Meadowlark, verify the ports being used to make sure that you are
+> running against the TestContainers and not the real ones.
 
 ## Troubleshooting
 
@@ -36,10 +74,10 @@ Verify that Docker is up and running
 
 `Error: docker endpoint for "default" not found`
 
-This is an issue with Docker Compose and WSL 2, see [full discussion](https://github.com/docker/compose/issues/9956).
-To fix, go to C:\Users\your-username and delete the .docker folder. Restart Docker and run the tests again. This does not affects your running containers or configuration.
+This is an issue with Docker Compose and WSL 2, see [full discussion](https://github.com/docker/compose/issues/9956). To fix,
+go to C:\Users\your-username and delete the .docker folder. Restart Docker and run the tests again. This does not affects
+your running containers or configuration.
 
 `Error: (HTTP code 500) server error - i/o timeout`
 
 This is an error with Docker Desktop. Restart Docker and run tests again
-

--- a/Meadowlark-js/tests/e2e/setup/.env-e2e.example
+++ b/Meadowlark-js/tests/e2e/setup/.env-e2e.example
@@ -2,9 +2,11 @@ OAUTH_SIGNING_KEY={{OAUTH_SIGNING_KEY}}
 
 # OPTIONAL SETTINGS
 
+# DOCUMENT_STORE_PLUGIN=@edfi/meadowlark-mongodb-backend
+# AUTHORIZATION_STORE_PLUGIN=@edfi/meadowlark-mongodb-backend
 # QUERY_HANDLER_PLUGIN=@edfi/meadowlark-opensearch-backend
 # LISTENER1_PLUGIN=@edfi/meadowlark-opensearch-backend
-# DOCUMENT_STORE_PLUGIN={{DOCUMENT_STORE_PLUGIN}} # defaults to @edfi/meadowlark-mongodb-backend
+
 # MONGODB_USER={{MONGODB_USER}}
 # MONGODB_PASS={{MONGODB_PASS}}
 

--- a/Meadowlark-js/tests/e2e/setup/SetupTestContainers.ts
+++ b/Meadowlark-js/tests/e2e/setup/SetupTestContainers.ts
@@ -14,11 +14,14 @@ import { endLog } from './LogConfig';
 export async function stop() {
   endLog();
   console.info('-- Tearing down environment --');
-  await Promise.all([MongoContainer.stop(), ApiContainer.stop()]);
+  await ApiContainer.stop();
 
   if (process.env.DOCUMENT_STORE_PLUGIN === '@edfi/meadowlark-postgresql-backend') {
     console.info('-- Tearing down postgres --');
     await PostgreSqlContainer.stop();
+  } else {
+    console.info('-- Tearing down mongo --');
+    await MongoContainer.stop();
   }
 
   if (process.env.QUERY_HANDLER_PLUGIN === '@edfi/meadowlark-elasticsearch-backend') {
@@ -44,21 +47,30 @@ export async function configure(initialize = true) {
     );
   } else {
     console.info('-- Setting up containers --');
-    // Starting Mongo container since it's required for Authentication
-    await Promise.all([MongoContainer.setup(network), ApiContainer.setup(network)]);
 
-    if (process.env.DOCUMENT_STORE_PLUGIN === '@edfi/meadowlark-postgresql-backend') {
+    if (
+      process.env.DOCUMENT_STORE_PLUGIN === '@edfi/meadowlark-postgresql-backend' ||
+      process.env.AUTHORIZATION_STORE_PLUGIN === '@edfi/meadowlark-postgresql-backend'
+    ) {
       console.info('-- Setting up postgres --');
       await PostgreSqlContainer.setup(network);
+    } else {
+      console.info('-- Setting up mongo --');
+      await MongoContainer.setup(network);
     }
 
-    if (process.env.QUERY_HANDLER_PLUGIN === '@edfi/meadowlark-elasticsearch-backend') {
+    if (
+      process.env.QUERY_HANDLER_PLUGIN === '@edfi/meadowlark-elasticsearch-backend' ||
+      process.env.LISTENER1_PLUGIN === '@edfi/meadowlark-elasticsearch-backend'
+    ) {
       console.info('-- Setting up elasticsearch --');
       await ElasticSearchContainer.setup(network);
     } else {
       console.info('-- Setting up opensearch --');
       await OpenSearchContainer.setup(network);
     }
+
+    await ApiContainer.setup(network);
   }
 
   console.debug('-- Environment Ready --');


### PR DESCRIPTION
- Setting up mongo in e2e tests only when required.
- Update e2e tests documentation.
- Refactor versioning logic to run tests in main without adding multiple ifs in the code.