### PR TITLE
[RND-697] Refactor test to avoid race conditions on depending tests

### DIFF
--- a/Meadowlark-js/backends/meadowlark-elasticsearch-backend/package.json
+++ b/Meadowlark-js/backends/meadowlark-elasticsearch-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edfi/meadowlark-elasticsearch-backend",
   "main": "dist/index.js",
-  "version": "0.4.1-pre.0",
+  "version": "0.4.1-pre.1",
   "description": "Meadowlark backend plugin for elasticsearch",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -19,8 +19,8 @@
     "build:copy-non-ts": "copyfiles -u 1 -e \"**/*.ts\" \"src/**/*\" dist --verbose"
   },
   "dependencies": {
-    "@edfi/meadowlark-core": "0.4.1-pre.0",
-    "@edfi/meadowlark-utilities": "0.4.1-pre.0",
+    "@edfi/meadowlark-core": "0.4.1-pre.1",
+    "@edfi/meadowlark-utilities": "0.4.1-pre.1",
     "@elastic/elasticsearch": "^8.10.0",
     "@elastic/transport": "^8.3.4"
   },

--- a/Meadowlark-js/backends/meadowlark-mongodb-backend/package.json
+++ b/Meadowlark-js/backends/meadowlark-mongodb-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edfi/meadowlark-mongodb-backend",
   "main": "dist/index.js",
-  "version": "0.4.1-pre.0",
+  "version": "0.4.1-pre.1",
   "description": "Meadowlark backend plugin for MongoDB",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -19,9 +19,9 @@
     "build:copy-non-ts": "copyfiles -u 1 -e \"**/*.ts\" \"src/**/*\" dist --verbose"
   },
   "dependencies": {
-    "@edfi/meadowlark-authz-server": "0.4.1-pre.0",
-    "@edfi/meadowlark-core": "0.4.1-pre.0",
-    "@edfi/meadowlark-utilities": "0.4.1-pre.0",
+    "@edfi/meadowlark-authz-server": "0.4.1-pre.1",
+    "@edfi/meadowlark-core": "0.4.1-pre.1",
+    "@edfi/meadowlark-utilities": "0.4.1-pre.1",
     "async-retry": "^1.3.3",
     "mongodb": "^5.9.2",
     "ramda": "0.29.1"

--- a/Meadowlark-js/backends/meadowlark-opensearch-backend/package.json
+++ b/Meadowlark-js/backends/meadowlark-opensearch-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edfi/meadowlark-opensearch-backend",
   "main": "dist/index.js",
-  "version": "0.4.1-pre.0",
+  "version": "0.4.1-pre.1",
   "description": "Meadowlark backend plugin for OpenSearch",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -19,8 +19,8 @@
     "build:copy-non-ts": "copyfiles -u 1 -e \"**/*.ts\" \"src/**/*\" dist --verbose"
   },
   "dependencies": {
-    "@edfi/meadowlark-core": "0.4.1-pre.0",
-    "@edfi/meadowlark-utilities": "0.4.1-pre.0",
+    "@edfi/meadowlark-core": "0.4.1-pre.1",
+    "@edfi/meadowlark-utilities": "0.4.1-pre.1",
     "@opensearch-project/opensearch": "^2.4.0"
   },
   "devDependencies": {

--- a/Meadowlark-js/backends/meadowlark-postgresql-backend/package.json
+++ b/Meadowlark-js/backends/meadowlark-postgresql-backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edfi/meadowlark-postgresql-backend",
   "main": "dist/index.js",
-  "version": "0.4.1-pre.0",
+  "version": "0.4.1-pre.1",
   "description": "Meadowlark backend plugin for PostgreSQL",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -19,9 +19,9 @@
     "build:copy-non-ts": "copyfiles -u 1 -e \"**/*.ts\" \"src/**/*\" dist --verbose"
   },
   "dependencies": {
-    "@edfi/meadowlark-authz-server": "0.4.1-pre.0",
-    "@edfi/meadowlark-core": "0.4.1-pre.0",
-    "@edfi/meadowlark-utilities": "0.4.1-pre.0",
+    "@edfi/meadowlark-authz-server": "0.4.1-pre.1",
+    "@edfi/meadowlark-core": "0.4.1-pre.1",
+    "@edfi/meadowlark-utilities": "0.4.1-pre.1",
     "pg": "^8.11.3",
     "pg-format": "^1.0.4",
     "ramda": "0.29.1"

--- a/Meadowlark-js/lerna.json
+++ b/Meadowlark-js/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.4.1-pre.0",
+  "version": "0.4.1-pre.1",
   "npmClient": "npm",
   "useWorkspaces": true
 }

