### PR TITLE
[RND-663] Allow case insensitivity in OAuth requests

### DIFF
--- a/Meadowlark-js/backends/meadowlark-elasticsearch-backend/package.json
+++ b/Meadowlark-js/backends/meadowlark-elasticsearch-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edfi/meadowlark-elasticsearch-backend",
   "main": "dist/index.js",
-  "version": "0.4.0-pre.5",
+  "version": "0.4.0-pre.6",
   "description": "Meadowlark backend plugin for elasticsearch",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -19,8 +19,8 @@
     "build:copy-non-ts": "copyfiles -u 1 -e \"**/*.ts\" \"src/**/*\" dist --verbose"
   },
   "dependencies": {
-    "@edfi/meadowlark-core": "0.4.0-pre.5",
-    "@edfi/meadowlark-utilities": "0.4.0-pre.5",
+    "@edfi/meadowlark-core": "0.4.0-pre.6",
+    "@edfi/meadowlark-utilities": "0.4.0-pre.6",
     "@elastic/elasticsearch": "^8.10.0",
     "@elastic/transport": "^8.3.4"
   },

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/package.json
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edfi/meadowlark-mongodb-backend",
   "main": "dist/index.js",
-  "version": "0.4.0-pre.5",
+  "version": "0.4.0-pre.6",
   "description": "Meadowlark backend plugin for MongoDB",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -19,9 +19,9 @@
     "build:copy-non-ts": "copyfiles -u 1 -e \"**/*.ts\" \"src/**/*\" dist --verbose"
   },
   "dependencies": {
-    "@edfi/meadowlark-authz-server": "0.4.0-pre.5",
-    "@edfi/meadowlark-core": "0.4.0-pre.5",
-    "@edfi/meadowlark-utilities": "0.4.0-pre.5",
+    "@edfi/meadowlark-authz-server": "0.4.0-pre.6",
+    "@edfi/meadowlark-core": "0.4.0-pre.6",
+    "@edfi/meadowlark-utilities": "0.4.0-pre.6",
     "async-retry": "^1.3.3",
     "mongodb": "^5.9.0",
     "ramda": "0.29.1"

--- a/Meadowlark-js/backends/meadowlark-opensearch-backend/package.json
+++ b/Meadowlark-js/backends/meadowlark-opensearch-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edfi/meadowlark-opensearch-backend",
   "main": "dist/index.js",
-  "version": "0.4.0-pre.5",
+  "version": "0.4.0-pre.6",
   "description": "Meadowlark backend plugin for OpenSearch",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -19,8 +19,8 @@
     "build:copy-non-ts": "copyfiles -u 1 -e \"**/*.ts\" \"src/**/*\" dist --verbose"
   },
   "dependencies": {
-    "@edfi/meadowlark-core": "0.4.0-pre.5",
-    "@edfi/meadowlark-utilities": "0.4.0-pre.5",
+    "@edfi/meadowlark-core": "0.4.0-pre.6",
+    "@edfi/meadowlark-utilities": "0.4.0-pre.6",
     "@opensearch-project/opensearch": "^2.4.0"
   },
   "devDependencies": {

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/package.json
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edfi/meadowlark-postgresql-backend",
   "main": "dist/index.js",
-  "version": "0.4.0-pre.5",
+  "version": "0.4.0-pre.6",
   "description": "Meadowlark backend plugin for PostgreSQL",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -19,9 +19,9 @@
     "build:copy-non-ts": "copyfiles -u 1 -e \"**/*.ts\" \"src/**/*\" dist --verbose"
   },
   "dependencies": {
-    "@edfi/meadowlark-authz-server": "0.4.0-pre.5",
-    "@edfi/meadowlark-core": "0.4.0-pre.5",
-    "@edfi/meadowlark-utilities": "0.4.0-pre.5",
+    "@edfi/meadowlark-authz-server": "0.4.0-pre.6",
+    "@edfi/meadowlark-core": "0.4.0-pre.6",
+    "@edfi/meadowlark-utilities": "0.4.0-pre.6",
     "pg": "^8.11.3",
     "pg-format": "^1.0.4",
     "ramda": "0.29.1"

--- a/Meadowlark-js/lerna.json
+++ b/Meadowlark-js/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.4.0-pre.5",
+  "version": "0.4.0-pre.6",
   "npmClient": "npm",
   "useWorkspaces": true
 }

--- a/Meadowlark-js/package-lock.json
+++ b/Meadowlark-js/package-lock.json
@@ -18,7 +18,7 @@
         "@shelf/jest-mongodb": "^4.1.7",
         "@types/autocannon": "^7.12.1",
         "@types/eslint": "^8.44.3",
-        "@types/jest": "^29.5.5",
+        "@types/jest": "^29.5.11",
         "@types/node": "18.18.9",
         "@typescript-eslint/eslint-plugin": "5.62.0",
         "@typescript-eslint/parser": "5.62.0",