--- a/Meadowlark-js/package-lock.json
+++ b/Meadowlark-js/package-lock.json
@@ -52,11 +52,11 @@
     },
     "backends/meadowlark-elasticsearch-backend": {
       "name": "@edfi/meadowlark-elasticsearch-backend",
-      "version": "0.4.1-pre.0",
+      "version": "0.4.1-pre.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@edfi/meadowlark-core": "0.4.1-pre.0",
-        "@edfi/meadowlark-utilities": "0.4.1-pre.0",
+        "@edfi/meadowlark-core": "0.4.1-pre.1",
+        "@edfi/meadowlark-utilities": "0.4.1-pre.1",
         "@elastic/elasticsearch": "^8.10.0",
         "@elastic/transport": "^8.3.4"
       },
@@ -70,12 +70,12 @@
     },
     "backends/meadowlark-mongodb-backend": {
       "name": "@edfi/meadowlark-mongodb-backend",
-      "version": "0.4.1-pre.0",
+      "version": "0.4.1-pre.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@edfi/meadowlark-authz-server": "0.4.1-pre.0",
-        "@edfi/meadowlark-core": "0.4.1-pre.0",
-        "@edfi/meadowlark-utilities": "0.4.1-pre.0",
+        "@edfi/meadowlark-authz-server": "0.4.1-pre.1",
+        "@edfi/meadowlark-core": "0.4.1-pre.1",
+        "@edfi/meadowlark-utilities": "0.4.1-pre.1",
         "async-retry": "^1.3.3",
         "mongodb": "^5.9.2",
         "ramda": "0.29.1"
@@ -88,11 +88,11 @@
     },
     "backends/meadowlark-opensearch-backend": {
       "name": "@edfi/meadowlark-opensearch-backend",
-      "version": "0.4.1-pre.0",
+      "version": "0.4.1-pre.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@edfi/meadowlark-core": "0.4.1-pre.0",
-        "@edfi/meadowlark-utilities": "0.4.1-pre.0",
+        "@edfi/meadowlark-core": "0.4.1-pre.1",
+        "@edfi/meadowlark-utilities": "0.4.1-pre.1",
         "@opensearch-project/opensearch": "^2.4.0"
       },
       "devDependencies": {
@@ -105,12 +105,12 @@
     },
     "backends/meadowlark-postgresql-backend": {
       "name": "@edfi/meadowlark-postgresql-backend",
-      "version": "0.4.1-pre.0",
+      "version": "0.4.1-pre.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@edfi/meadowlark-authz-server": "0.4.1-pre.0",
-        "@edfi/meadowlark-core": "0.4.1-pre.0",
-        "@edfi/meadowlark-utilities": "0.4.1-pre.0",
+        "@edfi/meadowlark-authz-server": "0.4.1-pre.1",
+        "@edfi/meadowlark-core": "0.4.1-pre.1",
+        "@edfi/meadowlark-utilities": "0.4.1-pre.1",
         "pg": "^8.11.3",
         "pg-format": "^1.0.4",
         "ramda": "0.29.1"
@@ -22595,11 +22595,11 @@
     },
     "packages/meadowlark-authz-server": {
       "name": "@edfi/meadowlark-authz-server",
-      "version": "0.4.1-pre.0",
+      "version": "0.4.1-pre.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@apideck/better-ajv-errors": "^0.3.6",
-        "@edfi/meadowlark-utilities": "0.4.1-pre.0",
+        "@edfi/meadowlark-utilities": "0.4.1-pre.1",
         "ajv": "^8.12.0",
         "didyoumean2": "^6.0.1",
         "dotenv": "^16.3.1",
@@ -22649,11 +22649,11 @@
     },
     "packages/meadowlark-core": {
       "name": "@edfi/meadowlark-core",
-      "version": "0.4.1-pre.0",
+      "version": "0.4.1-pre.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@apideck/better-ajv-errors": "^0.3.6",
-        "@edfi/meadowlark-utilities": "0.4.1-pre.0",
+        "@edfi/meadowlark-utilities": "0.4.1-pre.1",
         "@isaacs/ttlcache": "^1.4.1",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
@@ -22743,7 +22743,7 @@
     },
     "packages/meadowlark-utilities": {
       "name": "@edfi/meadowlark-utilities",
-      "version": "0.4.1-pre.0",
+      "version": "0.4.1-pre.1",
       "license": "Apache-2.0",
       "dependencies": {
         "pino": "^8.15.7",
@@ -22790,12 +22790,12 @@
     },
     "services/meadowlark-fastify": {
       "name": "@edfi/meadowlark-fastify",
-      "version": "0.4.1-pre.0",
+      "version": "0.4.1-pre.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@edfi/meadowlark-authz-server": "0.4.1-pre.0",
-        "@edfi/meadowlark-core": "0.4.1-pre.0",
-        "@edfi/meadowlark-utilities": "0.4.1-pre.0",
+        "@edfi/meadowlark-authz-server": "0.4.1-pre.1",
+        "@edfi/meadowlark-core": "0.4.1-pre.1",
+        "@edfi/meadowlark-utilities": "0.4.1-pre.1",
         "@fastify/rate-limit": "^6.0.1",
         "dotenv": "^16.3.1",
         "fastify": "^3.29.5"
@@ -22808,10 +22808,10 @@
     },
     "tests/e2e": {
       "name": "@edfi/meadowlark-e2e-tests",
-      "version": "0.4.1-pre.0",
+      "version": "0.4.1-pre.1",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@edfi/meadowlark-utilities": "0.4.1-pre.0",
+        "@edfi/meadowlark-utilities": "0.4.1-pre.1",
         "@testcontainers/mongodb": "^10.3.1",
         "@testcontainers/postgresql": "^10.3.1",
         "@types/chance": "^1.1.6",

--- a/Meadowlark-js/packages/meadowlark-authz-server/package.json
+++ b/Meadowlark-js/packages/meadowlark-authz-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edfi/meadowlark-authz-server",
   "main": "dist/index.js",
-  "version": "0.4.1-pre.0",
+  "version": "0.4.1-pre.1",
   "description": "Meadowlark authorization server",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "@apideck/better-ajv-errors": "^0.3.6",
-    "@edfi/meadowlark-utilities": "0.4.1-pre.0",
+    "@edfi/meadowlark-utilities": "0.4.1-pre.1",
     "ajv": "^8.12.0",
     "didyoumean2": "^6.0.1",
     "dotenv": "^16.3.1",

--- a/Meadowlark-js/packages/meadowlark-core/package.json
+++ b/Meadowlark-js/packages/meadowlark-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edfi/meadowlark-core",
   "main": "dist/index.js",
-  "version": "0.4.1-pre.0",
+  "version": "0.4.1-pre.1",
   "description": "Meadowlark core functionality",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -14,7 +14,7 @@
   ],
   "dependencies": {
     "@apideck/better-ajv-errors": "^0.3.6",
-    "@edfi/meadowlark-utilities": "0.4.1-pre.0",
+    "@edfi/meadowlark-utilities": "0.4.1-pre.1",
     "@isaacs/ttlcache": "^1.4.1",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",

--- a/Meadowlark-js/packages/meadowlark-utilities/package.json
+++ b/Meadowlark-js/packages/meadowlark-utilities/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@edfi/meadowlark-utilities",
   "main": "dist/index.js",
-  "version": "0.4.1-pre.0",
+  "version": "0.4.1-pre.1",
   "description": "Meadowlark shared utilities",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/Meadowlark-js/services/meadowlark-fastify/package.json
+++ b/Meadowlark-js/services/meadowlark-fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edfi/meadowlark-fastify",
-  "version": "0.4.1-pre.0",
+  "version": "0.4.1-pre.1",
   "description": "Meadowlark service using Fastify",
   "license": "Apache-2.0",
   "publishConfig": {
@@ -12,9 +12,9 @@
     "/package.json"
   ],
   "dependencies": {
-    "@edfi/meadowlark-authz-server": "0.4.1-pre.0",
-    "@edfi/meadowlark-core": "0.4.1-pre.0",
-    "@edfi/meadowlark-utilities": "0.4.1-pre.0",
+    "@edfi/meadowlark-authz-server": "0.4.1-pre.1",
+    "@edfi/meadowlark-core": "0.4.1-pre.1",
+    "@edfi/meadowlark-utilities": "0.4.1-pre.1",
     "@fastify/rate-limit": "^6.0.1",
     "dotenv": "^16.3.1",
     "fastify": "^3.29.5"

--- a/Meadowlark-js/tests/e2e/helpers/Resources.ts
+++ b/Meadowlark-js/tests/e2e/helpers/Resources.ts
@@ -3,6 +3,7 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
+import request from 'supertest';
 import { Role, getAccessToken } from './Credentials';
 import { baseURLRequest, rootURLRequest } from './Shared';
 
@@ -53,4 +54,10 @@ export async function deleteResourceByLocation(location: string, resourceName = 
   } else {
     console.warn(`⚠️ Unable to delete ${resourceName}. Location not found. Verify that resource was created correctly ⚠️`);
   }
+}
+
+export async function getResourceByLocation(location: string): Promise<request.Response> {
+  return rootURLRequest()
+    .get(location)
+    .auth(await getAccessToken('host'), { type: 'bearer' });
 }

--- a/Meadowlark-js/tests/e2e/package.json
+++ b/Meadowlark-js/tests/e2e/package.json
@@ -1,13 +1,13 @@
 {
   "name": "@edfi/meadowlark-e2e-tests",
   "main": "dist/index.js",
-  "version": "0.4.1-pre.0",
+  "version": "0.4.1-pre.1",
   "description": "Meadowlark Ed-Fi API end to end tests",
   "license": "Apache-2.0",
   "private": true,
   "files": [],
   "devDependencies": {
-    "@edfi/meadowlark-utilities": "0.4.1-pre.0",
+    "@edfi/meadowlark-utilities": "0.4.1-pre.1",
     "@testcontainers/mongodb": "^10.3.1",
     "@testcontainers/postgresql": "^10.3.1",
     "@types/chance": "^1.1.6",

--- a/Meadowlark-js/tests/e2e/scenarios/ResourcesCRUDValidation.test.ts
+++ b/Meadowlark-js/tests/e2e/scenarios/ResourcesCRUDValidation.test.ts
@@ -1,6 +1,8 @@
 import { Response } from 'supertest';
 import { getAccessToken } from '../helpers/Credentials';
 import { baseURLRequest, rootURLRequest } from '../helpers/Shared';
+import { createContentClassDescriptor } from '../helpers/DataCreation';
+import { deleteResourceByLocation, getResourceByLocation } from '../helpers/Resources';
 
 describe('when performing crud operations', () => {
   const resource = 'contentClassDescriptors';
@@ -29,47 +31,33 @@ describe('when performing crud operations', () => {
   });
 
   describe('when creating a new resource', () => {
-    let response: Response;
+    let createdResourceLocation: string;
     beforeAll(async () => {
-      response = await baseURLRequest()
-        .post(resourceEndpoint)
-        .auth(await getAccessToken('host'), { type: 'bearer' })
-        .send(resourceBody);
+      createdResourceLocation = await createContentClassDescriptor();
     });
 
     afterAll(async () => {
-      await rootURLRequest()
-        .delete(response.headers.location)
-        .auth(await getAccessToken('host'), { type: 'bearer' })
-        .send(resourceBody);
+      await deleteResourceByLocation(createdResourceLocation);
     });
 
-    it('returns 201', () => {
-      expect(response.statusCode).toBe(201);
+    it('is created', () => {
+      expect(createdResourceLocation).toBeTruthy();
     });
   });
 
   describe('when getting a resource by ID', () => {
     describe('given the resource exists', () => {
-      let createResponse: Response;
+      let createdResourceLocation: string;
       let getResponse: Response;
 
       beforeAll(async () => {
-        createResponse = await baseURLRequest()
-          .post(resourceEndpoint)
-          .auth(await getAccessToken('host'), { type: 'bearer' })
-          .send(resourceBody);
+        createdResourceLocation = await createContentClassDescriptor();
 
-        getResponse = await rootURLRequest()
-          .get(createResponse.headers.location)
-          .auth(await getAccessToken('host'), { type: 'bearer' });
+        getResponse = await getResourceByLocation(createdResourceLocation);
       });
 
       afterAll(async () => {
-        await rootURLRequest()
-          .delete(createResponse.headers.location)
-          .auth(await getAccessToken('host'), { type: 'bearer' })
-          .send(resourceBody);
+        await deleteResourceByLocation(createdResourceLocation);
       });
 
       it('returns 200', () => {
@@ -81,37 +69,29 @@ describe('when performing crud operations', () => {
       });
 
       it('returns 404 when the resource does not exist', async () => {
-        await rootURLRequest()
-          .get(`${createResponse.headers.location.slice(0, -1)}F`)
-          .auth(await getAccessToken('host'), { type: 'bearer' })
-          .expect(404);
+        const response = await getResourceByLocation(`${createdResourceLocation.slice(0, -1)}F`);
+        expect(response.statusCode).toEqual(404);
       });
 
       it('should match the location', async () => {
-        const id = await rootURLRequest()
-          .get(createResponse.headers.location)
-          .auth(await getAccessToken('vendor'), { type: 'bearer' })
-          .then((response) => response.body.id);
+        const id = await getResourceByLocation(createdResourceLocation).then((response) => response.body.id);
 
-        await baseURLRequest()
+        const response = await baseURLRequest()
           .get(`${resourceEndpoint}/${id}`)
-          .auth(await getAccessToken('vendor'), { type: 'bearer' })
-          .expect(200);
+          .auth(await getAccessToken('host'), { type: 'bearer' });
+        expect(response.statusCode).toEqual(200);
 
-        expect(createResponse.headers.location).toContain(`${resourceEndpoint}/${id}`);
+        expect(createdResourceLocation).toContain(`${resourceEndpoint}/${id}`);
       });
     });
   });
 
   describe('when getting all resources', () => {
-    let createResponse: Response;
+    let createdResourceLocation: string;
     let getAllResponse: Response;
 
     beforeAll(async () => {
-      createResponse = await baseURLRequest()
-        .post(resourceEndpoint)
-        .auth(await getAccessToken('host'), { type: 'bearer' })
-        .send(resourceBody);
+      createdResourceLocation = await createContentClassDescriptor();
 
       getAllResponse = await baseURLRequest()
         .get(resourceEndpoint)
@@ -119,10 +99,7 @@ describe('when performing crud operations', () => {
     });
 
     afterAll(async () => {
-      await rootURLRequest()
-        .delete(createResponse.headers.location)
-        .auth(await getAccessToken('host'), { type: 'bearer' })
-        .send(resourceBody);
+      await deleteResourceByLocation(createdResourceLocation);
     });
 
     it('returns 200', () => {
@@ -135,14 +112,11 @@ describe('when performing crud operations', () => {
   });
 
   describe('when upserting a resource', () => {
-    let insertResponse: Response;
+    let createdResourceLocation: string;
     let upsertResponse: Response;
 
     beforeAll(async () => {
-      insertResponse = await baseURLRequest()
-        .post(resourceEndpoint)
-        .auth(await getAccessToken('host'), { type: 'bearer' })
-        .send(resourceBody);
+      createdResourceLocation = await createContentClassDescriptor();
 
       upsertResponse = await baseURLRequest()
         .post(resourceEndpoint)
@@ -151,10 +125,7 @@ describe('when performing crud operations', () => {
     });
 
     afterAll(async () => {
-      await rootURLRequest()
-        .delete(insertResponse.headers.location)
-        .auth(await getAccessToken('host'), { type: 'bearer' })
-        .send(resourceBody);
+      await deleteResourceByLocation(createdResourceLocation);
     });
 
     it('returns 200', () => {
@@ -162,23 +133,17 @@ describe('when performing crud operations', () => {
     });
 
     it('returns updated resource on get', async () => {
-      await rootURLRequest()
-        .get(upsertResponse.headers.location)
-        .auth(await getAccessToken('host'), { type: 'bearer' })
-        .then((updatedResponse) => {
-          expect(updatedResponse.body).toEqual(expect.objectContaining(resourceBodyUpdated));
-        });
+      await getResourceByLocation(upsertResponse.headers.location).then((updatedResponse) => {
+        expect(updatedResponse.body).toEqual(expect.objectContaining(resourceBodyUpdated));
+      });
     });
   });
 
   describe('when updating a resource', () => {
-    let insertResponse: Response;
+    let createdResourceLocation: string;
 
     beforeAll(async () => {
-      insertResponse = await baseURLRequest()
-        .post(resourceEndpoint)
-        .auth(await getAccessToken('host'), { type: 'bearer' })
-        .send(resourceBody);
+      createdResourceLocation = await createContentClassDescriptor();
 
       await baseURLRequest()
         .post(resourceEndpoint)
@@ -187,16 +152,13 @@ describe('when performing crud operations', () => {
     });
 
     afterAll(async () => {
-      await rootURLRequest()
-        .delete(insertResponse.headers.location)
-        .auth(await getAccessToken('host'), { type: 'bearer' })
-        .send(resourceBody);
+      await deleteResourceByLocation(createdResourceLocation);
     });
 
     describe('when updating a resource with empty body', () => {
       it('returns 400', async () => {
         await rootURLRequest()
-          .put(insertResponse.headers.location)
+          .put(createdResourceLocation)
           .auth(await getAccessToken('host'), { type: 'bearer' })
           .send({})
           .expect(400);
@@ -204,13 +166,10 @@ describe('when performing crud operations', () => {
     });
 
     it('returns 204', async () => {
-      const id = await rootURLRequest()
-        .get(insertResponse.headers.location)
-        .auth(await getAccessToken('vendor'), { type: 'bearer' })
-        .then((response) => response.body.id);
+      const id = await getResourceByLocation(createdResourceLocation).then((response) => response.body.id);
 
       await rootURLRequest()
-        .put(insertResponse.headers.location)
+        .put(createdResourceLocation)
         .auth(await getAccessToken('host'), { type: 'bearer' })
         .send({
           id,
@@ -222,7 +181,7 @@ describe('when performing crud operations', () => {
     it('should fail when resource ID is different in body on put', async () => {
       const id = 'differentId';
       await rootURLRequest()
-        .put(insertResponse.headers.location)
+        .put(createdResourceLocation)
         .auth(await getAccessToken('host'), { type: 'bearer' })
         .send({
           id,
@@ -240,7 +199,7 @@ describe('when performing crud operations', () => {
 
     it('should fail when resource ID is not included in body on put', async () => {
       await rootURLRequest()
-        .put(insertResponse.headers.location)
+        .put(createdResourceLocation)
         .auth(await getAccessToken('host'), { type: 'bearer' })
         .send(resourceBody)
         .expect(400)
@@ -260,19 +219,14 @@ describe('when performing crud operations', () => {
     });
 
     it('returns updated resource on get', async () => {
-      await rootURLRequest()
-        .get(insertResponse.headers.location)
-        .auth(await getAccessToken('host'), { type: 'bearer' })
-        .then((response) => {
-          expect(response.body).toEqual(expect.objectContaining(resourceBody));
-        });
+      await getResourceByLocation(createdResourceLocation).then((response) => {
+        expect(response.body).toEqual(expect.objectContaining(resourceBody));
+      });
     });
 
     it('should fail when resource ID is included in body on post', async () => {
-      const id = await rootURLRequest()
-        .get(insertResponse.headers.location)
-        .auth(await getAccessToken('host'), { type: 'bearer' })
-        .then((response) => response.body.id);
+      const id = await getResourceByLocation(createdResourceLocation).then((response) => response.body.id);
+
       await baseURLRequest()
         .post(`${resourceEndpoint}`)
         .auth(await getAccessToken('host'), { type: 'bearer' })
@@ -298,25 +252,20 @@ describe('when performing crud operations', () => {
   });
 
   describe('when deleting a resource', () => {
-    let createResponse: Response;
+    let createdResourceLocation: string;
     let deleteResponse: Response;
     beforeAll(async () => {
-      createResponse = await baseURLRequest()
-        .post(resourceEndpoint)
-        .auth(await getAccessToken('host'), { type: 'bearer' })
-        .send(resourceBody);
+      createdResourceLocation = await createContentClassDescriptor();
 
       deleteResponse = await rootURLRequest()
-        .delete(createResponse.headers.location)
-        .auth(await getAccessToken('host'), { type: 'bearer' })
-        .send(resourceBody);
+        .delete(createdResourceLocation)
+        .auth(await getAccessToken('host'), { type: 'bearer' });
     });
 
     it('returns 404 when deleting a resource that does not exist', async () => {
       await rootURLRequest()
-        .delete(`${createResponse.headers.location.slice(0, -1)}F`)
+        .delete(`${createdResourceLocation.slice(0, -1)}F`)
         .auth(await getAccessToken('host'), { type: 'bearer' })
-        .send(resourceBody)
         .expect(404);
     });
 
@@ -325,10 +274,8 @@ describe('when performing crud operations', () => {
     });
 
     it('returns 404 on get', async () => {
-      await rootURLRequest()
-        .get(createResponse.headers.location)
-        .auth(await getAccessToken('host'), { type: 'bearer' })
-        .expect(404);
+      const response = await getResourceByLocation(createdResourceLocation);
+      expect(response.statusCode).toEqual(404);
     });
   });
 });


### PR DESCRIPTION
Current behavior depends on a previous test before doing the next one, for example, to test the delete, it requires a previous it() to have run to set the element to delete, this causes a race condition since we cannot guarantee that the prerequisite will run first. This move that behavior as part of the before all hook