@@ -4921,9 +4921,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.5.5",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.5.tgz",
-      "integrity": "sha512-ebylz2hnsWR9mYvmBFbXJXr+33UPc4+ZdxyDXh5w0FlPBTfCVN3wPL+kuOiQt3xvrK419v7XWeAs+AeOksafXg==",
+      "version": "29.5.11",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.11.tgz",
+      "integrity": "sha512-S2mHmYIVe13vrm6q4kN6fLYYAka15ALQki/vgDC3mIukEOx8WJlv0kQPM+d4w8Gp6u0uSdKND04IlTXBv0rwnQ==",
       "dev": true,
       "dependencies": {
         "expect": "^29.0.0",
@@ -4937,9 +4937,10 @@
       "dev": true
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.11",
-      "dev": true,
-      "license": "MIT"
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -22682,6 +22683,7 @@
         "@apideck/better-ajv-errors": "^0.3.6",
         "@edfi/meadowlark-utilities": "0.4.0-pre.5",
         "ajv": "^8.12.0",
+        "didyoumean2": "^6.0.1",
         "dotenv": "^16.3.1",
         "fast-memoize": "^2.5.2",
         "njwt": "^2.0.0",

--- a/Meadowlark-js/package-lock.json
+++ b/Meadowlark-js/package-lock.json
@@ -52,11 +52,11 @@
     },
     "backends/meadowlark-elasticsearch-backend": {
       "name": "@edfi/meadowlark-elasticsearch-backend",
-      "version": "0.4.0-pre.5",
+      "version": "0.4.0-pre.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@edfi/meadowlark-core": "0.4.0-pre.5",
-        "@edfi/meadowlark-utilities": "0.4.0-pre.5",
+        "@edfi/meadowlark-core": "0.4.0-pre.6",
+        "@edfi/meadowlark-utilities": "0.4.0-pre.6",
         "@elastic/elasticsearch": "^8.10.0",
         "@elastic/transport": "^8.3.4"
       },
@@ -70,12 +70,12 @@
     },
     "backends/meadowlark-mongodb-backend": {
       "name": "@edfi/meadowlark-mongodb-backend",
-      "version": "0.4.0-pre.5",
+      "version": "0.4.0-pre.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@edfi/meadowlark-authz-server": "0.4.0-pre.5",
-        "@edfi/meadowlark-core": "0.4.0-pre.5",
-        "@edfi/meadowlark-utilities": "0.4.0-pre.5",
+        "@edfi/meadowlark-authz-server": "0.4.0-pre.6",
+        "@edfi/meadowlark-core": "0.4.0-pre.6",
+        "@edfi/meadowlark-utilities": "0.4.0-pre.6",
         "async-retry": "^1.3.3",
         "mongodb": "^5.9.0",
         "ramda": "0.29.1"
@@ -88,11 +88,11 @@
     },
     "backends/meadowlark-opensearch-backend": {
       "name": "@edfi/meadowlark-opensearch-backend",
-      "version": "0.4.0-pre.5",
+      "version": "0.4.0-pre.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@edfi/meadowlark-core": "0.4.0-pre.5",
-        "@edfi/meadowlark-utilities": "0.4.0-pre.5",
+        "@edfi/meadowlark-core": "0.4.0-pre.6",
+        "@edfi/meadowlark-utilities": "0.4.0-pre.6",
         "@opensearch-project/opensearch": "^2.4.0"
       },
       "devDependencies": {
@@ -105,12 +105,12 @@
     },
     "backends/meadowlark-postgresql-backend": {
       "name": "@edfi/meadowlark-postgresql-backend",
-      "version": "0.4.0-pre.5",
+      "version": "0.4.0-pre.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@edfi/meadowlark-authz-server": "0.4.0-pre.5",
-        "@edfi/meadowlark-core": "0.4.0-pre.5",
-        "@edfi/meadowlark-utilities": "0.4.0-pre.5",
+        "@edfi/meadowlark-authz-server": "0.4.0-pre.6",
+        "@edfi/meadowlark-core": "0.4.0-pre.6",
+        "@edfi/meadowlark-utilities": "0.4.0-pre.6",
         "pg": "^8.11.3",
         "pg-format": "^1.0.4",
         "ramda": "0.29.1"
@@ -22677,11 +22677,11 @@
     },
     "packages/meadowlark-authz-server": {
       "name": "@edfi/meadowlark-authz-server",
-      "version": "0.4.0-pre.5",
+      "version": "0.4.0-pre.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@apideck/better-ajv-errors": "^0.3.6",
-        "@edfi/meadowlark-utilities": "0.4.0-pre.5",
+        "@edfi/meadowlark-utilities": "0.4.0-pre.6",
         "ajv": "^8.12.0",
         "didyoumean2": "^6.0.1",
         "dotenv": "^16.3.1",
@@ -22731,11 +22731,11 @@
     },
     "packages/meadowlark-core": {
       "name": "@edfi/meadowlark-core",
-      "version": "0.4.0-pre.5",
+      "version": "0.4.0-pre.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@apideck/better-ajv-errors": "^0.3.6",
-        "@edfi/meadowlark-utilities": "0.4.0-pre.5",
+        "@edfi/meadowlark-utilities": "0.4.0-pre.6",
         "@isaacs/ttlcache": "^1.4.1",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
@@ -22824,7 +22824,7 @@
     },
     "packages/meadowlark-utilities": {
       "name": "@edfi/meadowlark-utilities",
-      "version": "0.4.0-pre.5",
+      "version": "0.4.0-pre.6",
       "license": "Apache-2.0",
       "dependencies": {
         "pino": "^8.15.4",
@@ -22871,12 +22871,12 @@
     },
     "services/meadowlark-fastify": {
       "name": "@edfi/meadowlark-fastify",
-      "version": "0.4.0-pre.5",
+      "version": "0.4.0-pre.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@edfi/meadowlark-authz-server": "0.4.0-pre.5",
-        "@edfi/meadowlark-core": "0.4.0-pre.5",
-        "@edfi/meadowlark-utilities": "0.4.0-pre.5",
+        "@edfi/meadowlark-authz-server": "0.4.0-pre.6",
+        "@edfi/meadowlark-core": "0.4.0-pre.6",
+        "@edfi/meadowlark-utilities": "0.4.0-pre.6",
         "@fastify/rate-limit": "^6.0.1",
         "dotenv": "^16.3.1",
         "fastify": "^3.29.5"
@@ -22889,10 +22889,10 @@
     },
     "tests/e2e": {
       "name": "@edfi/meadowlark-e2e-tests",
-      "version": "0.4.0-pre.5",
+      "version": "0.4.0-pre.6",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@edfi/meadowlark-utilities": "0.4.0-pre.5",
+        "@edfi/meadowlark-utilities": "0.4.0-pre.6",
         "@testcontainers/mongodb": "^10.3.1",
         "@testcontainers/postgresql": "^10.3.1",
         "@types/chance": "^1.1.6",

--- a/Meadowlark-js/package.json
+++ b/Meadowlark-js/package.json
@@ -7,7 +7,7 @@
     "@shelf/jest-mongodb": "^4.1.7",
     "@types/autocannon": "^7.12.1",
     "@types/eslint": "^8.44.3",
-    "@types/jest": "^29.5.5",
+    "@types/jest": "^29.5.11",
     "@types/node": "18.18.9",
     "@typescript-eslint/eslint-plugin": "5.62.0",
     "@typescript-eslint/parser": "5.62.0",

--- a/Meadowlark-js/packages/meadowlark-authz-server/package.json
+++ b/Meadowlark-js/packages/meadowlark-authz-server/package.json
@@ -16,6 +16,7 @@
     "@apideck/better-ajv-errors": "^0.3.6",
     "@edfi/meadowlark-utilities": "0.4.0-pre.5",
     "ajv": "^8.12.0",
+    "didyoumean2": "^6.0.1",
     "dotenv": "^16.3.1",
     "fast-memoize": "^2.5.2",
     "njwt": "^2.0.0",

--- a/Meadowlark-js/packages/meadowlark-authz-server/package.json
+++ b/Meadowlark-js/packages/meadowlark-authz-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edfi/meadowlark-authz-server",
   "main": "dist/index.js",
-  "version": "0.4.0-pre.5",
+  "version": "0.4.0-pre.6",
   "description": "Meadowlark authorization server",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "@apideck/better-ajv-errors": "^0.3.6",
-    "@edfi/meadowlark-utilities": "0.4.0-pre.5",
+    "@edfi/meadowlark-utilities": "0.4.0-pre.6",
     "ajv": "^8.12.0",
     "didyoumean2": "^6.0.1",
     "dotenv": "^16.3.1",

--- a/Meadowlark-js/packages/meadowlark-authz-server/src/handler/CreateClient.ts
+++ b/Meadowlark-js/packages/meadowlark-authz-server/src/handler/CreateClient.ts
@@ -13,7 +13,7 @@ import { AuthorizationRequest, extractAuthorizationHeader } from './Authorizatio
 import { AuthorizationResponse } from './AuthorizationResponse';
 import { CreateClientResponseBody } from '../model/CreateClientResponseBody';
 import { writeDebugObject, writeDebugStatusToLog, writeErrorToLog, writeRequestToLog } from '../Logger';
-import { BodyValidation, validateCreateClientBody } from '../validation/BodyValidation';
+import { BodyValidation, applySuggestions, validateCreateClientBody } from '../validation/BodyValidation';
 import { hashClientSecretBuffer } from '../security/HashClientSecret';
 import { TryCreateBootstrapAuthorizationAdminResult } from '../message/TryCreateBootstrapAuthorizationAdminResult';
 import { ClientId } from '../Utility';
@@ -119,7 +119,19 @@ export async function createClient(authorizationRequest: AuthorizationRequest): 
       return { body: { error }, statusCode: 400 };
     }
 
-    const validation: BodyValidation = validateCreateClientBody(parsedBody);
+    let validation: BodyValidation = validateCreateClientBody(parsedBody);
+    if (!validation.isValid && validation.suggestions) {
+      writeDebugStatusToLog(
+        moduleName,
+        authorizationRequest,
+        'createClient',
+        400,
+        'Invalid request body, checking for suggestions',
+      );
+      parsedBody = applySuggestions(parsedBody, validation.suggestions);
+      validation = validateCreateClientBody(parsedBody);
+    }
+
     if (!validation.isValid) {
       writeDebugObject(moduleName, authorizationRequest, 'createClient', 400, validation.failureMessage);
       return {

--- a/Meadowlark-js/packages/meadowlark-authz-server/src/handler/CreateClient.ts
+++ b/Meadowlark-js/packages/meadowlark-authz-server/src/handler/CreateClient.ts
@@ -120,6 +120,8 @@ export async function createClient(authorizationRequest: AuthorizationRequest): 
     }
 
     let validation: BodyValidation = validateCreateClientBody(parsedBody);
+    // The validation will return suggestions for properties not found that have a similar match,
+    // here will apply it and validate once more, if this does not pass validation will return failure with the error message.
     if (!validation.isValid && validation.suggestions) {
       writeDebugStatusToLog(
         moduleName,

--- a/Meadowlark-js/packages/meadowlark-authz-server/src/handler/RequestToken.ts
+++ b/Meadowlark-js/packages/meadowlark-authz-server/src/handler/RequestToken.ts
@@ -84,6 +84,8 @@ function parseRequestTokenBody(authorizationRequest: AuthorizationRequest): Pars
   }
 
   let validation: BodyValidation = validateRequestTokenBody(parsedBody);
+  // The validation will return suggestions for properties not found that have a similar match,
+  // here will apply it and validate once more, if this does not pass validation will return failure with the error message.
   if (!validation.isValid && validation.suggestions) {
     writeDebugStatusToLog(
       moduleName,

--- a/Meadowlark-js/packages/meadowlark-authz-server/src/validation/BodyValidation.ts
+++ b/Meadowlark-js/packages/meadowlark-authz-server/src/validation/BodyValidation.ts
@@ -34,6 +34,8 @@ function validateBody(body: object, schema: object, validateFunction: ValidateFu
         .map((property) => property.params.additionalProperty as string)
     : [];
 
+  // Will go through all additional properties found and tried to find match with the required
+  // properties. It is important to update the threshold for didYouMean to not allow words with similar lengths or typos.
   additionalKeys.forEach((current) => {
     const suggested = didYouMean(current, requiredKeys, { thresholdType: ThresholdTypeEnums.SIMILARITY, threshold: 1 });
     if (suggested) {

--- a/Meadowlark-js/packages/meadowlark-authz-server/src/validation/BodyValidation.ts
+++ b/Meadowlark-js/packages/meadowlark-authz-server/src/validation/BodyValidation.ts
@@ -3,14 +3,17 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+import didYouMean, { ThresholdTypeEnums } from 'didyoumean2';
 import { ValidateFunction } from 'ajv';
 import { betterAjvErrors } from '@apideck/better-ajv-errors';
 import { ajv } from './SharedAjv';
+
 import { clientBodySchema } from '../model/ClientBody';
 import { requestTokenBodySchema } from '../model/RequestTokenBody';
 import { verifyTokenBodySchema } from '../model/VerifyTokenBody';
 
-export type BodyValidation = { isValid: true } | { isValid: false; failureMessage: object };
+export type Suggestion = { current: string; suggested: string };
+export type BodyValidation = { isValid: true } | { isValid: false; failureMessage: object; suggestions: Suggestion[] };
 
 const createClientBodyValidator: ValidateFunction = ajv.compile(clientBodySchema);
 const requestTokenBodyValidator: ValidateFunction = ajv.compile(requestTokenBodySchema);
@@ -18,7 +21,26 @@ const verifyTokenBodyValidator: ValidateFunction = ajv.compile(verifyTokenBodySc
 
 function validateBody(body: object, schema: object, validateFunction: ValidateFunction): BodyValidation {
   const isValid: boolean = validateFunction(body);
+  const suggestions: Suggestion[] = [];
   if (isValid) return { isValid };
+
+  const { errors } = validateFunction;
+
+  // Should be typed
+  const requiredKeys = Object.keys((schema as any).properties);
+  const additionalKeys = errors
+    ? errors
+        .filter((key) => key.keyword === 'additionalProperties')
+        .map((property) => property.params.additionalProperty as string)
+    : [];
+
+  additionalKeys.forEach((current) => {
+    const suggested = didYouMean(current, requiredKeys, { thresholdType: ThresholdTypeEnums.SIMILARITY, threshold: 1 });
+    if (suggested) {
+      suggestions.push({ current, suggested });
+    }
+  });
+
   return {
     isValid,
     failureMessage: betterAjvErrors({
@@ -27,7 +49,18 @@ function validateBody(body: object, schema: object, validateFunction: ValidateFu
       errors: validateFunction.errors,
       basePath: '{requestBody}',
     }),
+    suggestions,
   };
+}
+
+export function applySuggestions(body: object, suggestions: Suggestion[]): object {
+  let bodyWithSuggestions = JSON.stringify(body);
+  suggestions.forEach((suggestion) => {
+    bodyWithSuggestions = bodyWithSuggestions.replace(suggestion.current, suggestion.suggested);
+  });
+
+  const updatedBody = JSON.parse(bodyWithSuggestions);
+  return updatedBody;
 }
 
 export function validateCreateClientBody(body: object): BodyValidation {

--- a/Meadowlark-js/packages/meadowlark-authz-server/src/validation/BodyValidation.ts
+++ b/Meadowlark-js/packages/meadowlark-authz-server/src/validation/BodyValidation.ts
@@ -34,9 +34,10 @@ function validateBody(body: object, schema: object, validateFunction: ValidateFu
         .map((property) => property.params.additionalProperty as string)
     : [];
 
-  // Will go through all additional properties found and tried to find match with the required
-  // properties. It is important to update the threshold for didYouMean to not allow words with similar lengths or typos.
+  // Check for expected values in the ajv error messages to compare with provided values.
+  // This will provide suggestions for properties with correct value but wrong case, allowing to have case insensitive requests
   additionalKeys.forEach((current) => {
+    // Update the threshold for didYouMean to not allow words with similar lengths or typos.
     const suggested = didYouMean(current, requiredKeys, { thresholdType: ThresholdTypeEnums.SIMILARITY, threshold: 1 });
     if (suggested) {
       suggestions.push({ current, suggested });

--- a/Meadowlark-js/packages/meadowlark-authz-server/test/validation/BodyValidation.test.ts
+++ b/Meadowlark-js/packages/meadowlark-authz-server/test/validation/BodyValidation.test.ts
@@ -1,0 +1,348 @@
+import {
+  BodyValidation,
+  Suggestion,
+  applySuggestions,
+  validateCreateClientBody,
+  validateRequestTokenBody,
+} from '../../src/validation/BodyValidation';
+
+describe("given it's validating the request body", () => {
+  describe("given it's validating the create client body", () => {
+    describe("given it's valid", () => {
+      const expected = {
+        clientName: 'Hometown SIS',
+        roles: ['vendor', 'assessment'],
+      };
+      let validationResult: BodyValidation;
+
+      beforeAll(() => {
+        // Act
+        validationResult = validateCreateClientBody(expected);
+      });
+
+      it('should return valid', () => {
+        expect(validationResult).toBeTruthy();
+      });
+    });
+
+    describe('given it has different casing', () => {
+      const actual = {
+        clientname: 'Hometown SIS',
+        ROLES: ['vendor', 'assessment'],
+      };
+
+      const expected = {
+        clientName: 'Hometown SIS',
+        roles: ['vendor', 'assessment'],
+      };
+
+      let validationResult: BodyValidation;
+      let suggestions: Suggestion[] = [];
+
+      beforeAll(() => {
+        // Act
+        validationResult = validateCreateClientBody(actual);
+        if (!validationResult.isValid) {
+          suggestions = validationResult.suggestions ?? [];
+        }
+      });
+
+      it('should return suggestions', () => {
+        if (validationResult.isValid) {
+          expect(validationResult.isValid).toBeFalsy();
+          return;
+        }
+
+        expect(validationResult.failureMessage).toMatchInlineSnapshot(`
+          [
+            {
+              "context": {
+                "errorType": "required",
+              },
+              "message": "{requestBody} must have required property 'clientName'",
+              "path": "{requestBody}",
+            },
+            {
+              "context": {
+                "errorType": "required",
+              },
+              "message": "{requestBody} must have required property 'roles'",
+              "path": "{requestBody}",
+            },
+            {
+              "context": {
+                "errorType": "additionalProperties",
+              },
+              "message": "'clientname' property is not expected to be here",
+              "path": "{requestBody}",
+              "suggestion": "Did you mean property 'clientName'?",
+            },
+            {
+              "context": {
+                "errorType": "additionalProperties",
+              },
+              "message": "'ROLES' property is not expected to be here",
+              "path": "{requestBody}",
+            },
+          ]
+        `);
+        expect(validationResult.suggestions).toMatchInlineSnapshot(`
+          [
+            {
+              "current": "clientname",
+              "suggested": "clientName",
+            },
+            {
+              "current": "ROLES",
+              "suggested": "roles",
+            },
+          ]
+        `);
+      });
+
+      it('should apply suggestions correctly', () => {
+        expect(applySuggestions(actual, suggestions)).toMatchObject(expected);
+      });
+    });
+
+    describe('given it has additional properties', () => {
+      const actual = {
+        clientName: 'Hometown SIS',
+        roles: ['vendor', 'assessment'],
+        extra: true,
+      };
+
+      let validationResult: BodyValidation;
+
+      beforeAll(() => {
+        // Act
+        validationResult = validateCreateClientBody(actual);
+      });
+
+      it('should return error message with no suggestions', () => {
+        if (validationResult.isValid) {
+          expect(validationResult.isValid).toBeFalsy();
+          return;
+        }
+        expect(validationResult.failureMessage).toMatchInlineSnapshot(`
+          [
+            {
+              "context": {
+                "errorType": "additionalProperties",
+              },
+              "message": "'extra' property is not expected to be here",
+              "path": "{requestBody}",
+            },
+          ]
+        `);
+        expect(validationResult.suggestions).toEqual([]);
+      });
+    });
+
+    describe('given it has a typo', () => {
+      const actual = {
+        clientNane: 'Hometown SIS',
+        roles: ['vendor', 'assessment'],
+      };
+
+      let validationResult: BodyValidation;
+
+      beforeAll(() => {
+        // Act
+        validationResult = validateCreateClientBody(actual);
+      });
+
+      it('should return suggestions', () => {
+        if (validationResult.isValid) {
+          expect(validationResult.isValid).toBeFalsy();
+          return;
+        }
+        expect(validationResult.failureMessage).toMatchInlineSnapshot(`
+          [
+            {
+              "context": {
+                "errorType": "required",
+              },
+              "message": "{requestBody} must have required property 'clientName'",
+              "path": "{requestBody}",
+            },
+            {
+              "context": {
+                "errorType": "additionalProperties",
+              },
+              "message": "'clientNane' property is not expected to be here",
+              "path": "{requestBody}",
+              "suggestion": "Did you mean property 'clientName'?",
+            },
+          ]
+        `);
+        expect(validationResult.suggestions).toEqual([]);
+      });
+    });
+  });
+
+  describe("given it's validating the request token body", () => {
+    describe("given it's valid", () => {
+      const expected = {
+        grant_type: 'client_credentials',
+        client_id: 'Hometown SIS',
+        client_secret: '123456',
+      };
+      let validationResult: BodyValidation;
+
+      beforeAll(() => {
+        // Act
+        validationResult = validateRequestTokenBody(expected);
+      });
+
+      it('should return valid', () => {
+        expect(validationResult).toBeTruthy();
+      });
+    });
+
+    describe('given it has different casing', () => {
+      const actual = {
+        GRANT_TYPE: 'client_credentials',
+        CLIENT_ID: 'Hometown SIS',
+        CLIENT_SECRET: '123456',
+      };
+
+      const expected = {
+        grant_type: 'client_credentials',
+        client_id: 'Hometown SIS',
+        client_secret: '123456',
+      };
+
+      let validationResult: BodyValidation;
+      let suggestions: Suggestion[] = [];
+
+      beforeAll(() => {
+        // Act
+        validationResult = validateRequestTokenBody(actual);
+        if (!validationResult.isValid) {
+          suggestions = validationResult.suggestions ?? [];
+        }
+      });
+
+      it('should return suggestions', () => {
+        if (validationResult.isValid) {
+          expect(validationResult.isValid).toBeFalsy();
+          return;
+        }
+        expect(validationResult.failureMessage).toMatchInlineSnapshot(`
+          [
+            {
+              "context": {
+                "errorType": "required",
+              },
+              "message": "{requestBody} must have required property 'grant_type'",
+              "path": "{requestBody}",
+            },
+            {
+              "context": {
+                "errorType": "additionalProperties",
+              },
+              "message": "'GRANT_TYPE' property is not expected to be here",
+              "path": "{requestBody}",
+              "suggestion": "Did you mean property 'grant_type'?",
+            },
+            {
+              "context": {
+                "errorType": "additionalProperties",
+              },
+              "message": "'CLIENT_ID' property is not expected to be here",
+              "path": "{requestBody}",
+              "suggestion": "Did you mean property 'client_id'?",
+            },
+            {
+              "context": {
+                "errorType": "additionalProperties",
+              },
+              "message": "'CLIENT_SECRET' property is not expected to be here",
+              "path": "{requestBody}",
+              "suggestion": "Did you mean property 'grant_type'?",
+            },
+          ]
+        `);
+        expect(validationResult.suggestions).toMatchInlineSnapshot(`
+          [
+            {
+              "current": "GRANT_TYPE",
+              "suggested": "grant_type",
+            },
+            {
+              "current": "CLIENT_ID",
+              "suggested": "client_id",
+            },
+            {
+              "current": "CLIENT_SECRET",
+              "suggested": "client_secret",
+            },
+          ]
+        `);
+      });
+
+      it('should apply suggestions correctly', () => {
+        expect(applySuggestions(actual, suggestions)).toMatchObject(expected);
+      });
+    });
+
+    describe('given it has a typo', () => {
+      const actual = {
+        grant_types: 'client_credentials',
+        clientid: 'Hometown SIS',
+        'client-secret': '123456',
+      };
+
+      let validationResult: BodyValidation;
+
+      beforeAll(() => {
+        // Act
+        validationResult = validateRequestTokenBody(actual);
+      });
+
+      it('should return suggestions', () => {
+        if (validationResult.isValid) {
+          expect(validationResult.isValid).toBeFalsy();
+          return;
+        }
+        expect(validationResult.failureMessage).toMatchInlineSnapshot(`
+          [
+            {
+              "context": {
+                "errorType": "required",
+              },
+              "message": "{requestBody} must have required property 'grant_type'",
+              "path": "{requestBody}",
+            },
+            {
+              "context": {
+                "errorType": "additionalProperties",
+              },
+              "message": "'grant_types' property is not expected to be here",
+              "path": "{requestBody}",
+              "suggestion": "Did you mean property 'grant_type'?",
+            },
+            {
+              "context": {
+                "errorType": "additionalProperties",
+              },
+              "message": "'clientid' property is not expected to be here",
+              "path": "{requestBody}",
+              "suggestion": "Did you mean property 'client_id'?",
+            },
+            {
+              "context": {
+                "errorType": "additionalProperties",
+              },
+              "message": "'client-secret' property is not expected to be here",
+              "path": "{requestBody}",
+              "suggestion": "Did you mean property 'client_secret'?",
+            },
+          ]
+        `);
+        expect(validationResult.suggestions).toEqual([]);
+      });
+    });
+  });
+});

--- a/Meadowlark-js/packages/meadowlark-core/package.json
+++ b/Meadowlark-js/packages/meadowlark-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edfi/meadowlark-core",
   "main": "dist/index.js",
-  "version": "0.4.0-pre.5",
+  "version": "0.4.0-pre.6",
   "description": "Meadowlark core functionality",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "@apideck/better-ajv-errors": "^0.3.6",
-    "@edfi/meadowlark-utilities": "0.4.0-pre.5",
+    "@edfi/meadowlark-utilities": "0.4.0-pre.6",
     "@isaacs/ttlcache": "^1.4.1",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",

--- a/Meadowlark-js/packages/meadowlark-utilities/package.json
+++ b/Meadowlark-js/packages/meadowlark-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edfi/meadowlark-utilities",
   "main": "dist/index.js",
-  "version": "0.4.0-pre.5",
+  "version": "0.4.0-pre.6",
   "description": "Meadowlark shared utilities",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/Meadowlark-js/services/meadowlark-fastify/package.json
+++ b/Meadowlark-js/services/meadowlark-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edfi/meadowlark-fastify",
-  "version": "0.4.0-pre.5",
+  "version": "0.4.0-pre.6",
   "description": "Meadowlark service using Fastify",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -12,9 +12,9 @@
     "/package.json"
   ],
   "dependencies": {
-    "@edfi/meadowlark-authz-server": "0.4.0-pre.5",
-    "@edfi/meadowlark-core": "0.4.0-pre.5",
-    "@edfi/meadowlark-utilities": "0.4.0-pre.5",
+    "@edfi/meadowlark-authz-server": "0.4.0-pre.6",
+    "@edfi/meadowlark-core": "0.4.0-pre.6",
+    "@edfi/meadowlark-utilities": "0.4.0-pre.6",
     "@fastify/rate-limit": "^6.0.1",
     "dotenv": "^16.3.1",
     "fastify": "^3.29.5"

--- a/Meadowlark-js/tests/e2e/package.json
+++ b/Meadowlark-js/tests/e2e/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@edfi/meadowlark-e2e-tests",
   "main": "dist/index.js",
-  "version": "0.4.0-pre.5",
+  "version": "0.4.0-pre.6",
   "description": "Meadowlark Ed-Fi API end to end tests",
   "license": "Apache-2.0",
   "private": true,
   "files": [],
   "devDependencies": {
-    "@edfi/meadowlark-utilities": "0.4.0-pre.5",
+    "@edfi/meadowlark-utilities": "0.4.0-pre.6",
     "@testcontainers/mongodb": "^10.3.1",
     "@testcontainers/postgresql": "^10.3.1",
     "@types/chance": "^1.1.6",

--- a/Meadowlark-js/tests/e2e/scenarios/AuthenticationValidation.test.ts
+++ b/Meadowlark-js/tests/e2e/scenarios/AuthenticationValidation.test.ts
@@ -35,6 +35,29 @@ describe("given it's authenticating a client", () => {
     });
   });
 
+  describe('when providing uppercase property names', () => {
+    it('should be able to return access token', async () => {
+      await baseURLRequest()
+        .post('/oauth/token')
+        .send({
+          Grant_Type: 'client_credentials',
+          Client_Id: client.key,
+          Client_Secret: client.secret,
+        })
+        .expect(200)
+        .then((response) => {
+          expect(response.body).toEqual(
+            expect.objectContaining({
+              access_token: expect.any(String),
+              expires_in: expect.any(Number),
+              refresh_token: 'not available',
+              token_type: 'bearer',
+            }),
+          );
+        });
+    });
+  });
+
   describe('when providing invalid grant type', () => {
     it('should return error message', async () => {
       await baseURLRequest()
@@ -91,6 +114,58 @@ describe("given it's authenticating a client", () => {
         .expect(401)
         .then((response) => {
           expect(response.body).toMatchInlineSnapshot(`""`);
+        });
+    });
+  });
+
+  describe('when providing invalid property name', () => {
+    it('should return 400 and error message', async () => {
+      await baseURLRequest()
+        .post('/oauth/token')
+        .send({
+          grand_type: 'client_credentials',
+          clientId: client.key,
+          client_secrets: 'secret',
+        })
+        .expect(400)
+        .then((response) => {
+          expect(response.body).toMatchInlineSnapshot(`
+            {
+              "error": [
+                {
+                  "context": {
+                    "errorType": "required",
+                  },
+                  "message": "{requestBody} must have required property 'grant_type'",
+                  "path": "{requestBody}",
+                },
+                {
+                  "context": {
+                    "errorType": "additionalProperties",
+                  },
+                  "message": "'grand_type' property is not expected to be here",
+                  "path": "{requestBody}",
+                  "suggestion": "Did you mean property 'grant_type'?",
+                },
+                {
+                  "context": {
+                    "errorType": "additionalProperties",
+                  },
+                  "message": "'clientId' property is not expected to be here",
+                  "path": "{requestBody}",
+                  "suggestion": "Did you mean property 'client_id'?",
+                },
+                {
+                  "context": {
+                    "errorType": "additionalProperties",
+                  },
+                  "message": "'client_secrets' property is not expected to be here",
+                  "path": "{requestBody}",
+                  "suggestion": "Did you mean property 'client_secret'?",
+                },
+              ],
+            }
+          `);
         });
     });
   });

--- a/Meadowlark-js/tests/http/local.RND663.http
+++ b/Meadowlark-js/tests/http/local.RND663.http
@@ -1,0 +1,123 @@
+##### START AUTHENTICATION SETUP
+
+@admin_client_id=meadowlark_admin_key_1
+@admin_client_secret=meadowlark_admin_secret_1
+
+### Authenticate admin
+# @name admin1
+POST http://localhost:3000/local/oauth/token
+content-type: application/json
+
+{
+    "GRANT_TYPE": "client_credentials",
+    "client_id": "{{admin_client_id}}",
+    "client_secret": "{{admin_client_secret}}"
+}
+
+###
+@admin_token={{admin1.response.body.$.access_token}}
+@auth_header_admin_1=Authorization: bearer {{admin1.response.body.$.access_token}}
+
+
+### Create client1
+# @name created_client1
+POST http://localhost:3000/local/oauth/clients
+content-type: application/json
+{{auth_header_admin_1}}
+
+{
+    "clientname": "Hometown SIS",
+    "rOLEs": [
+        "vendor"
+    ]
+}
+
+###
+@client1_client_id={{created_client1.response.body.$.client_id}}
+@client1_client_secret={{created_client1.response.body.$.client_secret}}
+
+### Authenticate client1
+# @name client1
+POST http://localhost:3000/local/oauth/token
+content-type: application/json
+
+{
+    "Grant_type": "client_credentials",
+    "Client_id": "{{client1_client_id}}",
+    "Client_secret": "{{client1_client_secret}}"
+}
+
+###
+@authToken1 = {{client1.response.body.$.access_token}}
+
+###
+
+
+### Create client4
+# This Should fail, values are not case sensitive
+POST http://localhost:3000/local/oauth/clients
+content-type: application/json
+{{auth_header_admin_1}}
+
+{
+    "clientName": "the-one-sis",
+    "roles": [
+        "VENDOR",
+        "assessment"
+    ]
+}
+
+###
+# @name contentClassDescriptor
+# This should fail, similar words, pluralization
+POST http://localhost:3000/local/v3.3b/ed-fi/contentClassDescriptors
+authorization: bearer {{authToken1}}
+content-type: application/json
+
+{
+  "goodValue": "Presentation",
+  "shortDescriptions": "Presentation",
+  "description": "Presentation",
+  "namespace": "uri://ed-fi.org/ContentClassDescriptor"
+}
+
+###
+# @name contentClassDescriptor
+# This should fail, wrong property
+POST http://localhost:3000/local/v3.3b/ed-fi/contentClassDescriptors
+authorization: bearer {{authToken1}}
+content-type: application/json
+
+{
+  "codeValue": "Presentation",
+  "shortDescription": "Presentation",
+  "description": "Presentation",
+  "uri": "uri://ed-fi.org/ContentClassDescriptor"
+}
+
+###
+# @name contentClassDescriptor
+# This should fail, missing property
+POST http://localhost:3000/local/v3.3b/ed-fi/contentClassDescriptors
+authorization: bearer {{authToken1}}
+content-type: application/json
+
+{
+  "codeValue": "Presentation",
+  "shortDescription": "Presentation",
+  "description": "Presentation"
+}
+
+###
+# @name contentClassDescriptor
+# This should work, uppercase keys
+POST http://localhost:3000/local/v3.3b/ed-fi/contentClassDescriptors
+authorization: bearer {{authToken1}}
+content-type: application/json
+
+{
+  "CODEVALUE": "Presentation",
+  "SHORTDESCRIPTION": "Presentation",
+  "DESCRIPTION": "Presentation",
+  "NAMESPACE": "uri://ed-fi.org/ContentClassDescriptor"
+}


### PR DESCRIPTION
Allow case insensitivity in OAuth requests, by checking suggestions given to properties, and applying those suggestions if valid.

## Description

The ODS/API allows for the payload of the requests to be case insensitive, which means that clientname, clientName and CLIENTNAME should all be valid in the payload.

In order to do that, we need to update the payload from the request with a suggested value.

- Update logging in changed classes to use helper function and match the other methods (trying to unify process on those similar classes)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
